### PR TITLE
Add email reply action for parent feedback

### DIFF
--- a/teacher/parents.php
+++ b/teacher/parents.php
@@ -57,9 +57,9 @@ function build_parent_mail_html(string $template, array $student, string $link):
 
 function build_feedback_reply_mailto(array $emails, string $studentName, string $message, string $createdAt): ?string {
   if (!$emails) return null;
-  $subject = 'Re: Eltern-Rückmeldung von ' . $studentName;
+  $subject = 'Re: Eltern-Rückmeldung zum Lernentwicklungsbericht von ' . $studentName;
   $replyText = trim($message) !== '' ? $message : '—';
-  $body = "Hallo,\n\n\n\n---\nRückmeldung von {$studentName} am {$createdAt}:\n" . $replyText;
+  $body = "Hallo,\n\n\n\n---\nIhre Rückmeldung vom {$createdAt}:\n" . $replyText;
   $recipients = implode(',', $emails);
   $query = 'subject=' . rawurlencode($subject) . '&body=' . rawurlencode($body);
   return 'mailto:' . $recipients . '?' . $query;


### PR DESCRIPTION
### Motivation
- Provide teachers a quick way to reply to parent feedback by opening their mail client prefilled with the original message and context.

### Description
- Added `quote_mail_text()` and `build_feedback_reply_mailto()` helpers to construct quoted reply bodies and `mailto:` URLs including subject and body.
- Included `s.email_parent1` and `s.email_parent2` in the feedback query to obtain parent addresses for replies.
- Rendered a “Per Mail antworten” reply button in the Eltern‑Rückmeldung table that opens the teacher's mail client with the quoted original message and timestamp, while keeping the existing review action.
- All changes are contained in `teacher/parents.php`.

### Testing
- Started a local PHP server with `php -S 0.0.0.0:8000 -t /workspace/leb_tool` and captured a login page screenshot using Playwright, which completed successfully and produced an artifact.
- No unit or integration test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ecce645b8832ea8d8f9757e84e0ba)