### PR TITLE
Hide locked child fields in child entry view

### DIFF
--- a/admin/ajax/option_lists_api.php
+++ b/admin/ajax/option_lists_api.php
@@ -173,7 +173,7 @@ try {
 
     // NEW: label_en
     $it = $pdo->prepare("
-      SELECT id, list_id, value, label, label_en, icon_id, sort_order
+      SELECT id, list_id, value, label, label_en, icon_id, sort_order, meta_json
       FROM option_list_items
       WHERE list_id=?
       ORDER BY sort_order ASC, id ASC
@@ -218,11 +218,11 @@ try {
     // NEW: label_en
     $ins = $pdo->prepare("
       INSERT INTO option_list_items (list_id, value, label, label_en, icon_id, sort_order, meta_json)
-      VALUES (?, ?, ?, ?, ?, ?, NULL)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
     ");
     $upd = $pdo->prepare("
       UPDATE option_list_items
-      SET value=?, label=?, label_en=?, icon_id=?, sort_order=?, updated_at=CURRENT_TIMESTAMP
+      SET value=?, label=?, label_en=?, icon_id=?, sort_order=?, meta_json=?, updated_at=CURRENT_TIMESTAMP
       WHERE id=? AND list_id=?
     ");
 
@@ -236,15 +236,17 @@ try {
       $labelEn = trim((string)($row['label_en'] ?? '')); // NEW (optional)
       $iconId = isset($row['icon_id']) && $row['icon_id'] !== null && $row['icon_id'] !== '' ? (int)$row['icon_id'] : null;
       $sort = (int)($row['sort_order'] ?? $i);
+      $lockChild = !empty($row['lock_child']);
+      $metaJson = $lockChild ? json_encode(['lock_child' => 1], JSON_UNESCAPED_UNICODE) : null;
 
       // Require value + DE label
       if ($value === '' || $label === '') { $i++; continue; }
 
       if ($itemId > 0 && in_array($itemId, $existingIds, true)) {
-        $upd->execute([$value, $label, $labelEn, $iconId, $sort, $itemId, $id]);
+        $upd->execute([$value, $label, $labelEn, $iconId, $sort, $metaJson, $itemId, $id]);
         $keepIds[] = $itemId;
       } else {
-        $ins->execute([$id, $value, $label, $labelEn, $iconId, $sort]);
+        $ins->execute([$id, $value, $label, $labelEn, $iconId, $sort, $metaJson]);
         $keepIds[] = (int)$pdo->lastInsertId();
       }
 

--- a/admin/icon_library.php
+++ b/admin/icon_library.php
@@ -185,8 +185,9 @@ render_admin_header('Admin – Icon & Options');
                   <th class="col-sort">Value</th>
                   <th>Label (DE)</th>
                   <th>Label (EN)</th>
-                  <th class="col-ico">Icon</th>
-                  <th style="width:90px; min-width:90px;">Aktion</th>
+                <th class="col-ico">Icon</th>
+                <th style="width:150px; min-width:150px;">Schülerfeld sperren</th>
+                <th style="width:90px; min-width:90px;">Aktion</th>
                 </tr>
               </thead>
               <tbody id="itemsTbody"></tbody>
@@ -353,7 +354,7 @@ render_admin_header('Admin – Icon & Options');
 
   let listsCache = [];
   let activeListId = 0;
-  let activeItems = []; // [{id?, sort_order, value,label,label_en,icon_id}]
+  let activeItems = []; // [{id?, sort_order, value,label,label_en,icon_id,lock_child}]
   let iconsForPicker = []; // from iconsCache
 
   function renderLists(){
@@ -399,6 +400,12 @@ render_admin_header('Admin – Icon & Options');
             <span class="muted small">Preview</span>
           </div>
         </td>
+        <td style="text-align:center;">
+          <label style="display:inline-flex; align-items:center; gap:6px;">
+            <input type="checkbox" ${it.lock_child ? 'checked' : ''}>
+            <span class="muted small">sperrt</span>
+          </label>
+        </td>
         <td>
           <button class="btn secondary js-del" type="button">Entfernen</button>
         </td>
@@ -410,6 +417,7 @@ render_admin_header('Admin – Icon & Options');
       const inpLabel = tr.querySelectorAll('td input[type="text"]')[1];
       const inpLabelEn = tr.querySelectorAll('td input[type="text"]')[2];
       const selIcon = tr.querySelector('select');
+      const lockToggle = tr.querySelector('input[type="checkbox"]');
       const delBtn = tr.querySelector('.js-del');
       const prevSpan = tr.querySelector('.js-icon-preview');
 
@@ -425,6 +433,7 @@ render_admin_header('Admin – Icon & Options');
       inpLabel.addEventListener('input', ()=> { activeItems[idx].label = inpLabel.value; });
       inpLabelEn.addEventListener('input', ()=> { activeItems[idx].label_en = inpLabelEn.value; });
       selIcon.addEventListener('change', ()=> { activeItems[idx].icon_id = selIcon.value ? parseInt(selIcon.value,10) : null; updatePreview(); });
+      lockToggle.addEventListener('change', ()=> { activeItems[idx].lock_child = lockToggle.checked; });
 
       delBtn.addEventListener('click', ()=> {
         activeItems.splice(idx, 1);
@@ -464,7 +473,15 @@ render_admin_header('Admin – Icon & Options');
       value: x.value,
       label: x.label,
       label_en: x.label_en, // NEW
-      icon_id: x.icon_id
+      icon_id: x.icon_id,
+      lock_child: (() => {
+        try {
+          const meta = x.meta_json ? JSON.parse(x.meta_json) : null;
+          return !!(meta && meta.lock_child);
+        } catch(e) {
+          return false;
+        }
+      })()
     }));
 
     noListSelected.style.display = 'none';
@@ -499,7 +516,7 @@ render_admin_header('Admin – Icon & Options');
   });
 
   btnAddItem.addEventListener('click', () => {
-    activeItems.push({ sort_order: activeItems.length, value:'', label:'', label_en:'', icon_id:null }); // NEW
+    activeItems.push({ sort_order: activeItems.length, value:'', label:'', label_en:'', icon_id:null, lock_child:false }); // NEW
     renderItems();
   });
 
@@ -517,7 +534,8 @@ render_admin_header('Admin – Icon & Options');
           value: String(x.value || '').trim(),
           label: String(x.label || '').trim(),
           label_en: String(x.label_en || '').trim(), // NEW
-          icon_id: x.icon_id ? Number(x.icon_id) : null
+          icon_id: x.icon_id ? Number(x.icon_id) : null,
+          lock_child: x.lock_child ? 1 : 0
         }))
         .filter(x => x.value !== '' && x.label !== '');
 

--- a/shared/export_api_core.php
+++ b/shared/export_api_core.php
@@ -159,6 +159,13 @@ function option_list_id_from_meta_export(array $meta): int {
   return (int)$tid;
 }
 
+function base_field_key_export(string $fieldName): string {
+  $s = strtolower(trim($fieldName));
+  $s = explode('-', $s, 2)[0];
+  $s = preg_replace('/\s+/', ' ', $s) ?? $s;
+  return trim($s);
+}
+
 function resolve_option_value_text_export(PDO $pdo, array $meta, ?string $valueJson, ?string $valueText): string {
   $listId = option_list_id_from_meta_export($meta);
   if ($listId <= 0) return (string)($valueText ?? '');
@@ -235,6 +242,109 @@ function load_values_for_report(PDO $pdo, int $reportInstanceId): array {
   return array_map(fn($row) => $row['value'], $map);
 }
 
+function load_teacher_values_for_export(PDO $pdo, int $reportId, array $fieldIds): array {
+  $fieldIds = array_values(array_unique(array_filter(array_map('intval', $fieldIds), fn($x)=>$x>0)));
+  if (!$fieldIds) return [];
+  $in = implode(',', array_fill(0, count($fieldIds), '?'));
+  $params = array_merge([$reportId], $fieldIds);
+  $st = $pdo->prepare(
+    "SELECT template_field_id, value_text, value_json
+     FROM field_values
+     WHERE report_instance_id=? AND source='teacher' AND template_field_id IN ($in)"
+  );
+  $st->execute($params);
+  $out = [];
+  foreach ($st->fetchAll(PDO::FETCH_ASSOC) as $r) {
+    $fid = (int)$r['template_field_id'];
+    $out[$fid] = [
+      'text' => $r['value_text'] !== null ? (string)$r['value_text'] : null,
+      'json' => $r['value_json'] !== null ? (string)$r['value_json'] : null,
+    ];
+  }
+  return $out;
+}
+
+function option_list_lock_map_export(PDO $pdo, int $listId, array &$cache): array {
+  if ($listId <= 0) return ['by_id' => [], 'by_value' => []];
+  if (isset($cache[$listId])) return $cache[$listId];
+  $st = $pdo->prepare(
+    "SELECT id, value, meta_json
+     FROM option_list_items
+     WHERE list_id=?"
+  );
+  $st->execute([$listId]);
+  $byId = [];
+  $byValue = [];
+  foreach ($st->fetchAll(PDO::FETCH_ASSOC) as $r) {
+    $id = (int)($r['id'] ?? 0);
+    $value = trim((string)($r['value'] ?? ''));
+    $meta = meta_read_export($r['meta_json'] ?? null);
+    $lock = !empty($meta['lock_child']);
+    $byId[$id] = [
+      'value' => $value,
+      'lock_child' => $lock,
+    ];
+    if ($value !== '' && !isset($byValue[$value])) $byValue[$value] = $id;
+  }
+  $cache[$listId] = ['by_id' => $byId, 'by_value' => $byValue];
+  return $cache[$listId];
+}
+
+function teacher_value_locks_child_export(PDO $pdo, array $teacherField, ?array $teacherValue, array &$cache): bool {
+  if (!$teacherValue) return false;
+  $type = (string)($teacherField['field_type'] ?? '');
+  if (!in_array($type, ['radio','select','grade'], true)) return false;
+  $meta = meta_read_export($teacherField['meta_json'] ?? null);
+  $listId = option_list_id_from_meta_export($meta);
+  if ($listId <= 0) return false;
+  $map = option_list_lock_map_export($pdo, $listId, $cache);
+  $optId = 0;
+  if (!empty($teacherValue['json'])) {
+    $decoded = json_decode((string)$teacherValue['json'], true);
+    if (is_array($decoded) && isset($decoded['option_item_id'])) {
+      $optId = (int)$decoded['option_item_id'];
+    }
+  }
+  if ($optId <= 0) {
+    $txt = trim((string)($teacherValue['text'] ?? ''));
+    if ($txt !== '' && isset($map['by_value'][$txt])) {
+      $optId = (int)$map['by_value'][$txt];
+    }
+  }
+  if ($optId <= 0) return false;
+  return !empty($map['by_id'][$optId]['lock_child']);
+}
+
+function locked_child_field_names_for_report(PDO $pdo, array $templateFields, int $reportId): array {
+  if ($reportId <= 0) return [];
+  $teacherByBase = [];
+  $teacherFieldIds = [];
+  foreach ($templateFields as $f) {
+    if ((int)($f['can_teacher_edit'] ?? 0) !== 1) continue;
+    $fid = (int)($f['id'] ?? 0);
+    if ($fid <= 0) continue;
+    $teacherFieldIds[] = $fid;
+    $base = base_field_key_export((string)($f['field_name'] ?? ''));
+    if ($base !== '' && !isset($teacherByBase[$base])) $teacherByBase[$base] = $f;
+  }
+  if (!$teacherFieldIds) return [];
+  $teacherValues = load_teacher_values_for_export($pdo, $reportId, $teacherFieldIds);
+  $lockCache = [];
+  $locked = [];
+  foreach ($templateFields as $f) {
+    if ((int)($f['can_child_edit'] ?? 0) !== 1) continue;
+    $base = base_field_key_export((string)($f['field_name'] ?? ''));
+    if ($base === '') continue;
+    $teacherField = $teacherByBase[$base] ?? null;
+    if (!$teacherField) continue;
+    $teacherValue = $teacherValues[(int)($teacherField['id'] ?? 0)] ?? null;
+    if (!teacher_value_locks_child_export($pdo, $teacherField, $teacherValue, $lockCache)) continue;
+    $name = (string)($f['field_name'] ?? '');
+    if ($name !== '') $locked[$name] = true;
+  }
+  return $locked;
+}
+
 function is_class_field_export(array $meta): bool {
   // Admin marks class-wide fields via meta_json: {"scope":"class"}
   // (We also accept a legacy boolean flag if ever introduced.)
@@ -264,13 +374,14 @@ function load_class_values(PDO $pdo, int $classReportInstanceId): array {
   return load_values_for_report($pdo, $classReportInstanceId);
 }
 
-function missing_fields_for_student(array $templateFields, array $values, array &$nonEditableOut = null): array {
+function missing_fields_for_student(array $templateFields, array $values, array &$nonEditableOut = null, array $lockedFieldNames = []): array {
   // IMPORTANT: warn on ALL fields (not only required)
   $missing = [];
   $nonEditable = [];
   foreach ($templateFields as $f) {
     $name = (string)($f['field_name'] ?? '');
     if ($name === '') continue;
+    if (!empty($lockedFieldNames[$name])) continue;
 
     $type = (string)($f['field_type'] ?? 'text');
     $label = (string)($f['label'] ?? $name);
@@ -439,7 +550,10 @@ function compute_export_payload(PDO $pdo, int $classId, ?int $onlyStudentId, boo
     // If no report instance exists, we still warn (everything missing), but label it compactly:
     $missing = [];
     if ($includeValues) {
-      if ($ri) $missing = missing_fields_for_student($tf, $values, $nonEditableFields);
+      if ($ri) {
+        $lockedFields = locked_child_field_names_for_report($pdo, $tf, (int)$ri['id']);
+        $missing = missing_fields_for_student($tf, $values, $nonEditableFields, $lockedFields);
+      }
       else {
         // show a single pseudo-entry instead of 200 fields
         $missing = [[

--- a/student/ajax/wizard_api.php
+++ b/student/ajax/wizard_api.php
@@ -135,6 +135,13 @@ function group_key_from_meta(array $meta): string {
   return $g !== '' ? $g : 'Allgemein';
 }
 
+function base_field_key(string $fieldName): string {
+  $s = strtolower(trim($fieldName));
+  $s = explode('-', $s, 2)[0];
+  $s = preg_replace('/\s+/', ' ', $s) ?? $s;
+  return trim($s);
+}
+
 function student_wizard_display_mode_from_class(array $classRow): string {
   $mode = (string)($classRow['student_wizard_display'] ?? 'groups');
   $mode = strtolower(trim($mode));
@@ -411,6 +418,16 @@ function load_child_fields(PDO $pdo, int $templateId): array {
   return $st->fetchAll(PDO::FETCH_ASSOC);
 }
 
+function load_teacher_fields(PDO $pdo, int $templateId): array {
+  $st = $pdo->prepare(
+    "SELECT id, field_name, field_type, meta_json
+     FROM template_fields
+     WHERE template_id=? AND can_teacher_edit=1"
+  );
+  $st->execute([$templateId]);
+  return $st->fetchAll(PDO::FETCH_ASSOC);
+}
+
 function load_child_values(PDO $pdo, int $reportInstanceId): array {
   $st = $pdo->prepare(
     "SELECT template_field_id, value_text, value_json
@@ -418,6 +435,28 @@ function load_child_values(PDO $pdo, int $reportInstanceId): array {
      WHERE report_instance_id=? AND source='child'"
   );
   $st->execute([$reportInstanceId]);
+  $out = [];
+  foreach ($st->fetchAll(PDO::FETCH_ASSOC) as $r) {
+    $fid = (int)$r['template_field_id'];
+    $out[$fid] = [
+      'text' => $r['value_text'] !== null ? (string)$r['value_text'] : null,
+      'json' => $r['value_json'] !== null ? $r['value_json'] : null,
+    ];
+  }
+  return $out;
+}
+
+function load_teacher_values(PDO $pdo, int $reportInstanceId, array $fieldIds): array {
+  $fieldIds = array_values(array_unique(array_filter(array_map('intval', $fieldIds), fn($x)=>$x>0)));
+  if (!$fieldIds) return [];
+  $in = implode(',', array_fill(0, count($fieldIds), '?'));
+  $params = array_merge([$reportInstanceId], $fieldIds);
+  $st = $pdo->prepare(
+    "SELECT template_field_id, value_text, value_json
+     FROM field_values
+     WHERE report_instance_id=? AND source='teacher' AND template_field_id IN ($in)"
+  );
+  $st->execute($params);
   $out = [];
   foreach ($st->fetchAll(PDO::FETCH_ASSOC) as $r) {
     $fid = (int)$r['template_field_id'];
@@ -442,13 +481,95 @@ function resolve_icon_urls(PDO $pdo, array $iconIds): array {
   return $map;
 }
 
-function all_child_fields_filled(PDO $pdo, int $templateId, int $reportId): bool {
+function option_list_lock_map(PDO $pdo, int $listId, array &$cache): array {
+  if ($listId <= 0) return ['by_id' => [], 'by_value' => []];
+  if (isset($cache[$listId])) return $cache[$listId];
+  $st = $pdo->prepare(
+    "SELECT id, value, meta_json
+     FROM option_list_items
+     WHERE list_id=?"
+  );
+  $st->execute([$listId]);
+  $byId = [];
+  $byValue = [];
+  foreach ($st->fetchAll(PDO::FETCH_ASSOC) as $r) {
+    $id = (int)($r['id'] ?? 0);
+    $value = trim((string)($r['value'] ?? ''));
+    $meta = meta_read($r['meta_json'] ?? null);
+    $lock = !empty($meta['lock_child']);
+    $byId[$id] = [
+      'value' => $value,
+      'lock_child' => $lock,
+    ];
+    if ($value !== '' && !isset($byValue[$value])) $byValue[$value] = $id;
+  }
+  $cache[$listId] = ['by_id' => $byId, 'by_value' => $byValue];
+  return $cache[$listId];
+}
+
+function teacher_value_locks_child(PDO $pdo, array $teacherField, ?array $teacherValue, array &$cache): bool {
+  if (!$teacherValue) return false;
+  $type = (string)($teacherField['field_type'] ?? '');
+  if (!in_array($type, ['radio','select','grade'], true)) return false;
+  $meta = meta_read($teacherField['meta_json'] ?? null);
+  $listId = option_list_id_from_meta($meta);
+  if ($listId <= 0) return false;
+  $map = option_list_lock_map($pdo, $listId, $cache);
+  $optId = 0;
+  if (!empty($teacherValue['json'])) {
+    $decoded = json_decode((string)$teacherValue['json'], true);
+    if (is_array($decoded) && isset($decoded['option_item_id'])) {
+      $optId = (int)$decoded['option_item_id'];
+    }
+  }
+  if ($optId <= 0) {
+    $txt = trim((string)($teacherValue['text'] ?? ''));
+    if ($txt !== '' && isset($map['by_value'][$txt])) {
+      $optId = (int)$map['by_value'][$txt];
+    }
+  }
+  if ($optId <= 0) return false;
+  return !empty($map['by_id'][$optId]['lock_child']);
+}
+
+function child_field_locked_by_teacher(PDO $pdo, array $childField, array &$context): bool {
+  $base = base_field_key((string)($childField['field_name'] ?? ''));
+  if ($base === '') return false;
+  $teacherField = $context['teacher_by_base'][$base] ?? null;
+  if (!$teacherField) return false;
+  $teacherValue = $context['teacher_values'][(int)($teacherField['id'] ?? 0)] ?? null;
+  return teacher_value_locks_child($pdo, $teacherField, $teacherValue, $context['option_cache']);
+}
+
+function child_lock_context(PDO $pdo, int $templateId, int $reportId): array {
+  $teacherFields = load_teacher_fields($pdo, $templateId);
+  $teacherByBase = [];
+  $teacherFieldIds = [];
+  foreach ($teacherFields as $f) {
+    $fid = (int)($f['id'] ?? 0);
+    if ($fid <= 0) continue;
+    $teacherFieldIds[] = $fid;
+    $base = base_field_key((string)($f['field_name'] ?? ''));
+    if ($base !== '' && !isset($teacherByBase[$base])) {
+      $teacherByBase[$base] = $f;
+    }
+  }
+  $teacherValues = $teacherFieldIds ? load_teacher_values($pdo, $reportId, $teacherFieldIds) : [];
+  return [
+    'teacher_by_base' => $teacherByBase,
+    'teacher_values' => $teacherValues,
+    'option_cache' => [],
+  ];
+}
+
+function all_child_fields_filled(PDO $pdo, int $templateId, int $reportId, array $lockedFieldIds = []): bool {
   $fields = load_child_fields($pdo, $templateId);
   if (!$fields) return true;
 
   $vals = load_child_values($pdo, $reportId);
   foreach ($fields as $f) {
     $fid = (int)$f['id'];
+    if (!empty($lockedFieldIds[$fid])) continue;
     $v = $vals[$fid]['text'] ?? null;
     if (trim((string)$v) === '') return false;
   }
@@ -532,9 +653,15 @@ try {
     $groups = [];
     $iconIds = [];
     $optCache = []; // listId => options array
+    $lockedFieldIds = [];
+    $lockContext = child_lock_context($pdo, $templateId, $reportId);
 
     foreach ($fieldsRaw as $r) {
       $fid = (int)$r['id'];
+      if (child_field_locked_by_teacher($pdo, $r, $lockContext)) {
+        $lockedFieldIds[$fid] = true;
+        continue;
+      }
       $meta = meta_read($r['meta_json'] ?? null);
 
       $gKey = group_key_from_meta($meta);
@@ -652,7 +779,7 @@ try {
     if ($fieldId <= 0) throw new RuntimeException('template_field_id fehlt.');
 
     $st = $pdo->prepare(
-      "SELECT id, field_type, meta_json
+      "SELECT id, field_name, field_type, meta_json
        FROM template_fields
        WHERE id=? AND template_id=? AND can_child_edit=1
        LIMIT 1"
@@ -660,6 +787,11 @@ try {
     $st->execute([$fieldId, $templateId]);
     $frow = $st->fetch(PDO::FETCH_ASSOC);
     if (!$frow) throw new RuntimeException('Feld nicht erlaubt.');
+
+    $lockContext = child_lock_context($pdo, $templateId, $reportId);
+    if (child_field_locked_by_teacher($pdo, $frow, $lockContext)) {
+      throw new RuntimeException('Feld ist gesperrt.');
+    }
 
     $type = (string)$frow['field_type'];
     $meta = meta_read($frow['meta_json'] ?? null);
@@ -719,7 +851,15 @@ try {
 
   // submit
   ensure_editable_or_throw($pdo, $reportId);
-  if (!all_child_fields_filled($pdo, $templateId, $reportId)) {
+  $lockContext = child_lock_context($pdo, $templateId, $reportId);
+  $lockedFieldIds = [];
+  foreach (load_child_fields($pdo, $templateId) as $f) {
+    $fid = (int)($f['id'] ?? 0);
+    if ($fid > 0 && child_field_locked_by_teacher($pdo, $f, $lockContext)) {
+      $lockedFieldIds[$fid] = true;
+    }
+  }
+  if (!all_child_fields_filled($pdo, $templateId, $reportId, $lockedFieldIds)) {
     throw new RuntimeException('Bitte fülle zuerst alle Felder aus.');
   }
 

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -695,6 +695,125 @@ function base_field_key(string $fieldName): string {
   return trim($s);
 }
 
+function load_teacher_values_raw(PDO $pdo, array $reportIds, array $fieldIds): array {
+  $reportIds = array_values(array_unique(array_filter(array_map('intval', $reportIds), fn($x)=>$x>0)));
+  $fieldIds = array_values(array_unique(array_filter(array_map('intval', $fieldIds), fn($x)=>$x>0)));
+  if (!$reportIds || !$fieldIds) return [];
+
+  $inR = implode(',', array_fill(0, count($reportIds), '?'));
+  $inF = implode(',', array_fill(0, count($fieldIds), '?'));
+  $params = array_merge($reportIds, $fieldIds);
+
+  $st = $pdo->prepare(
+    "SELECT report_instance_id, template_field_id, value_text, value_json
+     FROM field_values
+     WHERE report_instance_id IN ($inR)
+       AND template_field_id IN ($inF)
+       AND source='teacher'"
+  );
+  $st->execute($params);
+
+  $out = [];
+  foreach ($st->fetchAll(PDO::FETCH_ASSOC) as $r) {
+    $rid = (string)(int)$r['report_instance_id'];
+    $fid = (int)$r['template_field_id'];
+    if (!isset($out[$rid])) $out[$rid] = [];
+    $out[$rid][$fid] = [
+      'text' => $r['value_text'] !== null ? (string)$r['value_text'] : null,
+      'json' => $r['value_json'] !== null ? (string)$r['value_json'] : null,
+    ];
+  }
+  return $out;
+}
+
+function option_list_lock_map(PDO $pdo, int $listId, array &$cache): array {
+  if ($listId <= 0) return ['by_id' => [], 'by_value' => []];
+  if (isset($cache[$listId])) return $cache[$listId];
+  $st = $pdo->prepare(
+    "SELECT id, value, meta_json
+     FROM option_list_items
+     WHERE list_id=?"
+  );
+  $st->execute([$listId]);
+  $byId = [];
+  $byValue = [];
+  foreach ($st->fetchAll(PDO::FETCH_ASSOC) as $r) {
+    $id = (int)($r['id'] ?? 0);
+    $value = trim((string)($r['value'] ?? ''));
+    $meta = meta_read($r['meta_json'] ?? null);
+    $lock = !empty($meta['lock_child']);
+    $byId[$id] = [
+      'value' => $value,
+      'lock_child' => $lock,
+    ];
+    if ($value !== '' && !isset($byValue[$value])) $byValue[$value] = $id;
+  }
+  $cache[$listId] = ['by_id' => $byId, 'by_value' => $byValue];
+  return $cache[$listId];
+}
+
+function teacher_value_locks_child(PDO $pdo, array $teacherField, ?array $teacherValue, array &$cache): bool {
+  if (!$teacherValue) return false;
+  $type = (string)($teacherField['field_type'] ?? '');
+  if (!in_array($type, ['radio','select','grade'], true)) return false;
+  $meta = meta_read($teacherField['meta_json'] ?? null);
+  $listId = option_list_id_from_meta($meta);
+  if ($listId <= 0) return false;
+  $map = option_list_lock_map($pdo, $listId, $cache);
+  $optId = 0;
+  if (!empty($teacherValue['json'])) {
+    $decoded = json_decode((string)$teacherValue['json'], true);
+    if (is_array($decoded) && isset($decoded['option_item_id'])) {
+      $optId = (int)$decoded['option_item_id'];
+    }
+  }
+  if ($optId <= 0) {
+    $txt = trim((string)($teacherValue['text'] ?? ''));
+    if ($txt !== '' && isset($map['by_value'][$txt])) {
+      $optId = (int)$map['by_value'][$txt];
+    }
+  }
+  if ($optId <= 0) return false;
+  return !empty($map['by_id'][$optId]['lock_child']);
+}
+
+function locked_child_field_ids_for_reports(PDO $pdo, array $teacherFields, array $childFields, array $reportIds): array {
+  if (!$reportIds) return [];
+  $teacherByBase = [];
+  $teacherFieldIds = [];
+  foreach ($teacherFields as $f) {
+    $fid = (int)($f['id'] ?? 0);
+    if ($fid <= 0) continue;
+    $teacherFieldIds[] = $fid;
+    $base = base_field_key((string)($f['field_name'] ?? ''));
+    if ($base !== '' && !isset($teacherByBase[$base])) $teacherByBase[$base] = $f;
+  }
+  if (!$teacherFieldIds || !$teacherByBase) return [];
+  $teacherValues = load_teacher_values_raw($pdo, $reportIds, $teacherFieldIds);
+  if (!$teacherValues) return [];
+
+  $lockCache = [];
+  $out = [];
+  foreach ($reportIds as $rid) {
+    $ridKey = (string)(int)$rid;
+    $reportTeacherValues = $teacherValues[$ridKey] ?? [];
+    if (!$reportTeacherValues) continue;
+    foreach ($childFields as $cf) {
+      $cfId = (int)($cf['id'] ?? 0);
+      if ($cfId <= 0) continue;
+      $base = base_field_key((string)($cf['field_name'] ?? ''));
+      if ($base === '') continue;
+      $teacherField = $teacherByBase[$base] ?? null;
+      if (!$teacherField) continue;
+      $teacherValue = $reportTeacherValues[(int)($teacherField['id'] ?? 0)] ?? null;
+      if (!teacher_value_locks_child($pdo, $teacherField, $teacherValue, $lockCache)) continue;
+      if (!isset($out[$ridKey])) $out[$ridKey] = [];
+      $out[$ridKey][$cfId] = true;
+    }
+  }
+  return $out;
+}
+
 function is_system_bound(array $meta): bool {
   $tpl = $meta['system_binding_tpl'] ?? null;
   if (is_string($tpl) && trim($tpl) !== '') return true;
@@ -1524,9 +1643,12 @@ try {
     $overallTotal = $teacherTotal + $childTotal;
 
     $completeForms = 0;
+    $lockedChildIdsByReport = locked_child_field_ids_for_reports($pdo, $teacherFields, $childFieldsAll, $reportIds);
     foreach ($students as &$srow) {
       $rid = (int)($srow['report_instance_id'] ?? 0);
       $ridKey = (string)$rid;
+      $lockedChildIds = $lockedChildIdsByReport[$ridKey] ?? [];
+      $childTotalForStudent = max(0, $childTotal - count($lockedChildIds));
 
       $tDone = 0;
       if ($teacherTotal > 0) {
@@ -1538,8 +1660,9 @@ try {
 
       $cDone = 0;
       $missingChildLabels = [];
-      if ($childTotal > 0) {
+      if ($childTotalForStudent > 0) {
         foreach ($childProgressIds as $fid) {
+          if (!empty($lockedChildIds[$fid])) continue;
           $v = $valuesChildAllForProgress[$ridKey][(string)$fid] ?? '';
           $trimmed = trim((string)$v);
           if ($trimmed !== '') {
@@ -1551,21 +1674,22 @@ try {
         }
       }
 
+      $overallTotalForStudent = $teacherTotal + $childTotalForStudent;
       $oDone = $tDone + $cDone;
-      $oMissing = max(0, $overallTotal - $oDone);
-      $isComplete = ($overallTotal > 0 && $oMissing === 0);
+      $oMissing = max(0, $overallTotalForStudent - $oDone);
+      $isComplete = ($overallTotalForStudent > 0 && $oMissing === 0);
       if ($isComplete) $completeForms++;
 
       $srow['progress_teacher_total'] = $teacherTotal;
       $srow['progress_teacher_done'] = $tDone;
       $srow['progress_teacher_missing'] = max(0, $teacherTotal - $tDone);
 
-      $srow['progress_child_total'] = $childTotal;
+      $srow['progress_child_total'] = $childTotalForStudent;
       $srow['progress_child_done'] = $cDone;
-      $srow['progress_child_missing'] = max(0, $childTotal - $cDone);
+      $srow['progress_child_missing'] = max(0, $childTotalForStudent - $cDone);
       $srow['child_missing_fields'] = $missingChildLabels;
 
-      $srow['progress_overall_total'] = $overallTotal;
+      $srow['progress_overall_total'] = $overallTotalForStudent;
       $srow['progress_overall_done'] = $oDone;
       $srow['progress_overall_missing'] = $oMissing;
       $srow['progress_is_complete'] = $isComplete;
@@ -1620,6 +1744,7 @@ try {
       'values_teacher_parts' => $teacherValues['parts'] ?? [],
       'values_child' => $valuesChild,
       'value_history' => $valueHistory,
+      'locked_child_fields' => $lockedChildIdsByReport,
       'progress_summary' => $progressSummary,
       'class_report_instance_id' => $classReportInstanceId,
       'class_fields' => [

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -741,6 +741,7 @@ render_teacher_header($pageTitle);
     values_teacher_own: {},
     values_teacher_parts: {},
     values_child: {},
+    locked_child_fields: {},
     value_history: {},
     class_report_instance_id: 0,
     class_fields: null,
@@ -826,16 +827,17 @@ render_teacher_header($pageTitle);
   function esc(s){ return String(s ?? '').replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m])); }
   function normalize(s){ return String(s ?? '').toLowerCase().trim(); }
 
-  function activeProgressFieldIds(){
+  function activeProgressFieldIds(reportId){
     const ids = [];
-    activeGroups().forEach(g => {
+    const groups = CHILD_MODE ? activeGroupsForReport(reportId) : activeGroups();
+    groups.forEach(g => {
       (g.fields || []).forEach(f => { ids.push(Number(f.id)); });
     });
     return ids;
   }
 
   function activeProgressForStudent(reportId){
-    const ids = activeProgressFieldIds();
+    const ids = activeProgressFieldIds(reportId);
     const total = ids.length;
     let done = 0;
     ids.forEach(fid => {
@@ -940,8 +942,31 @@ render_teacher_header($pageTitle);
     return v;
   }
 
+  function lockedChildFieldMap(reportId){
+    const key = String(reportId || '');
+    const raw = (state.locked_child_fields && state.locked_child_fields[key]) ? state.locked_child_fields[key] : {};
+    return raw && typeof raw === 'object' ? raw : {};
+  }
+
+  function isChildFieldLocked(reportId, fieldId){
+    if (!CHILD_MODE) return false;
+    const locked = lockedChildFieldMap(reportId);
+    const key = String(fieldId || '');
+    return !!(locked[key] || locked[fieldId]);
+  }
+
   function activeGroups(){
     return CHILD_MODE ? (state.child_groups || []) : (state.groups || []);
+  }
+
+  function activeGroupsForReport(reportId){
+    if (!CHILD_MODE) return activeGroups();
+    const locked = lockedChildFieldMap(reportId);
+    return (state.child_groups || []).map(g => {
+      const fields = (g.fields || []).filter(f => !locked[String(f.id)] && !locked[f.id]);
+      if (!fields.length) return null;
+      return { ...g, fields };
+    }).filter(Boolean);
   }
 
   function activeFieldValue(reportId, fieldId){
@@ -953,6 +978,7 @@ render_teacher_header($pageTitle);
   }
 
   function isActiveFieldMissing(reportId, fieldId){
+    if (isChildFieldLocked(reportId, fieldId)) return false;
     return String(activeFieldValue(reportId, fieldId) ?? '').trim() === '';
   }
 
@@ -3238,7 +3264,7 @@ render_teacher_header($pageTitle);
     let childMissingFields = Array.isArray(s.child_missing_fields) ? s.child_missing_fields.filter(x => String(x).trim() !== '') : [];
     if (CHILD_MODE) {
       childMissingFields = [];
-      activeGroups().forEach(g => {
+      activeGroupsForReport(reportId).forEach(g => {
         (g.fields || []).forEach(f => {
           const v = activeFieldValue(reportId, f.id);
           if (String(v ?? '').trim() === '') {
@@ -3281,7 +3307,7 @@ render_teacher_header($pageTitle);
       `;
     }
 
-    activeGroups().forEach(g => {
+    activeGroupsForReport(reportId).forEach(g => {
       if (ui.studentGroupKey !== 'ALL' && String(g.key) !== String(ui.studentGroupKey)) return;
       const fields = ui.studentMissingOnly
         ? (g.fields || []).filter(f => isActiveFieldMissing(reportId, f.id))
@@ -3691,6 +3717,7 @@ render_teacher_header($pageTitle);
       state.values_teacher_own = j.values_teacher_own || {};
       state.values_teacher_parts = j.values_teacher_parts || {};
       state.values_child = j.values_child || {};
+      state.locked_child_fields = j.locked_child_fields || {};
       state.value_history = j.value_history || {};
       state.class_report_instance_id = j.class_report_instance_id || 0;
       state.class_fields = j.class_fields || null;


### PR DESCRIPTION
### Motivation
- Teacher-selected option items can mark corresponding student (child) fields as locked and these fields must be suppressed for students and not counted as missing in teacher/student UIs and exports.
- The client needed the per-report locked-child map from the server so child-entry rendering and progress calculations can exclude locked fields.
- The child-entry UI still showed locked fields as open; this change hides them and prevents students from saving into them.

### Description
- Exposed per-report `locked_child_fields` in the teacher entry API response so frontends can know which child fields are locked (`teacher/ajax/entry_api.php`).
- Implemented lock detection and filtering in the teacher UI: added `locked_child_fields` client state, `lockedChildFieldMap`, `isChildFieldLocked`, `activeGroupsForReport` helpers and updated progress/missing checks and rendering to exclude locked child fields (`teacher/entry.php`).
- Added server-side helpers to compute locks from teacher option selections and propagate them into export and student APIs, plus client-side checks in the student wizard to prevent saving locked fields and to ignore them when validating completion (`shared/export_api_core.php`, `student/ajax/wizard_api.php`, related helper functions for option-list lock maps and teacher value lookups).
- Extended option-list admin UI and persistence to include a `lock_child` flag for option items so option choices can mark child fields locked (`admin/icon_library.php`, `admin/ajax/option_lists_api.php`).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697191323d00832eac160a052ea9d63d)