### PR TITLE
Support snippet category IDs and per-field snippet filtering

### DIFF
--- a/admin/template_fields.php
+++ b/admin/template_fields.php
@@ -2639,7 +2639,7 @@ function openSnippetCategoryModal(fieldId){
       cb.value = cat.id;
       cb.checked = selectedSet.has(cat.id);
       const txt = document.createElement('span');
-      txt.textContent = `${cat.label} (${cat.id})`;
+      txt.textContent = `${cat.label}`;
       row.append(cb, txt);
       snippetCategoryList.appendChild(row);
     });

--- a/admin/template_fields.php
+++ b/admin/template_fields.php
@@ -354,6 +354,24 @@ render_admin_header(t('admin.template_fields.title'));
 </form>
 </dialog>
 
+<!-- SNIPPET CATEGORY MODAL -->
+<dialog id="snippetCategoryModal">
+  <div class="dlg-head">
+    <h3 class="dlg-title">Textbaustein-Kategorien</h3>
+    <div class="muted2" id="snippetCategorySubtitle"></div>
+  </div>
+  <div class="dlg-body">
+    <div class="muted2" style="margin-bottom:8px;">Verfügbare Kategorien für dieses Multiline-Feld auswählen.</div>
+    <div id="snippetCategoryList" style="display:flex; flex-direction:column; gap:6px; max-height:48vh; overflow:auto;"></div>
+  </div>
+  <form method="dialog">
+    <div class="dlg-foot">
+      <button class="btn secondary" value="cancel" type="submit">Abbrechen</button>
+      <button class="btn primary" value="ok" type="submit">Übernehmen</button>
+    </div>
+  </form>
+</dialog>
+
 <!-- PDF REPLACE -->
 <div class="card panel">
   <div style="display:flex; gap:12px; align-items:flex-start; justify-content:space-between; flex-wrap:wrap;">
@@ -587,6 +605,7 @@ const csrf = "<?=h(csrf_token())?>";
 const templateId = <?= (int)$templateId ?>;
 
 const apiUrl = "<?=h(url('admin/ajax/template_fields_api.php'))?>";
+const textSnippetsApiUrl = "<?=h(url('admin/ajax/text_snippets_api.php'))?>";
 const optionListsApiUrl = "<?=h(url('admin/ajax/option_lists_api.php'))?>";
 const replacePdfUrl = "<?=h(url('admin/ajax/templates_replace_pdf.php'))?>";
 const importFieldsUrl = "<?=h(url('admin/ajax/import_fields.php'))?>";
@@ -741,10 +760,14 @@ const dateSubtitle = document.getElementById('dateSubtitle');
 const dateMode = document.getElementById('dateMode');
 const datePreset = document.getElementById('datePreset');
 const dateCustom = document.getElementById('dateCustom');
+const snippetCategoryModal = document.getElementById('snippetCategoryModal');
+const snippetCategorySubtitle = document.getElementById('snippetCategorySubtitle');
+const snippetCategoryList = document.getElementById('snippetCategoryList');
 
 let template = null;
 let fields = [];
 let optionTemplates = [];
+let snippetCategoriesCache = null;
 
 let filterText = '';
 let excludeText = '';
@@ -2088,6 +2111,15 @@ function renderTable(){
       wrap.appendChild(btn);
     }
 
+    if (f.type === 'multiline' || f.multiline) {
+      const btnSnipCats = document.createElement('button');
+      btnSnipCats.type = 'button';
+      btnSnipCats.className = 'btn secondary';
+      btnSnipCats.textContent = 'Textbaustein-Kategorien';
+      btnSnipCats.addEventListener('click', (e)=>{ e.stopPropagation(); openSnippetCategoryModal(f.id); });
+      wrap.appendChild(btnSnipCats);
+    }
+
     if (['radio','select','grade'].includes(f.type)) {
       const tplSel = document.createElement('select');
       tplSel.style.maxWidth = '320px';
@@ -2198,6 +2230,32 @@ async function apiPost(payload){
   const j = await resp.json().catch(()=>({}));
   if (!resp.ok || !j.ok) throw new Error(j.error || tAdmin('api_error'));
   return j;
+}
+
+async function textSnippetsPost(payload){
+  const resp = await fetch(textSnippetsApiUrl, {
+    method:'POST',
+    headers:{ 'Content-Type':'application/json', 'X-CSRF-Token': csrf },
+    body: JSON.stringify({ csrf_token: csrf, ...payload })
+  });
+  const j = await resp.json().catch(()=>({}));
+  if (!resp.ok || !j.ok) throw new Error(j.error || 'Textbaustein-API Fehler');
+  return j;
+}
+
+async function fetchSnippetCategories(){
+  if (Array.isArray(snippetCategoriesCache)) return snippetCategoriesCache;
+  const j = await textSnippetsPost({ action: 'list' });
+  const map = new Map();
+  (j.snippets || []).forEach(s => {
+    const id = String(s?.category_id || '').trim();
+    const label = String(s?.category || '').trim() || 'Allgemein';
+    if (!id || map.has(id)) return;
+    map.set(id, label);
+  });
+  snippetCategoriesCache = [...map.entries()].map(([id, label]) => ({ id, label }))
+    .sort((a,b) => String(a.label).localeCompare(String(b.label), 'de'));
+  return snippetCategoriesCache;
 }
 
 async function optionListsPost(payload){
@@ -2548,6 +2606,60 @@ dateModal.addEventListener('close', ()=>{
     fields[idx].meta.date_format_preset = datePreset.value || 'MM/DD/YYYY';
     delete fields[idx].meta.date_format_custom;
   }
+  markDirty(fieldId);
+  renderTable();
+  scanForSplitCandidate();
+});
+
+function openSnippetCategoryModal(fieldId){
+  modalFieldId = fieldId;
+  const idx = fields.findIndex(x=>x.id===fieldId);
+  if (idx < 0 || !snippetCategoryModal) return;
+  const f = fields[idx];
+  snippetCategorySubtitle.textContent = f.name || '';
+  snippetCategoryList.innerHTML = '<div class="muted2">Lade Kategorien …</div>';
+  const selected = Array.isArray(f?.meta?.snippet_category_ids)
+    ? f.meta.snippet_category_ids.map(x => String(x).trim()).filter(Boolean)
+    : [];
+  const selectedSet = new Set(selected);
+
+  fetchSnippetCategories().then((cats) => {
+    snippetCategoryList.innerHTML = '';
+    if (!cats.length) {
+      snippetCategoryList.innerHTML = '<div class="muted2">Keine Kategorien vorhanden.</div>';
+      return;
+    }
+    cats.forEach(cat => {
+      const row = document.createElement('label');
+      row.style.display = 'flex';
+      row.style.alignItems = 'center';
+      row.style.gap = '8px';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.value = cat.id;
+      cb.checked = selectedSet.has(cat.id);
+      const txt = document.createElement('span');
+      txt.textContent = `${cat.label} (${cat.id})`;
+      row.append(cb, txt);
+      snippetCategoryList.appendChild(row);
+    });
+  }).catch((e) => {
+    snippetCategoryList.innerHTML = `<div class="muted2">${escapeHtml(e?.message || String(e))}</div>`;
+  });
+  snippetCategoryModal.showModal();
+}
+
+snippetCategoryModal?.addEventListener('close', ()=>{
+  if (snippetCategoryModal.returnValue !== 'ok') { modalFieldId = null; return; }
+  const fieldId = modalFieldId;
+  modalFieldId = null;
+  const idx = fields.findIndex(x=>x.id===fieldId);
+  if (idx < 0) return;
+  const picked = Array.from(snippetCategoryList.querySelectorAll('input[type="checkbox"]:checked'))
+    .map(el => String(el.value || '').trim()).filter(Boolean);
+  fields[idx].meta = fields[idx].meta || {};
+  if (picked.length) fields[idx].meta.snippet_category_ids = picked;
+  else delete fields[idx].meta.snippet_category_ids;
   markDirty(fieldId);
   renderTable();
   scanForSplitCandidate();

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -131,11 +131,6 @@ render_admin_header(t('admin.text_snippets.title'));
     return cat && cat.trim() !== '' ? cat : tSnippets('no_category');
   }
 
-  function categoryIdLabel(categoryId){
-    const id = String(categoryId || '').trim();
-    return id !== '' ? id : 'allgemein';
-  }
-
   function createSnippetRow(snippet){
     const row = document.createElement('div');
     row.className = 'del-row';
@@ -249,7 +244,6 @@ render_admin_header(t('admin.text_snippets.title'));
         <div class="row" style="align-items:center; justify-content:space-between; gap:10px;">
           <div style="display:flex; gap:8px; align-items:center;">
             <div style="font-weight:800;">${categoryLabel(cat)}</div>
-            <div class="muted" style="font-size:12px;"><code>ID: ${categoryIdLabel((grouped.get(cat) || [])[0]?.category_id)}</code></div>
             <div class="pill-mini">${tfmtSnippets('pill_count', { count: String((grouped.get(cat) || []).length) })}</div>
           </div>
           <div class="muted" style="font-size:12px;">${tSnippets('drag_hint')}</div>

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -131,6 +131,11 @@ render_admin_header(t('admin.text_snippets.title'));
     return cat && cat.trim() !== '' ? cat : tSnippets('no_category');
   }
 
+  function categoryIdLabel(categoryId){
+    const id = String(categoryId || '').trim();
+    return id !== '' ? id : 'allgemein';
+  }
+
   function createSnippetRow(snippet){
     const row = document.createElement('div');
     row.className = 'del-row';
@@ -139,6 +144,7 @@ render_admin_header(t('admin.text_snippets.title'));
     row.innerHTML = `
       <div class="l">
         <div class="t">${snippet.title ? snippet.title : tSnippets('untitled')}</div>
+        <div class="s"><code>ID: ${categoryIdLabel(snippet.category_id)}</code></div>
         <div class="s">${snippet.created_by_name || tSnippets('created_by_fallback')}${snippet.is_generated ? ' · ' + tSnippets('generated_badge') : ''}</div>
         <div class="s" style="white-space:pre-wrap;">${snippet.content}</div>
       </div>
@@ -244,6 +250,7 @@ render_admin_header(t('admin.text_snippets.title'));
         <div class="row" style="align-items:center; justify-content:space-between; gap:10px;">
           <div style="display:flex; gap:8px; align-items:center;">
             <div style="font-weight:800;">${categoryLabel(cat)}</div>
+            <div class="muted" style="font-size:12px;"><code>ID: ${categoryIdLabel((grouped.get(cat) || [])[0]?.category_id)}</code></div>
             <div class="pill-mini">${tfmtSnippets('pill_count', { count: String((grouped.get(cat) || []).length) })}</div>
           </div>
           <div class="muted" style="font-size:12px;">${tSnippets('drag_hint')}</div>

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -144,7 +144,6 @@ render_admin_header(t('admin.text_snippets.title'));
     row.innerHTML = `
       <div class="l">
         <div class="t">${snippet.title ? snippet.title : tSnippets('untitled')}</div>
-        <div class="s"><code>ID: ${categoryIdLabel(snippet.category_id)}</code></div>
         <div class="s">${snippet.created_by_name || tSnippets('created_by_fallback')}${snippet.is_generated ? ' · ' + tSnippets('generated_badge') : ''}</div>
         <div class="s" style="white-space:pre-wrap;">${snippet.content}</div>
       </div>

--- a/shared/text_snippets.php
+++ b/shared/text_snippets.php
@@ -3,6 +3,18 @@
 // Utilities for managing reusable text snippets.
 declare(strict_types=1);
 
+function text_snippet_category_id(string $category): string {
+  $category = trim($category);
+  if ($category === '') return 'allgemein';
+
+  $ascii = @iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $category);
+  if ($ascii === false || $ascii === null) $ascii = $category;
+  $ascii = strtolower((string)$ascii);
+  $ascii = preg_replace('/[^a-z0-9]+/', '-', $ascii) ?? '';
+  $ascii = trim($ascii, '-');
+  return $ascii !== '' ? $ascii : 'allgemein';
+}
+
 function text_snippet_base_templates(): array {
   return [
     ['category' => 'Schülerziele', 'title' => 'Lesekompetenz stärken', 'content' => 'vertieft seine Lesefertigkeit durch regelmäßiges Vorlesen, Gesprächsrunden und gezielte Lesestrategien.'],
@@ -42,6 +54,7 @@ function text_snippets_list(PDO $pdo): array {
       'id' => (int)$r['id'],
       'title' => (string)($r['title'] ?? ''),
       'category' => (string)($r['category'] ?? ''),
+      'category_id' => text_snippet_category_id((string)($r['category'] ?? '')),
       'content' => (string)($r['content'] ?? ''),
       'created_by' => $r['created_by'] !== null ? (int)$r['created_by'] : null,
       'created_by_name' => (string)($r['display_name'] ?? ''),
@@ -67,6 +80,7 @@ function text_snippet_find(PDO $pdo, int $id): ?array {
     'id' => (int)$row['id'],
     'title' => (string)($row['title'] ?? ''),
     'category' => (string)($row['category'] ?? ''),
+    'category_id' => text_snippet_category_id((string)($row['category'] ?? '')),
     'content' => (string)($row['content'] ?? ''),
     'created_by' => $row['created_by'] !== null ? (int)$row['created_by'] : null,
     'created_by_name' => (string)($row['display_name'] ?? ''),
@@ -117,6 +131,7 @@ function text_snippet_save(PDO $pdo, int $userId, string $title, string $categor
     'id' => $id,
     'title' => $title,
     'category' => $category,
+    'category_id' => text_snippet_category_id($category),
     'content' => $content,
     'created_by' => $userId,
     'created_by_name' => '',
@@ -152,6 +167,7 @@ function text_snippet_update(PDO $pdo, int $id, int $userId, string $title, stri
     'id' => $id,
     'title' => $title,
     'category' => $category,
+    'category_id' => text_snippet_category_id($category),
     'content' => $content,
     'created_by' => $userId,
     'created_by_name' => '',
@@ -173,6 +189,7 @@ function text_snippet_move(PDO $pdo, int $id, string $category): array {
     'id' => $id,
     'title' => '',
     'category' => $category,
+    'category_id' => text_snippet_category_id($category),
     'content' => '',
     'created_by' => null,
     'created_by_name' => '',

--- a/shared/text_snippets.php
+++ b/shared/text_snippets.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 
 function text_snippet_category_id(string $category): string {
   $category = trim($category);
-  if ($category === '') return 'allgemein';
+  if ($category === '') return 'k-allgem';
 
-  $ascii = @iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $category);
-  if ($ascii === false || $ascii === null) $ascii = $category;
-  $ascii = strtolower((string)$ascii);
-  $ascii = preg_replace('/[^a-z0-9]+/', '-', $ascii) ?? '';
-  $ascii = trim($ascii, '-');
-  return $ascii !== '' ? $ascii : 'allgemein';
+  $norm = function_exists('mb_strtolower')
+    ? mb_strtolower($category, 'UTF-8')
+    : strtolower($category);
+  $crc = crc32($norm);
+  $hash = base_convert(sprintf('%u', $crc), 10, 36);
+  $hash = strtolower(str_pad($hash, 6, '0', STR_PAD_LEFT));
+  return 'k-' . substr($hash, 0, 6);
 }
 
 function text_snippet_base_templates(): array {

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -57,6 +57,51 @@ function option_list_id_from_meta(array $meta): int {
   return (int)$tid;
 }
 
+function snippet_categories_from_meta(array $meta): ?array {
+  $raw = $meta['snippet_categories'] ?? null;
+  if ($raw === null) return null;
+
+  $cats = [];
+  if (is_string($raw)) {
+    foreach (preg_split('/[,\n;]/', $raw) ?: [] as $part) {
+      $cat = trim((string)$part);
+      if ($cat !== '') $cats[] = $cat;
+    }
+  } elseif (is_array($raw)) {
+    foreach ($raw as $part) {
+      $cat = trim((string)$part);
+      if ($cat !== '') $cats[] = $cat;
+    }
+  } else {
+    return null;
+  }
+
+  $cats = array_values(array_unique($cats));
+  return $cats ?: [];
+}
+
+function snippet_category_ids_from_meta(array $meta): ?array {
+  $raw = $meta['snippet_category_ids'] ?? ($meta['snippet_categories_ids'] ?? null);
+  if ($raw === null) return null;
+
+  $ids = [];
+  if (is_string($raw)) {
+    foreach (preg_split('/[,\n;]/', $raw) ?: [] as $part) {
+      $id = trim((string)$part);
+      if ($id !== '') $ids[] = $id;
+    }
+  } elseif (is_array($raw)) {
+    foreach ($raw as $part) {
+      $id = trim((string)$part);
+      if ($id !== '') $ids[] = $id;
+    }
+  } else {
+    return null;
+  }
+  $ids = array_values(array_unique($ids));
+  return $ids ?: [];
+}
+
 function resolve_icon_urls(PDO $pdo, array $iconIds, array &$cache = []): array {
   $iconIds = array_values(array_unique(array_filter(array_map('intval', $iconIds), fn($x)=>$x>0)));
   $iconIds = array_values(array_filter($iconIds, fn($id) => !isset($cache[$id])));
@@ -2021,6 +2066,8 @@ try {
         'is_multiline' => (int)($f0['is_multiline'] ?? 0),
         'options' => $optsTeacher,
         'can_edit' => $canEditClassField ? 1 : 0,
+        'snippet_categories' => snippet_categories_from_meta($m0),
+        'snippet_category_ids' => snippet_category_ids_from_meta($m0),
       ];
     }
 
@@ -2100,6 +2147,8 @@ try {
         'subgroup' => $gParts['subgroup'],
         'subgroup_title_en' => (string)($meta['subgroup_title_en'] ?? ''),
         'can_edit' => $canEditField ? 1 : 0,
+        'snippet_categories' => snippet_categories_from_meta($meta),
+        'snippet_category_ids' => snippet_category_ids_from_meta($meta),
         'child' => $child ? [
           'id' => (int)$child['id'],
           'field_name' => (string)($child['field_name'] ?? ''),
@@ -2108,6 +2157,8 @@ try {
           'help_text' => (string)($child['help_text'] ?? ''),
           'is_multiline' => (int)($child['is_multiline'] ?? 0),
           'options' => $child['options'],
+          'snippet_categories' => snippet_categories_from_meta(meta_read($child['meta_json'] ?? null)),
+          'snippet_category_ids' => snippet_category_ids_from_meta(meta_read($child['meta_json'] ?? null)),
         ] : null,
       ];
     }

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -4561,7 +4561,22 @@ render_teacher_header($pageTitle);
 
   function openSnippetMenu(x, y, target){
     lastSnippetTarget = target || lastSnippetTarget;
-    const list = state.text_snippets || [];
+    const allSnippets = state.text_snippets || [];
+    const fieldId = Number(lastSnippetTarget?.getAttribute?.('data-field-id') || '0');
+    const fieldDef = fieldId > 0 ? state.fieldMap?.[String(fieldId)] : null;
+    const allowedCategoryIds = Array.isArray(fieldDef?.snippet_category_ids)
+      ? fieldDef.snippet_category_ids.map(c => String(c || '').trim()).filter(Boolean)
+      : null;
+    const allowedCategories = Array.isArray(fieldDef?.snippet_categories)
+      ? fieldDef.snippet_categories.map(c => String(c || '').trim()).filter(Boolean)
+      : null;
+    const list = allSnippets.filter(s => {
+      const cat = s?.category && String(s.category).trim() !== '' ? String(s.category).trim() : tEntry('snippet_default_category');
+      const catId = String(s?.category_id || '').trim();
+      if (allowedCategoryIds !== null) return catId !== '' && allowedCategoryIds.includes(catId);
+      if (allowedCategories !== null) return allowedCategories.includes(cat);
+      return true;
+    });
     snippetMenu.innerHTML = '';
 
     const trimmedSel = (lastSnippetSelection || '').trim();


### PR DESCRIPTION
### Motivation

- Introduce a stable machine-friendly category identifier for text snippets to enable reliable client-side filtering. 
- Allow fields to declare allowed snippet categories or category IDs in their metadata so the UI can limit snippet choices per field. 
- Filter the snippet menu on the frontend according to the field's allowed categories or category IDs to improve UX and reduce irrelevant suggestions.

### Description

- Add `text_snippet_category_id(string $category): string` and populate a `category_id` property in `text_snippets_list`, `text_snippet_find`, `text_snippet_save`, `text_snippet_update`, and `text_snippet_move` so snippets carry a normalized category identifier. 
- Add `snippet_categories_from_meta(array $meta): ?array` and `snippet_category_ids_from_meta(array $meta): ?array` helpers in `teacher/ajax/entry_api.php` to parse category lists from field metadata. 
- Include `snippet_categories` and `snippet_category_ids` in field definitions returned by the entry API for class-level fields, group fields and child fields so the client receives allowed categories per field. 
- Update frontend `openSnippetMenu` in `teacher/entry.php` to filter `state.text_snippets` using either `snippet_category_ids` or `snippet_categories` from the field definition and to fall back to the default snippet category name when needed.

### Testing

- Ran PHP syntax checks (`php -l`) on modified PHP files and they succeeded. 
- Ran JS linting (`eslint`) on modified frontend file and no lint errors were reported; no new unit tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d2fd9114832e87b9fd01e9787315)