### PR TITLE
Improve action menu render stability

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -262,6 +262,10 @@ code{background:#f1f2f6; padding:2px 6px; border-radius:6px}
 }
 .action-dropdown-menu{
   display:none;
+  backface-visibility:hidden;
+  contain:paint;
+  transform:translateZ(0);
+  will-change:transform;
 }
 .action-dropdown-menu .btn,
 .action-dropdown-menu form,


### PR DESCRIPTION
### Motivation
- Users reported Chrome sometimes crashing with visual/graphics glitches when opening per-row action dropdowns, so the dropdown rendering is hardened to avoid compositor issues.

### Description
- Add rendering containment and GPU compositing hints to `.action-dropdown-menu` in `assets/app.css` by adding `backface-visibility: hidden; contain: paint; transform: translateZ(0); will-change: transform;` to reduce painting/compositing glitches.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69728871279c832e8a33df9c4f2fe133)