### PR TITLE
Add consistent navigation bars for admin and teacher pages

### DIFF
--- a/admin/_layout.php
+++ b/admin/_layout.php
@@ -1,6 +1,11 @@
 <?php
 declare(strict_types=1);
 
+function nav_is_active(array $files): bool {
+  $current = basename(parse_url((string)($_SERVER['PHP_SELF'] ?? ''), PHP_URL_PATH));
+  return in_array($current, $files, true);
+}
+
 function render_admin_header(string $title): void {
   $b = brand();
   $org = $b['org_name'] ?? 'LEG Tool';
@@ -30,6 +35,29 @@ function render_admin_header(string $title): void {
           <div class="brand-title"><?=h($org)?></div>
           <div class="brand-subtitle"><?=h($title)?></div>
         </div>
+      </div>
+    </div>
+    <div class="menu-bar">
+      <div class="nav-shell">
+        <nav class="nav-menu" aria-label="Admin Navigation">
+          <?php
+          $items = [
+            ['Dashboard', 'admin/index.php', ['index.php']],
+            ['Klassen', 'admin/classes.php', ['classes.php']],
+            ['Nutzer', 'admin/users.php', ['users.php']],
+            ['Schüler', 'admin/students.php', ['students.php']],
+            ['Templates', 'admin/templates.php', ['templates.php']],
+            ['Felder', 'admin/template_fields.php', ['template_fields.php']],
+            ['Mappings', 'admin/template_mappings.php', ['template_mappings.php']],
+            ['Optionen', 'admin/option_scales.php', ['option_scales.php']],
+            ['Export', 'admin/export.php', ['export.php']],
+          ];
+          foreach ($items as [$label, $href, $files]):
+            $active = nav_is_active($files) ? 'active' : '';
+          ?>
+            <a class="nav-link <?=$active?>" href="<?=h(url($href))?>"><?=h($label)?></a>
+          <?php endforeach; ?>
+        </nav>
       </div>
     </div>
     <div class="container">

--- a/admin/index.php
+++ b/admin/index.php
@@ -16,13 +16,49 @@ render_admin_header('Admin – Dashboard');
 
 <div class="card">
   <h2>Verwaltung</h2>
-  <div class="actions">
-    <a class="btn primary" href="<?=h(url('admin/classes.php'))?>">Klassen</a>
-    <a class="btn primary" href="<?=h(url('admin/users.php'))?>">Nutzer</a>
-    <a class="btn primary" href="<?=h(url('admin/students.php'))?>">Schüler</a>
-    <a class="btn secondary" href="<?=h(url('admin/settings.php'))?>">Settings / Branding</a>
-    <a class="btn secondary" href="<?=h(url('admin/templates.php'))?>">Templates (PDF Upload & Felder auslesen)</a>
-    <a class="btn secondary" href="<?=h(url('admin/export.php'))?>">PDF-Export</a>
+  <div class="nav-grid">
+    <a class="nav-tile primary" href="<?=h(url('admin/classes.php'))?>">
+      <div class="nav-title">Klassen</div>
+      <p class="nav-desc">Klassen strukturieren, Schuljahre pflegen und Zuweisungen erledigen.</p>
+    </a>
+    <a class="nav-tile primary" href="<?=h(url('admin/users.php'))?>">
+      <div class="nav-title">Nutzer</div>
+      <p class="nav-desc">Accounts verwalten, Rollen vergeben und Zugänge aktuell halten.</p>
+    </a>
+    <a class="nav-tile primary" href="<?=h(url('admin/students.php'))?>">
+      <div class="nav-title">Schüler</div>
+      <p class="nav-desc">Schüler importieren oder erfassen und Klassen zuordnen.</p>
+    </a>
+    <a class="nav-tile" href="<?=h(url('admin/settings.php'))?>">
+      <div class="nav-title">Branding & Einstellungen</div>
+      <p class="nav-desc">Logo, Farben, Sprache und weitere Grundeinstellungen anpassen.</p>
+    </a>
+  </div>
+</div>
+
+<div class="card">
+  <h2>Vorlagen & Exporte</h2>
+  <div class="nav-grid">
+    <a class="nav-tile" href="<?=h(url('admin/templates.php'))?>">
+      <div class="nav-title">Templates</div>
+      <p class="nav-desc">PDF-Vorlagen hochladen, strukturieren und für Eingaben vorbereiten.</p>
+    </a>
+    <a class="nav-tile" href="<?=h(url('admin/template_fields.php'))?>">
+      <div class="nav-title">Felder & Zuordnungen</div>
+      <p class="nav-desc">Ausgelesene Felder prüfen und den richtigen Reports zuordnen.</p>
+    </a>
+    <a class="nav-tile" href="<?=h(url('admin/template_mappings.php'))?>">
+      <div class="nav-title">Template-Mappings</div>
+      <p class="nav-desc">Felder mit Skalen und Eingabefeldern verbinden.</p>
+    </a>
+    <a class="nav-tile" href="<?=h(url('admin/option_scales.php'))?>">
+      <div class="nav-title">Optionen & Skalen</div>
+      <p class="nav-desc">Antwortoptionen, Skalen und Auswahllisten verwalten.</p>
+    </a>
+    <a class="nav-tile" href="<?=h(url('admin/export.php'))?>">
+      <div class="nav-title">PDF-Export</div>
+      <p class="nav-desc">Reports als PDF bündeln und für den Versand herunterladen.</p>
+    </a>
   </div>
   <p class="muted">Empfohlene Reihenfolge: Klassen anlegen & zuordnen → Templates hochladen → Felder auslesen → Schüler importieren/erfassen → Reports pro Kind erzeugen.</p>
 </div>

--- a/assets/app.css
+++ b/assets/app.css
@@ -44,6 +44,13 @@ body.page{
 .brand-title{font-weight:750; letter-spacing:.2px}
 .brand-subtitle{color:var(--muted); font-size:12px}
 
+.menu-bar{background:#fff; border-bottom:1px solid var(--border); box-shadow:0 1px 6px rgba(16,24,40,.05);}
+.nav-shell{max-width:1200px; margin:0 auto; padding:0 16px; overflow-x:auto;}
+.nav-menu{display:flex; gap:10px; align-items:center; padding:10px 6px; margin:0; list-style:none;}
+.nav-link{padding:8px 12px; border-radius:10px; color:var(--secondary); text-decoration:none; font-weight:600; border:1px solid transparent; white-space:nowrap;}
+.nav-link:hover{background:rgba(0,0,0,0.04);}
+.nav-link.active{background:rgba(11,87,208,0.1); color:var(--primary); border-color:rgba(11,87,208,0.3);}
+
 h1{margin:18px 0 12px}
 h2{margin:0 0 12px}
 
@@ -104,6 +111,30 @@ code{background:#f1f2f6; padding:2px 6px; border-radius:6px}
 }
 .actions{display:flex; gap:10px; flex-wrap:wrap; align-items:center; margin-top:12px}
 
+.nav-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+  gap:12px;
+  margin-top:12px;
+}
+.nav-tile{
+  display:block;
+  padding:14px;
+  border-radius:12px;
+  border:1px solid var(--border);
+  background:#fff;
+  color:inherit;
+  text-decoration:none;
+  box-shadow:0 4px 14px rgba(16,24,40,.04);
+  transition:all .15s ease;
+}
+.nav-tile:hover{ border-color: var(--primary); box-shadow:0 10px 24px rgba(16,24,40,.08); transform: translateY(-1px); }
+.nav-tile .nav-title{ font-weight:700; margin:0 0 4px; color:#0f172a; }
+.nav-tile .nav-desc{ margin:0; color:var(--muted); font-size:13px; line-height:1.4; }
+.nav-tile .nav-meta{ margin-top:8px; display:flex; gap:8px; align-items:center; }
+.nav-tile.primary{ border-color: rgba(11,87,208,0.25); background: rgba(11,87,208,0.04); }
+.nav-tile.primary .nav-title{ color: var(--primary); }
+
 .alert{
   border-radius:var(--radius);
   padding:12px 14px;
@@ -118,6 +149,15 @@ code{background:#f1f2f6; padding:2px 6px; border-radius:6px}
 table{width:100%; border-collapse:collapse}
 th,td{border-bottom:1px solid #eef0f4; padding:10px; text-align:left; vertical-align:top}
 th{color:#111; font-size:13px}
+.badge{
+  display:inline-block;
+  padding:3px 8px;
+  border-radius:999px;
+  font-size:12px;
+  border:1px solid rgba(0,0,0,0.08);
+  background: rgba(0,0,0,0.04);
+  color:#0f172a;
+}
 .pill{
   display:inline-block;
   padding:3px 9px;

--- a/teacher/_layout.php
+++ b/teacher/_layout.php
@@ -1,6 +1,11 @@
 <?php
 declare(strict_types=1);
 
+function nav_is_active(array $files): bool {
+  $current = basename(parse_url((string)($_SERVER['PHP_SELF'] ?? ''), PHP_URL_PATH));
+  return in_array($current, $files, true);
+}
+
 function render_teacher_header(string $title): void {
   $b = brand();
   $org = (string)($b['org_name'] ?? 'LEG Tool');
@@ -36,6 +41,26 @@ function render_teacher_header(string $title): void {
           <a class="lang <?= $lang==='de' ? 'active' : '' ?>" href="<?=h(url_with_lang('de'))?>" title="Deutsch">🇩🇪</a>
           <a class="lang <?= $lang==='en' ? 'active' : '' ?>" href="<?=h(url_with_lang('en'))?>" title="English">🇬🇧</a>
         </div>
+      </div>
+    </div>
+    <div class="menu-bar">
+      <div class="nav-shell">
+        <nav class="nav-menu" aria-label="Lehrkraft Navigation">
+          <?php
+          $items = [
+            ['Übersicht', 'teacher/index.php', ['index.php']],
+            ['Klassen', 'teacher/classes.php', ['classes.php']],
+            ['Eingaben', 'teacher/entry.php', ['entry.php']],
+            ['Delegationen', 'teacher/delegations.php', ['delegations.php']],
+            ['QR-Druck', 'teacher/qr_print.php', ['qr_print.php']],
+            ['Export', 'teacher/export.php', ['export.php']],
+          ];
+          foreach ($items as [$label, $href, $files]):
+            $active = nav_is_active($files) ? 'active' : '';
+          ?>
+            <a class="nav-link <?=$active?>" href="<?=h(url($href))?>"><?=h($label)?></a>
+          <?php endforeach; ?>
+        </nav>
       </div>
     </div>
     <div class="container">

--- a/teacher/index.php
+++ b/teacher/index.php
@@ -39,14 +39,7 @@ render_teacher_header('Lehrkraft – Übersicht');
 
 <div class="card">
   <div class="row-actions">
-    <a class="btn secondary" href="<?=h(url('teacher/classes.php'))?>">Meine Klassen</a>
-    <a class="btn secondary" href="<?=h(url('teacher/delegations.php'))?>">Delegationen<?= $delegationCount>0 ? ' <span class="badge">'.h((string)$delegationCount).'</span>' : '' ?></a>
-  </div>
-</div>
-
-
-<div class="card">
-  <div class="row-actions">
+    <span class="pill"><?=h((string)$u['display_name'])?> · <?=h((string)$u['role'])?></span>
     <a class="btn secondary" href="<?=h(url('logout.php'))?>">Logout</a>
     <?php if (($u['role'] ?? '') === 'admin'): ?>
       <a class="btn secondary" href="<?=h(url('admin/index.php'))?>">Admin</a>
@@ -54,11 +47,37 @@ render_teacher_header('Lehrkraft – Übersicht');
   </div>
 
   <h1 style="margin-top:0;">Hallo <?=h((string)($u['display_name'] ?? ''))?></h1>
-  <p class="muted">Hier verwaltest du deine Klassen und Schüler. Danach können Berichte vorbereitet und ausgefüllt werden.</p>
+  <p class="muted">Hier findest du alle wichtigen Wege rund um Klassen, Delegationen und Eingaben auf einen Blick.</p>
 
-  <div class="actions">
-    <a class="btn primary" href="<?=h(url('teacher/classes.php'))?>">Meine Klassen</a>
-    <a class="btn secondary" href="<?=h(url('teacher/entry.php'))?>">Eingaben ausfüllen</a>
+  <div class="nav-grid">
+    <a class="nav-tile primary" href="<?=h(url('teacher/classes.php'))?>">
+      <div class="nav-title">Meine Klassen</div>
+      <p class="nav-desc">Zugeordnete Klassen ansehen, Schülerinnen und Schüler verwalten.</p>
+    </a>
+    <a class="nav-tile primary" href="<?=h(url('teacher/entry.php'))?>">
+      <div class="nav-title">Eingaben ausfüllen</div>
+      <p class="nav-desc">Berichte vorbereiten und direkt im Browser bearbeiten.</p>
+    </a>
+    <a class="nav-tile" href="<?=h(url('teacher/delegations.php'))?>">
+      <div class="nav-title">Delegationen</div>
+      <p class="nav-desc">Geteilte Klassen und Aufgaben im Blick behalten.</p>
+      <div class="nav-meta">
+        <?php if ($delegationCount>0): ?>
+          <span class="badge"><?=h((string)$delegationCount)?></span>
+          <span class="small">offene Delegationen</span>
+        <?php else: ?>
+          <span class="small muted">Keine offenen Delegationen</span>
+        <?php endif; ?>
+      </div>
+    </a>
+    <a class="nav-tile" href="<?=h(url('teacher/qr_print.php'))?>">
+      <div class="nav-title">QR-Codes drucken</div>
+      <p class="nav-desc">Zugänge und Aushänge für Klassen schnell bereitstellen.</p>
+    </a>
+    <a class="nav-tile" href="<?=h(url('teacher/export.php'))?>">
+      <div class="nav-title">PDF-Export</div>
+      <p class="nav-desc">Berichte herunterladen oder weitergeben.</p>
+    </a>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- add reusable top navigation bars to admin and teacher layouts so menus stay visible on every page
- highlight active section and align links for key admin and teacher workflows
- style navigation links for the new menus alongside existing branding

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f0f0304a8832eab66693a8d92d192)