### PR TITLE
Allow teachers to edit or delete student entries

### DIFF
--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -1678,6 +1678,93 @@ if ($action === 'delegations_save') {
     json_out(['ok' => true]);
   }
 
+  if ($action === 'child_value_update') {
+    $reportId = (int)($data['report_instance_id'] ?? 0);
+    $fieldId = (int)($data['child_field_id'] ?? 0);
+    $deleteValue = array_key_exists('value_text', $data) ? ($data['value_text'] === null) : false;
+    $valueText = array_key_exists('value_text', $data) ? (string)$data['value_text'] : null;
+
+    if ($reportId <= 0) throw new RuntimeException('report_instance_id fehlt.');
+    if ($fieldId <= 0) throw new RuntimeException('child_field_id fehlt.');
+
+    $st = $pdo->prepare(
+      "SELECT ri.template_id AS report_template_id, ri.school_year, ri.period_label, s.class_id, c.template_id AS class_template_id,
+              tf.field_type, tf.meta_json
+       FROM report_instances ri
+       JOIN students s ON s.id=ri.student_id
+       JOIN classes c ON c.id=s.class_id
+       JOIN template_fields tf ON tf.id=? AND tf.template_id=ri.template_id AND tf.can_child_edit=1
+       WHERE ri.id=?
+       LIMIT 1"
+    );
+    $st->execute([$fieldId, $reportId]);
+    $row = $st->fetch(PDO::FETCH_ASSOC);
+    if (!$row) throw new RuntimeException('Schülerfeld nicht gefunden oder nicht freigegeben.');
+
+    $classId = (int)($row['class_id'] ?? 0);
+    if (($u['role'] ?? '') !== 'admin' && !user_can_access_class($pdo, $userId, $classId)) {
+      throw new RuntimeException('Keine Berechtigung.');
+    }
+
+    $reportTplId = (int)($row['report_template_id'] ?? 0);
+    $classTplId = (int)($row['class_template_id'] ?? 0);
+    if ($reportTplId <= 0 || $classTplId <= 0) throw new RuntimeException('Vorlage nicht gefunden.');
+    if ($reportTplId !== $classTplId) throw new RuntimeException('Vorlagenkonflikt: Der Bericht gehört zu einer anderen Vorlage als der Klasse zugeordnet ist.');
+
+    $meta = meta_read($row['meta_json'] ?? null);
+    if (is_system_bound($meta)) throw new RuntimeException('Dieses Feld wird automatisch befüllt und kann nicht bearbeitet werden.');
+
+    $type = (string)($row['field_type'] ?? '');
+    $valueJson = null;
+
+    if ($deleteValue) {
+      $valueText = null;
+    } elseif (in_array($type, ['radio','select','grade'], true)) {
+      $valueText = $valueText !== null ? trim($valueText) : '';
+      if ($valueText === '') $valueText = null;
+
+      $listId = option_list_id_from_meta($meta);
+      if ($listId > 0 && $valueText !== null) {
+        $st2 = $pdo->prepare("SELECT id FROM option_list_items WHERE list_id=? AND value=? LIMIT 1");
+        $st2->execute([$listId, $valueText]);
+        $optId = (int)($st2->fetchColumn() ?: 0);
+        if ($optId > 0) {
+          $valueJson = json_encode(['option_item_id' => $optId], JSON_UNESCAPED_UNICODE);
+        }
+      }
+    } elseif ($type === 'checkbox') {
+      $valueText = ($valueText === '1' || $valueText === 'true' || $valueText === 'on') ? '1' : '0';
+    } else {
+      $valueText = $valueText !== null ? trim($valueText) : null;
+      if ($valueText === '') $valueText = null;
+    }
+
+    $up = $pdo->prepare(
+      "INSERT INTO field_values (report_instance_id, template_field_id, value_text, value_json, source, updated_by_user_id, updated_at)
+       VALUES (?, ?, ?, ?, 'child', ?, NOW())
+       ON DUPLICATE KEY UPDATE
+         value_text=VALUES(value_text),
+         value_json=VALUES(value_json),
+         source='child',
+         updated_by_user_id=VALUES(updated_by_user_id),
+         updated_by_student_id=NULL,
+         updated_at=NOW()"
+    );
+    $up->execute([$reportId, $fieldId, $valueText, $valueJson, $userId]);
+
+    record_field_value_history($pdo, $reportId, $fieldId, $valueText, $valueJson, 'child', $userId, null);
+
+    $resolved = resolve_option_value_text($pdo, $meta, $valueJson, $valueText, $lang);
+    audit('teacher_child_value_update', $userId, ['report_instance_id'=>$reportId,'template_field_id'=>$fieldId]);
+
+    json_out([
+      'ok' => true,
+      'value_text' => $resolved['text'] !== null ? (string)$resolved['text'] : '',
+      'value_json' => $resolved['json'] ?? $valueJson,
+      'raw_value_text' => $valueText,
+    ]);
+  }
+
   if ($action === 'unlock_child_entry') {
     $reportId = (int)($data['report_instance_id'] ?? 0);
     if ($reportId <= 0) throw new RuntimeException('report_instance_id fehlt.');

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -777,6 +777,32 @@ render_teacher_header($pageTitle);
     return v;
   }
 
+  function childLabel(field){
+    if (!field || !field.child) return '';
+    const c = field.child;
+    return String(c.label || c.field_name || 'Schülerfeld');
+  }
+
+  function childInfoHtml(f, reportId){
+    if (!f || !f.child || !f.child.id) return '';
+    const childId = Number(f.child.id);
+    const rawChild = childVal(reportId, childId);
+    const shownChild = rawChild ? childDisplay(f, rawChild) : '';
+    const label = childLabel(f);
+    const baseAttrs = `data-child-field="${esc(childId)}" data-child-label="${esc(label)}"`;
+    const deleteDisabled = rawChild ? '' : 'disabled';
+
+    return `
+      <div class="child">
+        <div><strong>Schüler:</strong> ${shownChild ? esc(shownChild) : '<span class="muted">—</span>'}</div>
+        <div class="child-actions" style="display:flex; gap:6px; margin-top:6px; flex-wrap:wrap;">
+          <button class="btn secondary" type="button" data-edit-child="${esc(reportId)}" ${baseAttrs}>Bearbeiten</button>
+          <button class="btn secondary" type="button" data-delete-child="${esc(reportId)}" ${baseAttrs} ${deleteDisabled}>Löschen</button>
+        </div>
+      </div>
+    `;
+  }
+
   function resolveMergeWithChild(reportId, fieldId, nextValue){
     const f = state.fieldMap[String(fieldId)];
     if (!f || !f.child || !f.child.id) return String(nextValue ?? '');
@@ -1118,6 +1144,97 @@ render_teacher_header($pageTitle);
     });
 
     if (list.length > 5) list.length = 5;
+  }
+
+  function adjustChildProgress(reportId, label, prevRaw, nextRaw){
+    const stu = (state.students || []).find(s => Number(s.report_instance_id || 0) === Number(reportId));
+    if (!stu) return;
+
+    const wasDone = String(prevRaw ?? '').trim() !== '';
+    const isDone = String(nextRaw ?? '').trim() !== '';
+    if (wasDone === isDone) return;
+
+    const total = Number(stu.progress_child_total || 0);
+    let done = Number(stu.progress_child_done || 0);
+    done = wasDone && !isDone ? Math.max(0, done - 1) : done;
+    done = !wasDone && isDone ? done + 1 : done;
+    stu.progress_child_done = Math.min(total, Math.max(0, done));
+    stu.progress_child_missing = Math.max(0, total - stu.progress_child_done);
+
+    const teacherDone = Number(stu.progress_teacher_done || 0);
+    const overallTotal = Number(stu.progress_overall_total || 0);
+    stu.progress_overall_done = teacherDone + stu.progress_child_done;
+    stu.progress_overall_missing = Math.max(0, overallTotal - stu.progress_overall_done);
+    stu.progress_is_complete = stu.progress_overall_missing === 0;
+
+    const lbl = String(label || '').trim();
+    if (lbl !== '') {
+      const missingList = Array.isArray(stu.child_missing_fields) ? [...stu.child_missing_fields] : [];
+      const inList = missingList.includes(lbl);
+      const updatedList = isDone ? missingList.filter(x => x !== lbl) : (inList ? missingList : missingList.concat([lbl]));
+      stu.child_missing_fields = updatedList;
+    }
+  }
+
+  async function updateChildValue(reportId, childFieldId, nextValue, childLabelText){
+    const rid = Number(reportId || 0);
+    const fid = Number(childFieldId || 0);
+    if (!rid || !fid) return;
+
+    const prevRaw = childVal(rid, fid);
+    const deleting = nextValue === null || typeof nextValue === 'undefined';
+
+    try {
+      setSaveStatus('saving', deleting ? '⏳ Schülereingabe wird gelöscht …' : '⏳ Schülereingabe wird aktualisiert …');
+      const res = await api('child_value_update', {
+        report_instance_id: rid,
+        child_field_id: fid,
+        value_text: deleting ? null : String(nextValue ?? ''),
+      });
+
+      const ridKey = String(rid);
+      const fidKey = String(fid);
+      if (!state.values_child[ridKey]) state.values_child[ridKey] = {};
+      state.values_child[ridKey][fidKey] = res.value_text ?? '';
+
+      addHistoryEntry(rid, fid, res.value_text || '', 'child', res.raw_value_text ?? null, res.value_json ?? null);
+      adjustChildProgress(rid, childLabelText || '', prevRaw, res.raw_value_text ?? (deleting ? '' : nextValue));
+
+      render();
+      setSaveStatus('ok', deleting ? '✔ Schülereingabe gelöscht' : '✔ Schülereingabe aktualisiert');
+    } catch (e) {
+      console.error(e);
+      showErr(e?.message || 'Fehler beim Aktualisieren.');
+      setSaveStatus('error', '❌ Konnte nicht gespeichert werden');
+    }
+  }
+
+  function wireChildValueControls(root){
+    const cont = root || document;
+
+    cont.querySelectorAll('[data-edit-child]').forEach(btn => {
+      btn.addEventListener('click', async (ev) => {
+        ev.preventDefault();
+        const rid = Number(btn.getAttribute('data-edit-child') || 0);
+        const fid = Number(btn.getAttribute('data-child-field') || 0);
+        const lbl = String(btn.getAttribute('data-child-label') || 'Schülereingabe');
+        const current = childVal(rid, fid);
+        const next = window.prompt(`Neuer Schülerwert für "${lbl}":`, current);
+        if (next === null) return;
+        await updateChildValue(rid, fid, next, lbl);
+      });
+    });
+
+    cont.querySelectorAll('[data-delete-child]').forEach(btn => {
+      btn.addEventListener('click', async (ev) => {
+        ev.preventDefault();
+        const rid = Number(btn.getAttribute('data-delete-child') || 0);
+        const fid = Number(btn.getAttribute('data-child-field') || 0);
+        const lbl = String(btn.getAttribute('data-child-label') || 'Schülereingabe');
+        if (!window.confirm(`Schülereingabe "${lbl}" wirklich löschen?`)) return;
+        await updateChildValue(rid, fid, null, lbl);
+      });
+    });
   }
 
   function renderHistoryHtml(reportId, fieldId){
@@ -2176,9 +2293,7 @@ render_teacher_header($pageTitle);
       html += `<div class="progress sm" style="margin:6px 0 10px;"><div class="progress-bar${_gtMiss === 0 ? ' ok' : ''}" style="width:${_gtPct}%;"></div></div>`;
       fields.forEach(f => {
         const v = teacherVal(reportId, f.id);
-        const rawChild = (f.child && f.child.id) ? childVal(reportId, f.child.id) : '';
-        const shownChild = rawChild ? childDisplay(f, rawChild) : '';
-        const childInfo = (f.child && f.child.id) ? `<div class="child"><strong>Schüler:</strong> ${shownChild ? esc(shownChild) : '<span class="muted">—</span>'}</div>` : '';
+        const childInfo = childInfoHtml(f, reportId);
         const lbl = resolveLabelTemplate(String(f.label || f.field_name || 'Feld'));
         const help = resolveLabelTemplate(String(f.help_text || ''));
         const missingCls = (v === '') ? 'missing' : '';
@@ -2226,6 +2341,7 @@ render_teacher_header($pageTitle);
       });
     });
 
+    wireChildValueControls(studentForm);
     wireTeacherInputs(studentForm);
 
   }
@@ -2292,26 +2408,24 @@ render_teacher_header($pageTitle);
           const gObj = (state.groups||[]).find(x => String(x.key) === String(f._group_key));
           const canEditGroup = gObj ? (Number(gObj.can_edit||0) === 1) : true;
 
-          const rawChild = (f.child && f.child.id) ? childVal(reportId, f.child.id) : '';
-          const shownChild = rawChild ? childDisplay(f, rawChild) : '';
-
-        const missingCls = (v === '') ? 'missing' : '';
-        td.innerHTML = `
-          <div class="cellWrap ${missingCls}">
-            ${renderInputHtml(f, reportId, v, locked, canEditGroup)}
-            ${renderHistoryHtml(reportId, f.id)}
-            ${(f.child && f.child.id) ? `<div class="cellChild"><strong>Schüler:</strong> ${shownChild ? esc(shownChild) : '—'}</div>` : ''}
-          </div>
-        `;
-        row.appendChild(td);
+          const missingCls = (v === '') ? 'missing' : '';
+          td.innerHTML = `
+            <div class="cellWrap ${missingCls}">
+              ${renderInputHtml(f, reportId, v, locked, canEditGroup)}
+              ${renderHistoryHtml(reportId, f.id)}
+              ${(f.child && f.child.id) ? `<div class="cellChild">${childInfoHtml(f, reportId)}</div>` : ''}
+            </div>
+          `;
+          row.appendChild(td);
         });
 
-        gradeBody.appendChild(row);
-      });
+      gradeBody.appendChild(row);
+    });
 
-      wireTeacherInputs(gradeBody);
-      return;
-    }
+    wireTeacherInputs(gradeBody);
+    wireChildValueControls(gradeBody);
+    return;
+  }
 
     gradeHead.innerHTML = '';
     const tr1 = document.createElement('tr');
@@ -2369,14 +2483,11 @@ render_teacher_header($pageTitle);
         const gObj = (state.groups||[]).find(x => String(x.key) === String(f._group_key));
         const canEditGroup = gObj ? (Number(gObj.can_edit||0) === 1) : true;
 
-        const rawChild = (f.child && f.child.id) ? childVal(reportId, f.child.id) : '';
-        const shownChild = rawChild ? childDisplay(f, rawChild) : '';
-
         const missingCls = (v === '') ? 'missing' : '';
         td.innerHTML = `
           <div class="cellWrap ${missingCls}">
             ${renderInputHtml(f, reportId, v, locked, canEditGroup)}
-            ${(f.child && f.child.id) ? `<div class="cellChild"><strong>Schüler:</strong> ${shownChild ? esc(shownChild) : '—'}</div>` : ''}
+            ${(f.child && f.child.id) ? `<div class="cellChild">${childInfoHtml(f, reportId)}</div>` : ''}
           </div>
         `;
         tr.appendChild(td);
@@ -2386,6 +2497,7 @@ render_teacher_header($pageTitle);
     });
 
     wireTeacherInputs(gradeBody);
+    wireChildValueControls(gradeBody);
   }
 
   function renderItemView(){
@@ -2442,15 +2554,12 @@ render_teacher_header($pageTitle);
         const gObj = (state.groups||[]).find(x => String(x.key) === String(f._group_key));
         const canEditGroup = gObj ? (Number(gObj.can_edit||0) === 1) : true;
 
-        const rawChild = (f.child && f.child.id) ? childVal(reportId, f.child.id) : '';
-        const shownChild = rawChild ? childDisplay(f, rawChild) : '';
-
         const missingCls = (v === '') ? 'missing' : '';
           td.innerHTML = `
           <div class="cellWrap ${missingCls}">
             ${renderInputHtml(f, reportId, v, locked, canEditGroup)}
             ${renderHistoryHtml(reportId, f.id)}
-            ${(f.child && f.child.id) ? `<div class="cellChild"><strong>Schüler:</strong> ${shownChild ? esc(shownChild) : '—'}</div>` : ''}
+            ${(f.child && f.child.id) ? `<div class="cellChild">${childInfoHtml(f, reportId)}</div>` : ''}
           </div>
         `;
         row.appendChild(td);
@@ -2460,6 +2569,7 @@ render_teacher_header($pageTitle);
     });
 
     wireTeacherInputs(itemBody);
+    wireChildValueControls(itemBody);
   }
 
   async function loadClass(classId){


### PR DESCRIPTION
## Summary
- add server-side action for teachers to update or clear student-provided field values with validation and audit logging
- introduce UI controls to edit or delete student entries and reuse shared child info rendering
- refresh local progress and history data after teacher changes to keep the interface consistent

## Testing
- php -l teacher/ajax/entry_api.php
- php -l teacher/entry.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd7ca761c832e91e3f6fd46284036)