### PR TITLE
Use NULL student_id for class report instances

### DIFF
--- a/install.php
+++ b/install.php
@@ -373,7 +373,7 @@ CREATE TABLE IF NOT EXISTS `template_fields` (
 CREATE TABLE IF NOT EXISTS `report_instances` (
   `id` bigint UNSIGNED NOT NULL AUTO_INCREMENT,
   `template_id` bigint UNSIGNED NOT NULL,
-  `student_id` bigint UNSIGNED NOT NULL,
+  `student_id` bigint UNSIGNED DEFAULT NULL,
   `period_label` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
   `school_year` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
   `status` enum('draft','submitted','locked') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'draft',

--- a/parent/portal.php
+++ b/parent/portal.php
@@ -79,14 +79,14 @@ function parent_is_class_field(array $meta): bool {
 }
 
 /**
- * ✅ NEW: find class report instance (student_id=0, period_label=class_report_period_label(class_id))
+ * ✅ NEW: find class report instance (student_id IS NULL, period_label=class_report_period_label(class_id))
  */
 function parent_find_class_report_instance_id(PDO $pdo, int $templateId, int $classId, string $schoolYear): ?int {
   $periodLabel = class_report_period_label($classId);
   $st = $pdo->prepare(
     "SELECT id
      FROM report_instances
-     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label=?
+     WHERE template_id=? AND student_id IS NULL AND school_year=? AND period_label=?
      ORDER BY updated_at DESC, id DESC
      LIMIT 1"
   );

--- a/shared/export_api_core.php
+++ b/shared/export_api_core.php
@@ -245,12 +245,12 @@ function is_class_field_export(array $meta): bool {
 
 function find_class_report_instance(PDO $pdo, int $templateId, int $classId, string $schoolYear): ?int {
   // Class-wide values are stored in a dedicated report instance:
-  // student_id = 0, period_label = class_report_period_label(class_id), school_year = class school year.
+  // student_id IS NULL, period_label = class_report_period_label(class_id), school_year = class school year.
   $periodLabel = class_report_period_label($classId);
   $st = $pdo->prepare(
     "SELECT id
      FROM report_instances
-     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label=?
+     WHERE template_id=? AND student_id IS NULL AND school_year=? AND period_label=?
      ORDER BY updated_at DESC, id DESC
      LIMIT 1"
   );

--- a/student/ajax/wizard_api.php
+++ b/student/ajax/wizard_api.php
@@ -293,7 +293,7 @@ function find_or_create_class_report_instance(PDO $pdo, int $templateId, int $cl
   $st = $pdo->prepare(
     "SELECT id
      FROM report_instances
-     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label=?
+     WHERE template_id=? AND student_id IS NULL AND school_year=? AND period_label=?
      ORDER BY updated_at DESC, id DESC
      LIMIT 1"
   );

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -831,7 +831,7 @@ function find_or_create_class_report_instance(PDO $pdo, int $templateId, int $cl
   $st = $pdo->prepare(
     "SELECT id, status
      FROM report_instances
-     WHERE template_id=? AND student_id=0 AND school_year=? AND period_label=?
+     WHERE template_id=? AND student_id IS NULL AND school_year=? AND period_label=?
      ORDER BY updated_at DESC, id DESC
      LIMIT 1"
   );
@@ -841,7 +841,7 @@ function find_or_create_class_report_instance(PDO $pdo, int $templateId, int $cl
 
   $pdo->prepare(
     "INSERT INTO report_instances (template_id, student_id, period_label, school_year, status, created_by_user_id, created_at, updated_at)
-     VALUES (?, 0, ?, ?, 'draft', NULL, NOW(), NOW())"
+     VALUES (?, NULL, ?, ?, 'draft', NULL, NOW(), NOW())"
   )->execute([$templateId, $periodLabel, $schoolYear]);
 
   return (int)$pdo->lastInsertId();
@@ -2803,7 +2803,7 @@ if ($action === 'delegations_save') {
     if (!$ri) throw new RuntimeException('Report nicht gefunden.');
 
     if ((int)($ri['template_id'] ?? 0) !== $templateId) throw new RuntimeException('Vorlagenkonflikt.');
-    if ((int)($ri['student_id'] ?? 0) !== 0) throw new RuntimeException('Kein Klassen-Report.');
+    if ($ri['student_id'] !== null) throw new RuntimeException('Kein Klassen-Report.');
     if ((string)($ri['school_year'] ?? '') !== $schoolYear) throw new RuntimeException('Schuljahr-Konflikt.');
     $expectedLabel = class_report_period_label($classId);
     if ((string)($ri['period_label'] ?? '') !== $expectedLabel) throw new RuntimeException('Perioden-Konflikt.');


### PR DESCRIPTION
### Motivation
- Class-level report instances must not use `0` for `student_id` because that can violate the foreign key constraint to `students`; `NULL` should be used instead to represent class-wide reports.
- Queries and validation logic must consistently treat class reports as `student_id IS NULL` so class-field flows behave correctly across teacher, student, parent and export code paths.

### Description
- Change lookups to query class reports with `student_id IS NULL` instead of `student_id=0` in `teacher/ajax/entry_api.php`, `student/ajax/wizard_api.php`, `shared/export_api_core.php`, and `parent/portal.php`.
- Insert new class reports using `NULL` for `student_id` (replace `VALUES (?, 0, ...)` with `VALUES (?, NULL, ...)`) in `teacher/ajax/entry_api.php`.
- Update class-report validation to check `student_id !== null` when denying non-class reports in `teacher/ajax/entry_api.php`.
- Allow `report_instances.student_id` to be `NULL` in the installation schema by changing the `report_instances` table definition in `install.php`.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696db63b99c0832e921c16b48779e007)