### PR TITLE
Add ability to delete icons from library

### DIFF
--- a/admin/ajax/icon_delete.php
+++ b/admin/ajax/icon_delete.php
@@ -1,0 +1,52 @@
+<?php
+// admin/ajax/icon_delete.php
+declare(strict_types=1);
+
+require __DIR__ . '/../../bootstrap.php';
+require_admin();
+
+header('Content-Type: application/json; charset=utf-8');
+
+try {
+  csrf_verify();
+
+  $data = json_decode(file_get_contents('php://input'), true) ?: [];
+  $iconId = isset($data['icon_id']) ? (int)$data['icon_id'] : 0;
+  if ($iconId <= 0) throw new RuntimeException('icon_id fehlt.');
+
+  $pdo = db();
+
+  $usedStmt = $pdo->prepare("SELECT COUNT(*) FROM option_list_items WHERE icon_id = ?");
+  $usedStmt->execute([$iconId]);
+  $usedCount = (int)$usedStmt->fetchColumn();
+  if ($usedCount > 0) {
+    throw new RuntimeException('Icon wird noch in Option-Listen verwendet.');
+  }
+
+  $st = $pdo->prepare("SELECT storage_path FROM icon_library WHERE id=?");
+  $st->execute([$iconId]);
+  $row = $st->fetch();
+  if (!$row) throw new RuntimeException('Icon nicht gefunden.');
+
+  $storagePath = (string)($row['storage_path'] ?? '');
+  $rootAbs = realpath(__DIR__ . '/../..');
+  if ($rootAbs && $storagePath !== '') {
+    $abs = $rootAbs . '/' . ltrim($storagePath, '/');
+    if (is_file($abs)) {
+      @unlink($abs);
+    }
+  }
+
+  $del = $pdo->prepare("DELETE FROM icon_library WHERE id=?");
+  $del->execute([$iconId]);
+
+  audit('icon_delete', (int)current_user()['id'], ['icon_id' => $iconId]);
+
+  echo json_encode(['ok' => true], JSON_UNESCAPED_UNICODE);
+  exit;
+
+} catch (Throwable $e) {
+  http_response_code(400);
+  echo json_encode(['ok' => false, 'error' => $e->getMessage()], JSON_UNESCAPED_UNICODE);
+  exit;
+}

--- a/admin/ajax/icon_upload.php
+++ b/admin/ajax/icon_upload.php
@@ -75,9 +75,9 @@ try {
     (int)current_user()['id']
   ]);
   $iconId = (int)$pdo->lastInsertId();
-  audit('icon_upload', (int)current_user()['id'], ['icon_id'=>$id,'file'=>basename($destAbs)]);
+  audit('icon_upload', (int)current_user()['id'], ['icon_id'=>$iconId,'file'=>basename($destAbs)]);
 
-  echo json_encode(['ok'=>true, 'icon_id'=>$id, 'filename'=>basename($destAbs)], JSON_UNESCAPED_UNICODE);
+  echo json_encode(['ok'=>true, 'icon_id'=>$iconId, 'filename'=>basename($destAbs)], JSON_UNESCAPED_UNICODE);
   exit;
 
 } catch (Throwable $e) {


### PR DESCRIPTION
## Summary
- add delete controls and feedback for icon library entries
- introduce an API endpoint to remove stored icons while blocking deletion when still used
- fix icon upload logging/response to use the created icon id

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695030503480832e96eb48c6b8f46d0b)