### PR TITLE
Show system-bound fields read-only and add student-value info tooltip

### DIFF
--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -1160,6 +1160,14 @@ try {
       $classFieldIdsEditable[] = (int)$f0['id'];
     }
 
+    // system-bound fields (read-only) should still be visible
+    $systemFieldIds = [];
+    foreach ($teacherFields as $f0) {
+      $m0 = meta_read($f0['meta_json'] ?? null);
+      if (!is_system_bound($m0)) continue;
+      $systemFieldIds[] = (int)$f0['id'];
+    }
+
     $periodLabel = 'Standard';
     $delegations = load_class_group_delegations($pdo, $classId, $schoolYear, $periodLabel);
     $delegationUsers = load_teachers_for_delegation($pdo);
@@ -1199,7 +1207,8 @@ try {
     $classValueByName = [];
     foreach ($teacherFields as $f0) {
       $m0 = meta_read($f0['meta_json'] ?? null);
-      if (!is_class_field($m0) || is_system_bound($m0)) continue;
+      if (!is_class_field($m0)) continue;
+      $isSystemBound = is_system_bound($m0);
       $fid0 = (string)(int)$f0['id'];
       $val0 = '';
       $ridKey = (string)(int)$classReportInstanceId;
@@ -1255,7 +1264,8 @@ try {
         'help_text_resolved' => resolve_label_placeholders((string)($f0['help_text'] ?? ''), $classValueByName),
         'is_multiline' => (int)($f0['is_multiline'] ?? 0),
         'options' => $optsTeacher,
-        'can_edit' => $canEditClassField ? 1 : 0,
+        'can_edit' => ($canEditClassField && !$isSystemBound) ? 1 : 0,
+        'is_system_bound' => $isSystemBound ? 1 : 0,
       ];
     }
 
@@ -1264,8 +1274,8 @@ try {
     foreach ($teacherFields as $f) {
       $meta = meta_read($f['meta_json'] ?? null);
 
-      if (is_system_bound($meta)) continue;
       if (is_class_field($meta)) continue;
+      $isSystemBound = is_system_bound($meta);
 
       $gKey = group_key_from_meta($meta);
       if (!isset($groups[$gKey])) {
@@ -1319,6 +1329,7 @@ try {
         (string)($f['field_type'] ?? ''),
         (int)($f['is_multiline'] ?? 0)
       );
+      if ($isSystemBound) $canEditField = false;
 
       $groups[$gKey]['fields'][] = [
         'id' => (int)$f['id'],
@@ -1331,6 +1342,7 @@ try {
         'is_multiline' => (int)($f['is_multiline'] ?? 0),
         'options' => $optsTeacher,
         'can_edit' => $canEditField ? 1 : 0,
+        'is_system_bound' => $isSystemBound ? 1 : 0,
         'child' => $child ? [
           'id' => (int)$child['id'],
           'field_name' => (string)($child['field_name'] ?? ''),
@@ -1386,6 +1398,18 @@ try {
     $valuesTeacher = $teacherValues['combined'] ?? [];
     $valuesTeacherOwn = $teacherValues['own'] ?? [];
     $valuesChild = load_values($pdo, $reportIds, $childFieldIds, 'child', $lang);
+
+    if ($systemFieldIds) {
+      $systemValues = load_values($pdo, $reportIds, $systemFieldIds, 'system', $lang);
+      foreach ($systemValues as $rid => $fields) {
+        if (!isset($valuesTeacher[$rid])) $valuesTeacher[$rid] = [];
+        if (!isset($valuesTeacherOwn[$rid])) $valuesTeacherOwn[$rid] = [];
+        foreach ($fields as $fid => $val) {
+          $valuesTeacher[$rid][(string)$fid] = $val;
+          $valuesTeacherOwn[$rid][(string)$fid] = $val;
+        }
+      }
+    }
 
     // --- progress (teacher / child / overall) ---
     $teacherProgressIds = [];

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -513,11 +513,32 @@ render_teacher_header($pageTitle);
   }
 
   .field{ border:1px solid var(--border); border-radius:14px; padding:12px; background:#fff; margin-bottom:10px; }
-  .field .lbl{ font-weight:800; }
+  .field .lbl{ font-weight:800; display:flex; align-items:center; gap:6px; }
   .field .help{ color:var(--muted); font-size:12px; margin-top:6px; }
   .field .child{ display:none; margin-top:8px; border-top:1px dashed var(--border); padding-top:8px; color:var(--muted); font-size:12px; }
   .field .child strong{ color: rgba(0,0,0,0.75); }
   .field.show-child .child{ display:block; }
+  .child-tip{ display:inline-flex; align-items:center; position:relative; }
+  .child-tip-btn{
+    width:18px; height:18px; min-height:18px;
+    border-radius:50%; border:1px solid var(--border);
+    font-size:11px; font-weight:800; padding:0;
+    line-height:1; display:inline-flex; align-items:center; justify-content:center;
+  }
+  .child-tip-btn:hover{ color:#0b57d0; border-color:rgba(11,87,208,0.4); }
+  .child-tip-bubble{
+    position:absolute; bottom: calc(100% + 6px); left:0;
+    background:#fff; border:1px solid var(--border); border-radius:10px;
+    padding:8px 10px; font-size:12px; color:var(--text);
+    box-shadow:0 8px 24px rgba(0,0,0,0.12);
+    min-width:220px; max-width:320px; z-index:30; display:none;
+  }
+  .child-tip.open .child-tip-bubble{ display:block; }
+  .child-tip-bubble::after{
+    content:""; position:absolute; top:100%; left:10px;
+    border-width:6px; border-style:solid;
+    border-color:#fff transparent transparent transparent;
+  }
 
   .opts{ display:flex; gap:8px; margin-top:8px; flex-wrap:wrap; align-items:stretch; }
   .opt{ display:inline-flex; gap:8px; align-items:center; padding:8px 10px; border-radius:12px; border:1px solid var(--border); background: #fff; cursor:pointer; user-select:none; flex:0 0 auto; text-align:left; color: inherit; min-height:36px; }
@@ -958,6 +979,22 @@ render_teacher_header($pageTitle);
           <button class="btn secondary" type="button" data-delete-child="${esc(reportId)}" ${baseAttrs} ${deleteDisabled}>Löschen</button>
         </div>
       </div>
+    `;
+  }
+
+  function childInfoTipHtml(f, reportId){
+    if (!f || !f.child || !f.child.id) return '';
+    if (!isFreeTextField(f)) return '';
+    const childId = Number(f.child.id);
+    const rawChild = childVal(reportId, childId);
+    if (!String(rawChild ?? '').trim()) return '';
+    const shownChild = childDisplay(f, rawChild) || rawChild;
+    const html = esc(String(shownChild)).replace(/\n/g, '<br>');
+    return `
+      <span class="child-tip" data-tip="1">
+        <button type="button" class="btn ghost icon child-tip-btn js-child-tip" aria-label="Schülerwert anzeigen">i</button>
+        <span class="child-tip-bubble">${html}</span>
+      </span>
     `;
   }
 
@@ -2747,6 +2784,13 @@ render_teacher_header($pageTitle);
     });
   }
 
+  function closeChildTips(except){
+    document.querySelectorAll('.child-tip.open').forEach(t => {
+      if (except && t === except) return;
+      t.classList.remove('open');
+    });
+  }
+
   document.addEventListener('click', (ev) => {
     const tipBtn = ev.target && ev.target.closest('.js-combined-tip');
     if (tipBtn) {
@@ -2755,6 +2799,18 @@ render_teacher_header($pageTitle);
       if (tipWrap) {
         const open = tipWrap.classList.contains('open');
         closeCombinedTips(open ? null : tipWrap);
+        tipWrap.classList.toggle('open', !open);
+      }
+      return;
+    }
+
+    const childTipBtn = ev.target && ev.target.closest('.js-child-tip');
+    if (childTipBtn) {
+      ev.preventDefault();
+      const tipWrap = childTipBtn.closest('.child-tip');
+      if (tipWrap) {
+        const open = tipWrap.classList.contains('open');
+        closeChildTips(open ? null : tipWrap);
         tipWrap.classList.toggle('open', !open);
       }
       return;
@@ -2787,6 +2843,7 @@ render_teacher_header($pageTitle);
     if (ev.target && ev.target.closest('[data-history-menu="1"]')) return;
     closeHistoryMenus();
     closeCombinedTips();
+    closeChildTips();
 
     if (ev.target && snippetMenu.contains(ev.target)) return;
     hideSnippetMenu();
@@ -3260,6 +3317,7 @@ render_teacher_header($pageTitle);
         const v = activeFieldValue(reportId, f.id);
         const canEditField = (Number(f.can_edit || 0) === 1);
         const childInfo = CHILD_MODE ? '' : childInfoHtml(f, reportId);
+        const childTip = CHILD_MODE ? '' : childInfoTipHtml(f, reportId);
         const lbl = resolveLabelTemplate(String(f.label || f.field_name || 'Feld'));
         const help = resolveLabelTemplate(String(f.help_text || ''));
         const missingCls = (v === '') ? 'missing' : '';
@@ -3273,7 +3331,7 @@ render_teacher_header($pageTitle);
           : '';
         html += `
           <div class="field ${missingCls}" data-fieldwrap="1" data-field-id="${esc(f.id)}">
-            <div class="lbl">${esc(lbl)}</div>
+            <div class="lbl">${esc(lbl)}${childTip}</div>
             <div class="help" style="${help.trim() ? '' : 'display:none;'}">${esc(help)}</div>
             ${renderActiveInputHtml(f, reportId, v, locked, canEditField)}
             ${actionsHtml}
@@ -3572,6 +3630,7 @@ render_teacher_header($pageTitle);
         const locked = (status === 'locked');
         const v = activeFieldValue(reportId, f.id);
         const canEditField = (Number(f.can_edit || 0) === 1);
+        const childTip = CHILD_MODE ? '' : childInfoTipHtml(f, reportId);
 
         const missingCls = (v === '') ? 'missing' : '';
           const combinedHtml = CHILD_MODE ? '' : combinedPreviewHtml(reportId, f);
@@ -3582,6 +3641,7 @@ render_teacher_header($pageTitle);
           td.innerHTML = `
           <div class="cellWrap ${missingCls}">
             ${renderActiveInputHtml(f, reportId, v, locked, canEditField)}
+            ${childTip}
             ${actionsHtml}
             ${(!CHILD_MODE && f.child && f.child.id) ? `<div class="cellChild">${childInfoHtml(f, reportId)}</div>` : ''}
           </div>


### PR DESCRIPTION
### Motivation
- Systemgebundene Felder (automatisch befüllte) müssen sichtbar, aber nicht editierbar in der Eingabeoberfläche sein. 
- Bei Textfeldern mit zugehörigem Schülerwert soll ein kleines (i) die Schüler-Einträge anzeigen, damit Lehrkräfte den Schülerwert leicht einsehen können.

### Description
- Back-end: `teacher/ajax/entry_api.php` — sammelt IDs systemgebundener Felder, markiert Felder mit `is_system_bound` und verhindert Editieren dieser Felder in den `can_edit`-Flags, und lädt `system`-Werte mittels `load_values` und merged diese in die Teacher-Werte (`values_teacher` / `values_teacher_own`) damit sie im UI als read-only angezeigt werden.
- Front-end: `teacher/entry.php` — Styling für Feldlabel angepasst und neue CSS-Regeln für das Child-Info-Tooltip (`.child-tip*`) hinzugefügt.
- Front-end JS: `teacher/entry.php` — neue Helfer `childInfoTipHtml` und `closeChildTips` implementiert, Event-Handler zum Öffnen/Schließen des (i)-Tooltips hinzugefügt und Tooltip-Inhalte in Student-/Item-/Field-Views gerendert; das Tooltip zeigt formatierte Schülerwerte nur für freie Textfelder an.

### Testing
- Keine automatisierten Tests wurden ausgeführt in diesem Rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d354b7390832eafdbc30c455436b9)