### PR TITLE
Remove hardcoded 1–6 grade scale shortcuts

### DIFF
--- a/admin/icon_library.php
+++ b/admin/icon_library.php
@@ -117,7 +117,7 @@ render_admin_header('Admin – Icon & Options');
 
   <div id="tab-lists" class="tabpanel active">
     <h2 style="margin-top:0;">Option-Listen Vorlagen</h2>
-    <p class="muted">Erstelle hier Auswahllisten (z.B. Skala 1–6, Ja/Nein, Smileys). Diese Vorlagen nutzt du später in <code>template_fields.php</code> für Radio/Select-Felder.</p>
+    <p class="muted">Erstelle hier Auswahllisten (z.B. Skala, Ja/Nein, Smileys). Diese Vorlagen nutzt du später in <code>template_fields.php</code> für Radio/Select-Felder.</p>
 
     <div class="grid2">
       <div class="card" style="margin:0;">
@@ -126,7 +126,7 @@ render_admin_header('Admin – Icon & Options');
         <div class="grid" style="gap:12px; align-items:end;">
           <div>
             <label>Neue Vorlage</label>
-            <input id="newListName" placeholder="z.B. Skala 1–6">
+            <input id="newListName" placeholder="z.B. Skala, Ja/Nein">
           </div>
           <div class="actions" style="justify-content:flex-start;">
             <button class="btn primary" id="btnCreateList" type="button">Erstellen</button>

--- a/admin/template_fields.php
+++ b/admin/template_fields.php
@@ -295,7 +295,6 @@ render_admin_header('Feld-Editor');
         <div class="muted2">Setzt options_json + merkt <code>meta.option_list_template_id</code>.</div>
       </div>
       <div class="actions" style="justify-content:flex-start; gap:8px;">
-        <button class="btn secondary" type="button" id="btnGrade16">Noten 1–6</button>
         <button class="btn secondary" type="button" id="btnClearOptions">Leeren</button>
       </div>
     </div>
@@ -654,7 +653,6 @@ const optionsModal = document.getElementById('optionsModal');
 const optSubtitle = document.getElementById('optSubtitle');
 const optTpl = document.getElementById('optTpl');
 const optJson = document.getElementById('optJson');
-const btnGrade16 = document.getElementById('btnGrade16');
 const btnClearOptions = document.getElementById('btnClearOptions');
 
 const dateModal = document.getElementById('dateModal');
@@ -790,10 +788,6 @@ function flashRow(tr){
 
 function escapeHtml(s){
   return String(s ?? '').replace(/[&<>"']/g, (m)=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;' }[m]));
-}
-
-function grade16Options(){
-  return { options: ['1','2','3','4','5','6'].map(v => ({ value: v, label: v })) };
 }
 
 /** Convert option_list_items -> template_fields.options JSON */
@@ -1452,7 +1446,6 @@ function computeExtras(f){
     if (count) badges.push(`☰ ${count} Optionen`);
     else badges.push('☰ — Optionen');
 
-    if (f.type === 'grade') badges.push('🎓 1–6 verfügbar');
   }
 
   if (f.type === 'multiline' || f.multiline) badges.push('↵ multiline');
@@ -1834,11 +1827,6 @@ function renderTable(){
       e.stopPropagation();
       fields[idx].type = selT.value;
       if (selT.value === 'multiline') fields[idx].multiline = 1;
-      if (selT.value === 'grade' && (!fields[idx].options || !fields[idx].options.options)) {
-        fields[idx].options = grade16Options();
-        fields[idx].meta = fields[idx].meta || {};
-        delete fields[idx].meta.option_list_template_id;
-      }
       markDirty(f.id);
       renderTable();
       scanForSplitCandidate();
@@ -2035,15 +2023,6 @@ function renderTable(){
       btnOpt.addEventListener('click', (e)=>{ e.stopPropagation(); openOptionsModal(f.id); });
       wrap.appendChild(btnOpt);
 
-      if (f.type === 'grade') {
-        const btnG = document.createElement('button');
-        btnG.type = 'button';
-        btnG.className = 'btn secondary';
-        btnG.textContent = 'Noten 1–6';
-        btnG.title = 'Setzt Standard-Notenskala (1–6).';
-        btnG.addEventListener('click', (e)=>{ e.stopPropagation(); setGrade16(f.id); });
-        wrap.appendChild(btnG);
-      }
     }
 
     const badges = document.createElement('div');
@@ -2209,11 +2188,6 @@ async function applyBulk(targetIds){
     if (patch.type) {
       nf.type = patch.type;
       if (nf.type === 'multiline') nf.multiline = 1;
-      if (nf.type === 'grade' && (!nf.options || !nf.options.options)) {
-        nf.options = grade16Options();
-        nf.meta = nf.meta || {};
-        delete nf.meta.option_list_template_id;
-      }
     }
 
     if (patch.hasOwnProperty('can_child_edit')) nf.can_child_edit = patch.can_child_edit;
@@ -2341,18 +2315,6 @@ async function save(){
 }
 
 /* ---------- Options dialog ---------- */
-function setGrade16(fieldId){
-  const idx = fields.findIndex(x => x.id === fieldId);
-  if (idx < 0) return;
-  fields[idx].options = grade16Options();
-  fields[idx].meta = fields[idx].meta || {};
-  delete fields[idx].meta.option_list_template_id;
-  markDirty(fieldId);
-  renderTable();
-  scanForSplitCandidate();
-  updateMeta();
-}
-
 function openOptionsModal(fieldId){
   modalFieldId = fieldId;
   const f = fields.find(x=>x.id===fieldId);
@@ -2363,10 +2325,6 @@ function openOptionsModal(fieldId){
   optionsModal.showModal();
 }
 
-btnGrade16.addEventListener('click', ()=>{
-  optJson.value = JSON.stringify(grade16Options(), null, 2);
-  optTpl.value = '';
-});
 btnClearOptions.addEventListener('click', ()=>{ optJson.value = ''; optTpl.value=''; });
 
 optTpl.addEventListener('change', async ()=>{


### PR DESCRIPTION
### Motivation
- The grade scale must not be hardcoded in the editor because option lists/templates should control available grade scales.

### Description
- Remove the `Noten 1–6` quick-button from the options modal and per-field UI in `admin/template_fields.php` so the UI no longer offers a fixed 1–6 shortcut.
- Remove the `grade16Options` helper and `setGrade16` logic and stop auto-populating a 1–6 `options` payload when switching a field to type `grade` or when applying bulk type changes.
- Remove the `🎓 1–6 verfügbar` badge emitted for grade fields in `computeExtras`.
- Update example/help text in `admin/icon_library.php` to use generic examples (`Skala`, `Ja/Nein`, `Smileys`) instead of `Skala 1–6`.

### Testing
- Started the PHP built-in server with `php -S` and it started successfully.
- Ran a Playwright-based screenshot attempt which failed due to Chromium crashing with a SIGSEGV during launch. No further automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69728a4d2884832ea74e11d119580e4d)