### PR TITLE
Allow multiple icon uploads

### DIFF
--- a/admin/ajax/icon_upload.php
+++ b/admin/ajax/icon_upload.php
@@ -11,15 +11,39 @@ function ensure_dir(string $p): void {
   if (!is_dir($p)) @mkdir($p, 0755, true);
 }
 
-try {
-  csrf_verify();
+function normalize_uploads(): array {
+  if (!isset($_FILES['icon'])) return [];
 
-  if (!isset($_FILES['icon']) || ($_FILES['icon']['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
-    throw new RuntimeException('Bitte eine Datei auswählen.');
+  $f = $_FILES['icon'];
+  if (is_array($f['name'])) {
+    $out = [];
+    foreach ($f['name'] as $idx => $name) {
+      $err = $f['error'][$idx] ?? UPLOAD_ERR_NO_FILE;
+      if ($err === UPLOAD_ERR_NO_FILE) continue;
+      if ($err !== UPLOAD_ERR_OK) throw new RuntimeException('Upload-Fehler bei "' . ($name ?: 'Datei') . '" (Code ' . $err . ').');
+      $out[] = [
+        'tmp_name' => $f['tmp_name'][$idx] ?? null,
+        'name' => $name,
+      ];
+    }
+    return $out;
   }
 
-  $tmp = $_FILES['icon']['tmp_name'];
-  $orig = (string)($_FILES['icon']['name'] ?? 'icon');
+  $err = $f['error'] ?? UPLOAD_ERR_NO_FILE;
+  if ($err === UPLOAD_ERR_NO_FILE) return [];
+  if ($err !== UPLOAD_ERR_OK) throw new RuntimeException('Upload-Fehler (Code ' . $err . ').');
+
+  return [[
+    'tmp_name' => $f['tmp_name'] ?? null,
+    'name' => $f['name'] ?? 'icon',
+  ]];
+}
+
+function handle_icon_upload(array $file, PDO $pdo, string $rootAbs, string $uploadsRel, int $userId): array {
+  $tmp = (string)($file['tmp_name'] ?? '');
+  $orig = (string)($file['name'] ?? 'icon');
+  if ($tmp === '' || !is_uploaded_file($tmp)) throw new RuntimeException('Temporäre Datei fehlt.');
+
   $ext = strtolower(pathinfo($orig, PATHINFO_EXTENSION));
 
   $allowed = [
@@ -34,12 +58,6 @@ try {
   $mime = $allowed[$ext];
   $safe = preg_replace('/[^a-z0-9._-]+/i', '_', pathinfo($orig, PATHINFO_FILENAME));
   if ($safe === '' || $safe === '_') $safe = 'icon';
-
-  $cfg = app_config();
-  $uploadsRel = $cfg['app']['uploads_dir'] ?? 'uploads';
-
-  $rootAbs = realpath(__DIR__ . '/../..');
-  if (!$rootAbs) throw new RuntimeException('Root-Pfad nicht gefunden.');
 
   $iconsAbs = $rootAbs . '/' . $uploadsRel . '/icons';
   ensure_dir($iconsAbs);
@@ -61,7 +79,6 @@ try {
 
   $storageRel = $uploadsRel . '/icons/' . basename($destAbs);
 
-  $pdo = db();
   $stmt = $pdo->prepare("
     INSERT INTO icon_library (filename, storage_path, file_ext, mime_type, sha256, created_by_user_id)
     VALUES (?, ?, ?, ?, ?, ?)
@@ -72,15 +89,64 @@ try {
     $ext,
     $mime,
     $sha,
-    (int)current_user()['id']
+    $userId
   ]);
   $iconId = (int)$pdo->lastInsertId();
-  audit('icon_upload', (int)current_user()['id'], ['icon_id'=>$iconId,'file'=>basename($destAbs)]);
+  audit('icon_upload', $userId, ['icon_id'=>$iconId,'file'=>basename($destAbs)]);
 
-  echo json_encode(['ok'=>true, 'icon_id'=>$iconId, 'filename'=>basename($destAbs)], JSON_UNESCAPED_UNICODE);
+  return [
+    'icon_id' => $iconId,
+    'filename' => basename($destAbs),
+    'dest_abs' => $destAbs,
+  ];
+}
+
+try {
+  csrf_verify();
+
+  $files = normalize_uploads();
+  if (!$files) throw new RuntimeException('Bitte mindestens eine Datei auswählen.');
+
+  $cfg = app_config();
+  $uploadsRel = $cfg['app']['uploads_dir'] ?? 'uploads';
+
+  $rootAbs = realpath(__DIR__ . '/../..');
+  if (!$rootAbs) throw new RuntimeException('Root-Pfad nicht gefunden.');
+
+  $pdo = db();
+  $pdo->beginTransaction();
+
+  $userId = (int)current_user()['id'];
+  $uploaded = [];
+  $savedPaths = [];
+
+  foreach ($files as $f) {
+    $result = handle_icon_upload($f, $pdo, $rootAbs, $uploadsRel, $userId);
+    $uploaded[] = [
+      'icon_id' => $result['icon_id'],
+      'filename' => $result['filename'],
+    ];
+    $savedPaths[] = $result['dest_abs'];
+  }
+
+  $pdo->commit();
+
+  echo json_encode([
+    'ok'=>true,
+    'uploaded'=>$uploaded,
+    'filename'=>$uploaded[0]['filename'] ?? null,
+  ], JSON_UNESCAPED_UNICODE);
   exit;
 
 } catch (Throwable $e) {
+  if (isset($pdo) && $pdo instanceof PDO && $pdo->inTransaction()) {
+    $pdo->rollBack();
+  }
+  if (isset($savedPaths)) {
+    foreach ($savedPaths as $p) {
+      if (is_string($p) && is_file($p)) @unlink($p);
+    }
+  }
   http_response_code(400);
   echo json_encode(['ok'=>false, 'error'=>$e->getMessage()], JSON_UNESCAPED_UNICODE);
   exit;


### PR DESCRIPTION
## Summary
- allow selecting and uploading multiple icons at once in the admin icon library UI
- extend icon upload endpoint to process multiple files atomically with validation and cleanup
- return aggregated upload details for client display while keeping backward compatibility

## Testing
- php -l admin/icon_library.php
- php -l admin/ajax/icon_upload.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959dc123b9c832eb057beb5446e722d)