### PR TITLE
Scope class-wide report values per class

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -69,6 +69,10 @@ function url_with_lang(string $lang): string {
   return $path . ($newQs ? ('?' . $newQs) : '');
 }
 
+function class_report_period_label(int $classId): string {
+  return '__class__:' . $classId;
+}
+
 // One-shot: allow switching language via ?lang=de|en
 if (isset($_GET['lang'])) {
   ui_lang_set((string)$_GET['lang']);

--- a/parent/portal.php
+++ b/parent/portal.php
@@ -79,17 +79,18 @@ function parent_is_class_field(array $meta): bool {
 }
 
 /**
- * ✅ NEW: find class report instance (student_id=0, period_label='__class__')
+ * ✅ NEW: find class report instance (student_id=0, period_label=class_report_period_label(class_id))
  */
-function parent_find_class_report_instance_id(PDO $pdo, int $templateId, string $schoolYear): ?int {
+function parent_find_class_report_instance_id(PDO $pdo, int $templateId, int $classId, string $schoolYear): ?int {
+  $periodLabel = class_report_period_label($classId);
   $st = $pdo->prepare(
     "SELECT id
      FROM report_instances
-     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label='__class__'
+     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label=?
      ORDER BY updated_at DESC, id DESC
      LIMIT 1"
   );
-  $st->execute([$templateId, $schoolYear]);
+  $st->execute([$templateId, $schoolYear, $periodLabel]);
   $id = (int)($st->fetchColumn() ?: 0);
   return $id > 0 ? $id : null;
 }
@@ -228,7 +229,7 @@ if ($token === '') {
 }
 
 $st = $pdo->prepare(
-  "SELECT ppl.*, s.first_name, s.last_name, c.school_year, c.grade_level, c.label, c.name,\n" .
+  "SELECT ppl.*, s.first_name, s.last_name, c.id AS class_id, c.school_year, c.grade_level, c.label, c.name,\n" .
   "       ri.template_id, ri.period_label, ri.school_year AS report_school_year\n" .
   "FROM parent_portal_links ppl\n" .
   "JOIN students s ON s.id=ppl.student_id\n" .
@@ -325,7 +326,7 @@ if ($canPreview) {
 
   // ✅ NEW: merge class-wide values on top (override for class fields)
   if ($templateId > 0 && $reportSchoolYear !== '' && $classFieldNames) {
-    $classRiId = parent_find_class_report_instance_id($pdo, $templateId, $reportSchoolYear);
+    $classRiId = parent_find_class_report_instance_id($pdo, $templateId, (int)($link['class_id'] ?? 0), $reportSchoolYear);
     if ($classRiId) {
       $classValues = parent_load_values_for_report($pdo, (int)$classRiId);
       foreach ($classFieldNames as $fname => $_) {

--- a/shared/export_api_core.php
+++ b/shared/export_api_core.php
@@ -243,17 +243,18 @@ function is_class_field_export(array $meta): bool {
   return false;
 }
 
-function find_class_report_instance(PDO $pdo, int $templateId, string $schoolYear): ?int {
+function find_class_report_instance(PDO $pdo, int $templateId, int $classId, string $schoolYear): ?int {
   // Class-wide values are stored in a dedicated report instance:
-  // student_id = 0, period_label = '__class__', school_year = class school year.
+  // student_id = 0, period_label = class_report_period_label(class_id), school_year = class school year.
+  $periodLabel = class_report_period_label($classId);
   $st = $pdo->prepare(
     "SELECT id
      FROM report_instances
-     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label='__class__'
+     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label=?
      ORDER BY updated_at DESC, id DESC
      LIMIT 1"
   );
-  $st->execute([$templateId, $schoolYear]);
+  $st->execute([$templateId, $schoolYear, $periodLabel]);
   $id = (int)($st->fetchColumn() ?: 0);
   return $id > 0 ? $id : null;
 }
@@ -396,7 +397,7 @@ function compute_export_payload(PDO $pdo, int $classId, ?int $onlyStudentId, boo
   // Load class-wide values once (and merge them into each student's values for export)
   $classValues = [];
   if ($includeValues && $classFieldNames) {
-    $classRiId = find_class_report_instance($pdo, $templateId, $schoolYear);
+    $classRiId = find_class_report_instance($pdo, $templateId, $classId, $schoolYear);
     if ($classRiId) {
       $classValues = load_class_values($pdo, (int)$classRiId);
     }

--- a/student/ajax/wizard_api.php
+++ b/student/ajax/wizard_api.php
@@ -246,14 +246,15 @@ function template_for_student(PDO $pdo, int $studentId): array {
 }
 
 function find_or_create_class_report_instance(PDO $pdo, int $templateId, int $classId, string $schoolYear): int {
+  $periodLabel = class_report_period_label($classId);
   $st = $pdo->prepare(
     "SELECT id
      FROM report_instances
-     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label='__class__'
+     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label=?
      ORDER BY updated_at DESC, id DESC
      LIMIT 1"
   );
-  $st->execute([$templateId, $schoolYear]);
+  $st->execute([$templateId, $schoolYear, $periodLabel]);
   $id = (int)($st->fetchColumn() ?: 0);
   if ($id > 0) return $id;
 

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -552,21 +552,22 @@ function class_school_year(PDO $pdo, int $classId): string {
 }
 
 function find_or_create_class_report_instance(PDO $pdo, int $templateId, int $classId, string $schoolYear): int {
+  $periodLabel = class_report_period_label($classId);
   $st = $pdo->prepare(
     "SELECT id, status
      FROM report_instances
-     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label='__class__'
+     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label=?
      ORDER BY updated_at DESC, id DESC
      LIMIT 1"
   );
-  $st->execute([$templateId, $schoolYear]);
+  $st->execute([$templateId, $schoolYear, $periodLabel]);
   $row = $st->fetch(PDO::FETCH_ASSOC);
   if ($row) return (int)$row['id'];
 
   $pdo->prepare(
     "INSERT INTO report_instances (template_id, student_id, period_label, school_year, status, created_by_user_id, created_at, updated_at)
-     VALUES (?, 0, '__class__', ?, 'draft', NULL, NOW(), NOW())"
-  )->execute([$templateId, $schoolYear]);
+     VALUES (?, 0, ?, ?, 'draft', NULL, NOW(), NOW())"
+  )->execute([$templateId, $periodLabel, $schoolYear]);
 
   return (int)$pdo->lastInsertId();
 }
@@ -1544,7 +1545,8 @@ if ($action === 'delegations_save') {
     if ((int)($ri['template_id'] ?? 0) !== $templateId) throw new RuntimeException('Vorlagenkonflikt.');
     if ((int)($ri['student_id'] ?? 0) !== 0) throw new RuntimeException('Kein Klassen-Report.');
     if ((string)($ri['school_year'] ?? '') !== $schoolYear) throw new RuntimeException('Schuljahr-Konflikt.');
-    if ((string)($ri['period_label'] ?? '') !== '__class__') throw new RuntimeException('Perioden-Konflikt.');
+    $expectedLabel = class_report_period_label($classId);
+    if ((string)($ri['period_label'] ?? '') !== $expectedLabel) throw new RuntimeException('Perioden-Konflikt.');
 
     $status = (string)($ri['status'] ?? 'draft');
     if ($status === 'locked') throw new RuntimeException('Report ist gesperrt.');


### PR DESCRIPTION
### Motivation

- Klassenspezifische Felder wurden bislang über eine shared period label (`'__class__'`) global gespeichert, wodurch Werte zwischen Klassen überlappten.
- Ziel ist, class-wide Werte eindeutig einer Klasse zuzuordnen, damit jede Klasse eigene Klassenfelder haben kann.

### Description

- Added a helper `class_report_period_label(int $classId)` in `bootstrap.php` to build a per-class period label (`__class__:<classId>`).
- Switched class-report lookup/creation to use the per-class period label and added `classId` parameters where needed in `teacher/ajax/entry_api.php`, `student/ajax/wizard_api.php`, `shared/export_api_core.php`, and `parent/portal.php`.
- Updated validations to check the expected per-class `period_label` and updated parent portal query to include `c.id AS class_id` for resolving the correct class report instance.
- Merged class-wide values using the per-class report instance in export/parent/teacher/student flows so class fields no longer clash between classes.

### Testing

- No automated tests were run for this change.
- Existing code paths touched: teacher class save/load, student wizard class lookup, parent portal preview, and export merging logic; no CI executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69600616bc08832e929da1983ededa12)