### PR TITLE
Improve student TTS reliability and vits error handling

### DIFF
--- a/student/index.php
+++ b/student/index.php
@@ -804,7 +804,11 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     const mod = await loadVitsModule();
     if (!mod || !mod.download) return null;
     updateTtsUi(t('student.tts.model_loading', 'Vorlesemodell wird geladen …'));
-    vitsPrefetchPromise = mod.download(voiceId).catch(() => null);
+    vitsPrefetchPromise = mod.download(voiceId).catch((err) => {
+      console.warn('vits-web download failed', err);
+      vitsPrefetchPromise = null;
+      return null;
+    });
     return vitsPrefetchPromise;
   }
 
@@ -813,41 +817,54 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     if (!mod || !mod.TtsSession) return null;
     if (vitsSessions.has(voiceId)) return vitsSessions.get(voiceId);
     updateTtsUi(t('student.tts.model_loading', 'Vorlesemodell wird geladen …'));
-    const session = await mod.TtsSession.create({ voiceId });
-    vitsSessions.set(voiceId, session);
-    return session;
+    try {
+      const session = await mod.TtsSession.create({ voiceId });
+      vitsSessions.set(voiceId, session);
+      return session;
+    } catch (err) {
+      console.warn('vits-web session failed', err);
+      return null;
+    }
   }
 
   async function speakWithVits(text){
     const normalized = typeof text === 'string' ? text.trim() : '';
     if (!normalized) return false;
     const voiceId = vitsVoiceIdForLang();
-    const session = await ensureVitsSession(voiceId);
-    if (!session) return false;
-    stopTts();
-    updateTtsUi(t('student.tts.reading', 'Liest gerade …'));
-    const blob = await session.predict(normalized);
-    const url = URL.createObjectURL(blob);
-    const audio = new Audio(url);
-    audio.playbackRate = TTS_RATE;
-    audio.onended = () => {
-      URL.revokeObjectURL(url);
-      updateTtsUi(t('student.tts.ready', 'Bereit zum Vorlesen.'));
-      vitsAudio = null;
-    };
-    audio.onerror = () => {
-      URL.revokeObjectURL(url);
-      updateTtsUi(t('student.tts.error', 'Vorlesen wurde gestoppt.'));
-      vitsAudio = null;
-    };
-    vitsAudio = audio;
-    updateTtsUi(t('student.tts.reading', 'Liest gerade …'));
     try {
-      await audio.play();
-      updateTtsUi();
-      return true;
-    } catch (e) {
+      const session = await ensureVitsSession(voiceId);
+      if (!session) return false;
+      stopTts();
+      updateTtsUi(t('student.tts.reading', 'Liest gerade …'));
+      const blob = await session.predict(normalized);
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      audio.playbackRate = TTS_RATE;
+      audio.onended = () => {
+        URL.revokeObjectURL(url);
+        updateTtsUi(t('student.tts.ready', 'Bereit zum Vorlesen.'));
+        vitsAudio = null;
+      };
+      audio.onerror = () => {
+        URL.revokeObjectURL(url);
+        updateTtsUi(t('student.tts.error', 'Vorlesen wurde gestoppt.'));
+        vitsAudio = null;
+      };
+      vitsAudio = audio;
+      updateTtsUi(t('student.tts.reading', 'Liest gerade …'));
+      try {
+        await audio.play();
+        updateTtsUi();
+        return true;
+      } catch (e) {
+        URL.revokeObjectURL(url);
+        updateTtsUi(t('student.tts.error', 'Vorlesen wurde gestoppt.'));
+        return false;
+      }
+    } catch (err) {
+      console.warn('vits-web playback failed', err);
       updateTtsUi(t('student.tts.error', 'Vorlesen wurde gestoppt.'));
+      vitsAudio = null;
       return false;
     }
   }


### PR DESCRIPTION
### Motivation
- The read-aloud (TTS) flow could permanently fail when the vits-web model download, session creation, or playback throws, preventing fallback to the Web Speech API.
- The change aims to make failures recoverable so subsequent attempts can retry and the UI falls back gracefully.

### Description
- In `prefetchVitsModel` reset `vitsPrefetchPromise` and log on `mod.download` failures so future prefetch attempts can retry instead of staying stuck.
- In `ensureVitsSession` wrap `mod.TtsSession.create` in a `try/catch` and log errors, returning `null` on failure to allow fallback.
- In `speakWithVits` add an outer `try/catch`, ensure `URL.revokeObjectURL` is called on playback errors, clear `vitsAudio` on failure, and log playback errors so the function returns `false` and the caller can use `speakWithWebSpeech` as fallback.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766ea2edb0832e9818e0c8b2b097fc)