### PR TITLE
Normalize group key when propagating English group titles

### DIFF
--- a/admin/template_fields.php
+++ b/admin/template_fields.php
@@ -1157,11 +1157,21 @@ function getGroupPath(f){
   return (g && String(g).trim()) ? String(g).trim() : '—';
 }
 
+function normalizeGroupKeyValue(value){
+  return String(value || '').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
 function getGroupKey(f){
   const path = getGroupPath(f);
   if (path === '—') return '—';
   const parts = parseGroupParts(path);
   return parts.group || '—';
+}
+
+function getGroupMatchKey(f){
+  const key = getGroupKey(f);
+  if (key === '—') return '—';
+  return normalizeGroupKeyValue(key);
 }
 
 function getSubgroupMatchKey(f){
@@ -1810,9 +1820,9 @@ function renderTable(){
       // Beim Verlassen einmalig auf die gesamte Gruppe übertragen (ohne Re-Render während der Eingabe)
       e.stopPropagation();
       const v = String(inpGE.value || '').trim();
-      const gCur = getGroupKey(fields[idx]);
+      const gCur = getGroupMatchKey(fields[idx]);
       for (let i=0; i<fields.length; i++){
-        if (getGroupKey(fields[i]) !== gCur) continue;
+        if (getGroupMatchKey(fields[i]) !== gCur) continue;
         fields[i].meta = fields[i].meta || {};
         if (v) fields[i].meta.group_title_en = v;
         else delete fields[i].meta.group_title_en;
@@ -2055,7 +2065,7 @@ function syncGroupTitleEnDom(groupKey, value){
     if (!fid) continue;
     const ff = fields.find(x => x.id === fid);
     if (!ff) continue;
-    if (getGroupKey(ff) !== groupKey) continue;
+    if (getGroupMatchKey(ff) !== groupKey) continue;
     if (el.value !== v) el.value = v;
   }
 }


### PR DESCRIPTION
### Motivation
- Propagation of the English group title sometimes failed because group matching used raw group names which may differ by case/whitespace.

### Description
- Introduced `normalizeGroupKeyValue` to normalize group keys (trim, collapse whitespace, lowercase).
- Added `getGroupMatchKey` which returns a normalized group key for reliable comparisons.
- Replaced raw `getGroupKey` comparisons with `getGroupMatchKey` when applying group-level `group_title_en` changes and when syncing the DOM to ensure consistent propagation across fields.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb98dcd48832ea7b97aae96c5d43d)