### PR TITLE
Disable PDO emulated prepares for safer queries

### DIFF
--- a/debug.php
+++ b/debug.php
@@ -1,7 +1,7 @@
 <?php
-ini_set('display_errors','1');
-ini_set('display_startup_errors','1');
-error_reporting(E_ALL);
+require __DIR__ . '/bootstrap.php';
+require_admin();
+
 header('Content-Type: text/plain; charset=utf-8');
 
 echo "PHP OK\n";
@@ -9,13 +9,12 @@ echo "Version: " . PHP_VERSION . "\n";
 echo "SAPI: " . php_sapi_name() . "\n";
 
 try {
-  $pdo = new PDO("mysql:host=localhost;dbname=INTERNET_DBNAME;charset=utf8mb4", "INTERNET_DBUSER", "INTERNET_DBPASS", [
-    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
-  ]);
-  echo "DB OK\n";
+  $pdo = db();
   $v = $pdo->query("SELECT VERSION()")->fetchColumn();
+  echo "DB OK\n";
   echo "DB Version: $v\n";
 } catch (Throwable $e) {
-  echo "DB FAIL: " . $e->getMessage() . "\n";
+  http_response_code(500);
+  echo "DB FAIL\n";
 }
 


### PR DESCRIPTION
## Summary
- disable PDO emulated prepares for MySQL and SQLite connections to enforce real prepared statements

## Testing
- php -l bootstrap.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e5a02e24832eb453b71afaad91c5)