### PR TITLE
Maintain focus on student login input

### DIFF
--- a/student/login.php
+++ b/student/login.php
@@ -385,6 +385,16 @@ $logo = (string)($b['logo_path'] ?? '');
           input.setSelectionRange(pos, pos);
         }
 
+        function ensureInputFocus() {
+          if (qrScanActive) {
+            return;
+          }
+          if (document.activeElement !== input) {
+            input.focus({ preventScroll: true });
+            setCaretToEnd(getRaw().length);
+          }
+        }
+
         function renderOverlay(raw) {
           const showBlink = raw.length < 8;
           const blinkSlot = showBlink ? Math.min(raw.length, 7) : -1;
@@ -452,6 +462,28 @@ $logo = (string)($b['logo_path'] ?? '');
           }, 0);
         });
 
+        input.addEventListener('blur', () => {
+          setTimeout(() => {
+            ensureInputFocus();
+          }, 0);
+        });
+
+        document.addEventListener('pointerdown', (event) => {
+          if (event.target !== input) {
+            setTimeout(() => {
+              ensureInputFocus();
+            }, 0);
+          }
+        });
+
+        document.addEventListener('visibilitychange', () => {
+          if (!document.hidden) {
+            setTimeout(() => {
+              ensureInputFocus();
+            }, 0);
+          }
+        });
+
         // Init
         const initialRaw = cleanRaw(hidden.value);
         setRaw(initialRaw);
@@ -478,6 +510,7 @@ $logo = (string)($b['logo_path'] ?? '');
           if (document.webkitFullscreenElement) {
             document.webkitExitFullscreen();
           }
+          ensureInputFocus();
         }
 
         function playQrBeep() {
@@ -660,7 +693,7 @@ $logo = (string)($b['logo_path'] ?? '');
         });
 
         setTimeout(() => {
-          input.focus({ preventScroll: true });
+          ensureInputFocus();
           setRaw(getRaw());
         }, 0);
       });


### PR DESCRIPTION
### Motivation

- Ensure the student login code input keeps focus so pupils can continue typing without losing the on-screen keyboard or caret while still allowing QR scanning to work.

### Description

- Added a new `ensureInputFocus` helper in `student/login.php` that focuses the masked input and sets the caret, and it early-returns when `qrScanActive` is true.
- Added event handlers to reapply focus on `blur`, on document `pointerdown`, and on `visibilitychange`, and replaced the initial `input.focus` call with `ensureInputFocus` to centralize behavior.
- Call `ensureInputFocus` after `stopQrScan()` to refocus the input when QR scanning ends while respecting active scans.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c045fc7d0832eabf1a781e40749a3)