### PR TITLE
Prevent delegated users from importing XSchool final marks

### DIFF
--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -374,12 +374,15 @@ if ($finalmarksFormSchoolYear === '') {
 }
 
 if ($isTeacherRole && !$childMode && (string)($_SERVER['REQUEST_METHOD'] ?? '') === 'POST' && isset($_POST['finalmarks_action'])) {
-  $action = (string)$_POST['finalmarks_action'];
-  $finalmarksFormSchoolYear = trim((string)($_POST['school_year'] ?? $finalmarksFormSchoolYear));
+  if ($delegatedMode) {
+    $finalmarksErrors[] = 'Delegierte dürfen keine Endnoten aus XSchool importieren.';
+  } else {
+    $action = (string)$_POST['finalmarks_action'];
+    $finalmarksFormSchoolYear = trim((string)($_POST['school_year'] ?? $finalmarksFormSchoolYear));
 
-  if ($classId <= 0) {
-    $finalmarksErrors[] = 'Bitte zuerst eine Klasse auswählen.';
-  } elseif ($action === 'preview') {
+    if ($classId <= 0) {
+      $finalmarksErrors[] = 'Bitte zuerst eine Klasse auswählen.';
+    } elseif ($action === 'preview') {
     $blocksJson = (string)($_POST['finalmarks_blocks'] ?? '');
     $blocks = $blocksJson !== '' ? json_decode($blocksJson, true) : [];
     if (!is_array($blocks) || !$blocks) {
@@ -835,6 +838,7 @@ if ($isTeacherRole && !$childMode && (string)($_SERVER['REQUEST_METHOD'] ?? '') 
         // Token invalidieren
       }
     }
+    }
   }
 }
 
@@ -904,7 +908,7 @@ render_teacher_header($pageTitle);
   </div>
 </div>
 
-<?php if ($isTeacherRole && !$childMode): ?>
+<?php if ($isTeacherRole && !$childMode && !$delegatedMode): ?>
   <div class="card">
     <h2 style="margin-top:0;">Endnoten aus XSchool für diese Klasse importieren</h2>
     <?php if ($classId <= 0): ?>


### PR DESCRIPTION
### Motivation
- Delegated users must not be able to import final marks from XSchool or see the import UI for classes they only have delegated access to.

### Description
- Add a server-side guard in `teacher/entry.php` to reject POSTs with `finalmarks_action` when `delegatedMode` is active and append an explanatory error message.
- Hide the XSchool import panel by only rendering it when the user is a teacher, not in child mode, and not in `delegatedMode`.
- All changes are contained in `teacher/entry.php` (conditional checks around import handling and UI rendering).

### Testing
- Launched a local PHP dev server and used Playwright to load `/teacher/entry.php?delegated=1`, and a screenshot was successfully captured showing the import UI is not visible for delegated mode.
- No unit tests were added or run for this change; the interactive smoke-check via Playwright succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ac3ba140c832ea1d402ad28c1557e)