### PR TITLE
Add snippet category selection for multiline fields and expose category IDs to APIs

### DIFF
--- a/admin/template_fields.php
+++ b/admin/template_fields.php
@@ -354,6 +354,24 @@ render_admin_header(t('admin.template_fields.title'));
 </form>
 </dialog>
 
+<!-- SNIPPET CATEGORY MODAL -->
+<dialog id="snippetCategoryModal">
+  <div class="dlg-head">
+    <h3 class="dlg-title">Textbaustein-Kategorien</h3>
+    <div class="muted2" id="snippetCategorySubtitle"></div>
+  </div>
+  <div class="dlg-body">
+    <div class="muted2" style="margin-bottom:8px;">Verfügbare Kategorien für dieses Multiline-Feld auswählen.</div>
+    <div id="snippetCategoryList" style="display:flex; flex-direction:column; gap:6px; max-height:48vh; overflow:auto;"></div>
+  </div>
+  <form method="dialog">
+    <div class="dlg-foot">
+      <button class="btn secondary" value="cancel" type="submit">Abbrechen</button>
+      <button class="btn primary" value="ok" type="submit">Übernehmen</button>
+    </div>
+  </form>
+</dialog>
+
 <!-- PDF REPLACE -->
 <div class="card panel">
   <div style="display:flex; gap:12px; align-items:flex-start; justify-content:space-between; flex-wrap:wrap;">
@@ -587,6 +605,7 @@ const csrf = "<?=h(csrf_token())?>";
 const templateId = <?= (int)$templateId ?>;
 
 const apiUrl = "<?=h(url('admin/ajax/template_fields_api.php'))?>";
+const textSnippetsApiUrl = "<?=h(url('admin/ajax/text_snippets_api.php'))?>";
 const optionListsApiUrl = "<?=h(url('admin/ajax/option_lists_api.php'))?>";
 const replacePdfUrl = "<?=h(url('admin/ajax/templates_replace_pdf.php'))?>";
 const importFieldsUrl = "<?=h(url('admin/ajax/import_fields.php'))?>";
@@ -741,10 +760,14 @@ const dateSubtitle = document.getElementById('dateSubtitle');
 const dateMode = document.getElementById('dateMode');
 const datePreset = document.getElementById('datePreset');
 const dateCustom = document.getElementById('dateCustom');
+const snippetCategoryModal = document.getElementById('snippetCategoryModal');
+const snippetCategorySubtitle = document.getElementById('snippetCategorySubtitle');
+const snippetCategoryList = document.getElementById('snippetCategoryList');
 
 let template = null;
 let fields = [];
 let optionTemplates = [];
+let snippetCategoriesCache = null;
 
 let filterText = '';
 let excludeText = '';
@@ -2088,6 +2111,15 @@ function renderTable(){
       wrap.appendChild(btn);
     }
 
+    if (f.type === 'multiline' || f.multiline) {
+      const btnSnipCats = document.createElement('button');
+      btnSnipCats.type = 'button';
+      btnSnipCats.className = 'btn secondary';
+      btnSnipCats.textContent = 'Textbaustein-Kategorien';
+      btnSnipCats.addEventListener('click', (e)=>{ e.stopPropagation(); openSnippetCategoryModal(f.id); });
+      wrap.appendChild(btnSnipCats);
+    }
+
     if (['radio','select','grade'].includes(f.type)) {
       const tplSel = document.createElement('select');
       tplSel.style.maxWidth = '320px';
@@ -2198,6 +2230,32 @@ async function apiPost(payload){
   const j = await resp.json().catch(()=>({}));
   if (!resp.ok || !j.ok) throw new Error(j.error || tAdmin('api_error'));
   return j;
+}
+
+async function textSnippetsPost(payload){
+  const resp = await fetch(textSnippetsApiUrl, {
+    method:'POST',
+    headers:{ 'Content-Type':'application/json', 'X-CSRF-Token': csrf },
+    body: JSON.stringify({ csrf_token: csrf, ...payload })
+  });
+  const j = await resp.json().catch(()=>({}));
+  if (!resp.ok || !j.ok) throw new Error(j.error || 'Textbaustein-API Fehler');
+  return j;
+}
+
+async function fetchSnippetCategories(){
+  if (Array.isArray(snippetCategoriesCache)) return snippetCategoriesCache;
+  const j = await textSnippetsPost({ action: 'list' });
+  const map = new Map();
+  (j.snippets || []).forEach(s => {
+    const id = String(s?.category_id || '').trim();
+    const label = String(s?.category || '').trim() || 'Allgemein';
+    if (!id || map.has(id)) return;
+    map.set(id, label);
+  });
+  snippetCategoriesCache = [...map.entries()].map(([id, label]) => ({ id, label }))
+    .sort((a,b) => String(a.label).localeCompare(String(b.label), 'de'));
+  return snippetCategoriesCache;
 }
 
 async function optionListsPost(payload){
@@ -2548,6 +2606,60 @@ dateModal.addEventListener('close', ()=>{
     fields[idx].meta.date_format_preset = datePreset.value || 'MM/DD/YYYY';
     delete fields[idx].meta.date_format_custom;
   }
+  markDirty(fieldId);
+  renderTable();
+  scanForSplitCandidate();
+});
+
+function openSnippetCategoryModal(fieldId){
+  modalFieldId = fieldId;
+  const idx = fields.findIndex(x=>x.id===fieldId);
+  if (idx < 0 || !snippetCategoryModal) return;
+  const f = fields[idx];
+  snippetCategorySubtitle.textContent = f.name || '';
+  snippetCategoryList.innerHTML = '<div class="muted2">Lade Kategorien …</div>';
+  const selected = Array.isArray(f?.meta?.snippet_category_ids)
+    ? f.meta.snippet_category_ids.map(x => String(x).trim()).filter(Boolean)
+    : [];
+  const selectedSet = new Set(selected);
+
+  fetchSnippetCategories().then((cats) => {
+    snippetCategoryList.innerHTML = '';
+    if (!cats.length) {
+      snippetCategoryList.innerHTML = '<div class="muted2">Keine Kategorien vorhanden.</div>';
+      return;
+    }
+    cats.forEach(cat => {
+      const row = document.createElement('label');
+      row.style.display = 'flex';
+      row.style.alignItems = 'center';
+      row.style.gap = '8px';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.value = cat.id;
+      cb.checked = selectedSet.has(cat.id);
+      const txt = document.createElement('span');
+      txt.textContent = `${cat.label}`;
+      row.append(cb, txt);
+      snippetCategoryList.appendChild(row);
+    });
+  }).catch((e) => {
+    snippetCategoryList.innerHTML = `<div class="muted2">${escapeHtml(e?.message || String(e))}</div>`;
+  });
+  snippetCategoryModal.showModal();
+}
+
+snippetCategoryModal?.addEventListener('close', ()=>{
+  if (snippetCategoryModal.returnValue !== 'ok') { modalFieldId = null; return; }
+  const fieldId = modalFieldId;
+  modalFieldId = null;
+  const idx = fields.findIndex(x=>x.id===fieldId);
+  if (idx < 0) return;
+  const picked = Array.from(snippetCategoryList.querySelectorAll('input[type="checkbox"]:checked'))
+    .map(el => String(el.value || '').trim()).filter(Boolean);
+  fields[idx].meta = fields[idx].meta || {};
+  if (picked.length) fields[idx].meta.snippet_category_ids = picked;
+  else delete fields[idx].meta.snippet_category_ids;
   markDirty(fieldId);
   renderTable();
   scanForSplitCandidate();

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -223,8 +223,8 @@ render_admin_header(t('admin.text_snippets.title'));
         <div class="s" style="white-space:pre-wrap; line-height:1.3; color:#334155;">${formatPipeItalic(snippet.content)}</div>
       </div>
       <div style="display:flex; gap:4px; align-items:center; flex-wrap:wrap; justify-content:flex-end;">
-        <button class="btn secondary" type="button">${tSnippets('edit_button')}</button>
-        <button class="btn danger" type="button">${tSnippets('delete_button')}</button>
+        <button class="btn secondary" type="button" style="padding:4px 8px;">${tSnippets('edit_button')}</button>
+        <button class="btn danger" type="button" style="padding:4px 8px;">${tSnippets('delete_button')}</button>
       </div>
     `;
 
@@ -260,13 +260,13 @@ render_admin_header(t('admin.text_snippets.title'));
             <label class="label">${tSnippets('edit_category_label')}</label>
             <div class="muted2 cat-preview" style="margin-top:4px;"></div>
           </div>
-          <div style="flex:1 1 100%; min-width:240px;">
+          <div style="flex:1 1 100%; min-width:240px; width:100%; max-width:100%;">
             <label class="label">${tSnippets('edit_content_label')}</label>
             <textarea class="input" rows="4">${snippet.content}</textarea>
           </div>
           <div style="display:flex; gap:4px; align-items:center; margin-left:auto;">
-            <button class="btn secondary" type="button" title="${tSnippets('edit_save_button')}" style="padding:4px 8px; font-size:12px;">💾</button>
-            <button class="btn secondary" type="button" title="${tSnippets('edit_cancel_button')}" style="padding:4px 8px; font-size:12px;">✕</button>
+            <button class="btn secondary" type="button" style="padding:4px 8px;">${tSnippets('edit_save_button')}</button>
+            <button class="btn danger" type="button" style="padding:4px 8px;">${tSnippets('edit_cancel_button')}</button>
           </div>
         </div>
       `;

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -17,6 +17,7 @@ render_admin_header(t('admin.text_snippets.title'));
 
 <div class="card">
     <h2><?=h(t('admin.text_snippets.new_heading'))?></h2>
+  <div class="muted" style="margin-bottom:8px;">Mehrere Bausteine auf einmal: pro Zeile <code>Titel;Text</code> (optional nur <code>Text</code>).</div>
   <div class="row" style="align-items:flex-end; gap:10px; flex-wrap:wrap;">
     <div style="flex:1; min-width:220px;">
       <label class="label"><?=h(t('admin.text_snippets.title_label'))?></label>
@@ -30,7 +31,7 @@ render_admin_header(t('admin.text_snippets.title'));
     </div>
     <div style="flex:2; min-width:260px;">
       <label class="label"><?=h(t('admin.text_snippets.content_label'))?></label>
-      <textarea class="input" id="tsContent" rows="3" placeholder="<?=h(t('admin.text_snippets.content_placeholder'))?>" style="width:100%;"></textarea>
+      <textarea class="input" id="tsContent" rows="5" placeholder="<?=h(t('admin.text_snippets.content_placeholder'))?>&#10;Beispiel Mehrfachanlage:&#10;Titel 1;Text 1&#10;Titel 2;Text 2" style="width:100%;"></textarea>
     </div>
     <div style="display:flex; gap:8px; align-items:center; margin-top: 10px;">
       <a class="btn" type="button" id="tsSave"><?=h(t('admin.text_snippets.save_button'))?></a>
@@ -170,9 +171,32 @@ render_admin_header(t('admin.text_snippets.title'));
     return `${left}<i>${right}</i>`;
   }
 
+  function createCategorySelect(current = ''){
+    const sel = document.createElement('select');
+    sel.className = 'input';
+    sel.style.width = '100%';
+    const none = document.createElement('option');
+    none.value = '';
+    none.textContent = tSnippets('category_placeholder') || 'optional';
+    sel.appendChild(none);
+    allCategories().forEach(cat => {
+      const opt = document.createElement('option');
+      opt.value = cat;
+      opt.textContent = cat;
+      sel.appendChild(opt);
+    });
+    sel.value = String(current || '');
+    if (sel.value !== String(current || '')) sel.value = '';
+    return sel;
+  }
+
   function createSnippetRow(snippet){
     const row = document.createElement('div');
     row.className = 'del-row';
+    row.style.border = '1px solid var(--border)';
+    row.style.borderRadius = '10px';
+    row.style.padding = '10px';
+    row.style.background = '#fff';
     row.style.cursor = 'grab';
     row.draggable = true;
     row.innerHTML = `
@@ -215,9 +239,8 @@ render_admin_header(t('admin.text_snippets.title'));
             <label class="label">${tSnippets('edit_title_label')}</label>
             <input class="input" type="text" value="${snippet.title.replace(/"/g, '&quot;')}">
           </div>
-          <div style="flex:1; min-width:180px;">
+          <div style="flex:1; min-width:180px;" class="edit-cat-slot">
             <label class="label">${tSnippets('edit_category_label')}</label>
-            <input class="input" type="text" value="${snippet.category ? snippet.category.replace(/"/g, '&quot;') : ''}">
           </div>
           <div style="flex:2; min-width:240px;">
             <label class="label">${tSnippets('edit_content_label')}</label>
@@ -229,7 +252,11 @@ render_admin_header(t('admin.text_snippets.title'));
           </div>
         </div>
       `;
-      const [titleInput, categoryInput, contentInput] = panel.querySelectorAll('input, textarea');
+      const titleInput = panel.querySelector('input');
+      const contentInput = panel.querySelector('textarea');
+      const catSlot = panel.querySelector('.edit-cat-slot');
+      const categoryInput = createCategorySelect(snippet.category || '');
+      catSlot.appendChild(categoryInput);
       const [saveEditBtn, cancelBtn] = panel.querySelectorAll('button');
 
       saveEditBtn.addEventListener('click', async () => {
@@ -278,7 +305,9 @@ render_admin_header(t('admin.text_snippets.title'));
       const box = document.createElement('div');
       box.className = 'card';
       box.dataset.category = cat;
-      box.style.border = '1px dashed var(--border)';
+      box.style.border = '1px solid var(--border)';
+      box.style.borderRadius = '12px';
+      box.style.background = '#f8fafc';
       box.innerHTML = `
         <div class="row" style="align-items:center; justify-content:space-between; gap:10px;">
           <div style="display:flex; gap:8px; align-items:center;">
@@ -357,12 +386,28 @@ render_admin_header(t('admin.text_snippets.title'));
     const title = document.getElementById('tsTitle').value.trim();
     const cat = document.getElementById('tsCategory').value.trim();
     const content = document.getElementById('tsContent').value.trim();
-    if (!title || !content) { alert(tSnippets('required_fields')); return; }
+    if (!content) { alert(tSnippets('required_fields')); return; }
     try {
-      await api('save', { title, category: cat, content });
+      const lines = content.split(/\r?\n/).map(x => x.trim()).filter(Boolean);
+      let created = 0;
+      if (lines.length > 1) {
+        for (const line of lines) {
+          const sep = line.indexOf(';');
+          const t = sep >= 0 ? line.slice(0, sep).trim() : '';
+          const c = sep >= 0 ? line.slice(sep + 1).trim() : line;
+          const finalTitle = t || title || (c.slice(0, 60) || tSnippets('untitled'));
+          if (!c) continue;
+          await api('save', { title: finalTitle, category: cat, content: c });
+          created++;
+        }
+      } else {
+        const finalTitle = title || (content.slice(0, 60) || tSnippets('untitled'));
+        await api('save', { title: finalTitle, category: cat, content });
+        created = 1;
+      }
       document.getElementById('tsTitle').value = '';
       document.getElementById('tsContent').value = '';
-      showStatus(tSnippets('status_saved'));
+      showStatus(`${tSnippets('status_saved')} (${created})`);
       load();
     } catch (e) {
       alert(e.message || tSnippets('save_failed'));

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -217,11 +217,10 @@ render_admin_header(t('admin.text_snippets.title'));
     row.style.cursor = 'grab';
     row.draggable = true;
     row.innerHTML = `
-      <div class="l">
+      <div class="l" style="position:relative; padding-right:130px;">
+        <div style="position:absolute; top:0; right:0; font-size:11px; font-weight:700; background:#eef2ff; color:#3730a3; border:1px solid #c7d2fe; border-radius:999px; padding:2px 8px; max-width:120px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">${snippet.created_by_name || tSnippets('created_by_fallback')}${snippet.is_generated ? ' · ' + tSnippets('generated_badge') : ''}</div>
         <div class="s" style="font-size:11px; letter-spacing:.02em; text-transform:uppercase; color:#64748b;">Überschrift</div>
         <div class="t" style="margin-bottom:4px; line-height:1.25;">${snippet.title ? formatPipeItalic(snippet.title) : escHtml(tSnippets('untitled'))}</div>
-        <div class="s" style="font-size:11px; letter-spacing:.02em; text-transform:uppercase; color:#64748b;">Autor</div>
-        <div class="s" style="margin-bottom:4px; font-weight:600; line-height:1.2;">${snippet.created_by_name || tSnippets('created_by_fallback')}${snippet.is_generated ? ' · ' + tSnippets('generated_badge') : ''}</div>
         <div class="s" style="font-size:11px; letter-spacing:.02em; text-transform:uppercase; color:#64748b;">Text</div>
         <div class="s" style="white-space:pre-wrap; line-height:1.3;">${formatPipeItalic(snippet.content)}</div>
       </div>

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -218,9 +218,12 @@ render_admin_header(t('admin.text_snippets.title'));
     row.draggable = true;
     row.innerHTML = `
       <div class="l">
-        <div class="t">${snippet.title ? formatPipeItalic(snippet.title) : escHtml(tSnippets('untitled'))}</div>
-        <div class="s">${snippet.created_by_name || tSnippets('created_by_fallback')}${snippet.is_generated ? ' · ' + tSnippets('generated_badge') : ''}</div>
-        <div class="s" style="white-space:pre-wrap;">${formatPipeItalic(snippet.content)}</div>
+        <div class="s" style="font-size:11px; letter-spacing:.02em; text-transform:uppercase; color:#64748b;">Überschrift</div>
+        <div class="t" style="margin-bottom:6px;">${snippet.title ? formatPipeItalic(snippet.title) : escHtml(tSnippets('untitled'))}</div>
+        <div class="s" style="font-size:11px; letter-spacing:.02em; text-transform:uppercase; color:#64748b;">Autor</div>
+        <div class="s" style="margin-bottom:6px; font-weight:600;">${snippet.created_by_name || tSnippets('created_by_fallback')}${snippet.is_generated ? ' · ' + tSnippets('generated_badge') : ''}</div>
+        <div class="s" style="font-size:11px; letter-spacing:.02em; text-transform:uppercase; color:#64748b;">Text</div>
+        <div class="s" style="white-space:pre-wrap; line-height:1.4;">${formatPipeItalic(snippet.content)}</div>
       </div>
       <div style="display:flex; gap:6px; align-items:center; flex-wrap:wrap; justify-content:flex-end;">
         <button class="btn secondary" type="button">${tSnippets('edit_button')}</button>

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -24,7 +24,9 @@ render_admin_header(t('admin.text_snippets.title'));
     </div>
     <div style="flex:1; min-width:200px;">
       <label class="label"><?=h(t('admin.text_snippets.category_label'))?></label>
-      <input class="input" id="tsCategory" type="text" placeholder="<?=h(t('admin.text_snippets.category_placeholder'))?>" style="width:100%;">
+      <select class="input" id="tsCategory" style="width:100%;">
+        <option value=""><?=h(t('admin.text_snippets.category_placeholder'))?></option>
+      </select>
     </div>
     <div style="flex:2; min-width:260px;">
       <label class="label"><?=h(t('admin.text_snippets.content_label'))?></label>
@@ -87,6 +89,7 @@ render_admin_header(t('admin.text_snippets.title'));
     'status_generated' => t('admin.text_snippets.status_generated'),
     'generate_failed' => t('admin.text_snippets.generate_failed'),
     'status_group_created' => t('admin.text_snippets.status_group_created')
+    ,'category_placeholder' => t('admin.text_snippets.category_placeholder')
   ], JSON_UNESCAPED_UNICODE) ?>;
   const tSnippets = (key) => I18N[key] ?? key;
   const tfmtSnippets = (key, vars = {}) => {
@@ -98,6 +101,7 @@ render_admin_header(t('admin.text_snippets.title'));
   };
   const tsList = document.getElementById('tsList');
   const tsStatus = document.getElementById('tsStatus');
+  const tsCategory = document.getElementById('tsCategory');
   const tsNewGroup = document.getElementById('tsNewGroup');
   const tsAddGroup = document.getElementById('tsAddGroup');
 
@@ -129,6 +133,28 @@ render_admin_header(t('admin.text_snippets.title'));
 
   function categoryLabel(cat){
     return cat && cat.trim() !== '' ? cat : tSnippets('no_category');
+  }
+  function allCategories(){
+    const cats = new Set();
+    (state.snippets || []).forEach(s => {
+      const c = String(s?.category || '').trim();
+      if (c !== '') cats.add(c);
+    });
+    state.customGroups.forEach(c => { if (String(c || '').trim() !== '') cats.add(String(c).trim()); });
+    return [...cats].sort((a,b) => a.localeCompare(b, 'de'));
+  }
+  function refreshCategorySelect(current = null){
+    if (!tsCategory) return;
+    const keep = current === null ? String(tsCategory.value || '') : String(current || '');
+    tsCategory.innerHTML = `<option value="">${escHtml(tSnippets('category_placeholder') || '') || 'optional'}</option>`;
+    allCategories().forEach(cat => {
+      const opt = document.createElement('option');
+      opt.value = cat;
+      opt.textContent = cat;
+      tsCategory.appendChild(opt);
+    });
+    tsCategory.value = keep;
+    if (tsCategory.value !== keep) tsCategory.value = '';
   }
 
   function escHtml(s){
@@ -258,6 +284,7 @@ render_admin_header(t('admin.text_snippets.title'));
           <div style="display:flex; gap:8px; align-items:center;">
             <div style="font-weight:800;">${formatPipeItalic(categoryLabel(cat))}</div>
             <div class="pill-mini">${tfmtSnippets('pill_count', { count: String((grouped.get(cat) || []).length) })}</div>
+            <button class="btn secondary js-rename-cat" type="button" data-cat="${escHtml(cat)}" style="padding:4px 8px;">Umbenennen</button>
           </div>
           <div class="muted" style="font-size:12px;">${tSnippets('drag_hint')}</div>
         </div>
@@ -265,6 +292,25 @@ render_admin_header(t('admin.text_snippets.title'));
       `;
 
       const zone = box.querySelector('.drop-zone');
+      const renameBtn = box.querySelector('.js-rename-cat');
+      renameBtn?.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const oldCat = String(cat || '');
+        const newCat = window.prompt('Neuer Kategoriename:', oldCat);
+        if (newCat === null) return;
+        const targetCat = String(newCat || '').trim();
+        if (targetCat === oldCat) return;
+        const rows = grouped.get(cat) || [];
+        try {
+          for (const s of rows) await api('move', { id: s.id, category: targetCat });
+          state.customGroups.delete(oldCat);
+          if (targetCat) state.customGroups.add(targetCat);
+          showStatus(tSnippets('status_group_changed'));
+          await load();
+        } catch (err) {
+          alert(err.message || tSnippets('group_change_failed'));
+        }
+      });
 
       box.addEventListener('dragover', (e) => {
         e.preventDefault();
@@ -299,6 +345,7 @@ render_admin_header(t('admin.text_snippets.title'));
 
       tsList.appendChild(box);
     });
+    refreshCategorySelect();
   }
 
   async function load(){

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -260,13 +260,13 @@ render_admin_header(t('admin.text_snippets.title'));
             <label class="label">${tSnippets('edit_category_label')}</label>
             <div class="muted2 cat-preview" style="margin-top:4px;"></div>
           </div>
-          <div style="flex:2; min-width:240px;">
+          <div style="flex:1 1 100%; min-width:240px;">
             <label class="label">${tSnippets('edit_content_label')}</label>
-            <textarea class="input" rows="3">${snippet.content}</textarea>
+            <textarea class="input" rows="4">${snippet.content}</textarea>
           </div>
-          <div style="display:flex; gap:6px; align-items:center;">
-            <button class="btn" type="button">${tSnippets('edit_save_button')}</button>
-            <button class="btn secondary" type="button">${tSnippets('edit_cancel_button')}</button>
+          <div style="display:flex; gap:4px; align-items:center; margin-left:auto;">
+            <button class="btn secondary" type="button" title="${tSnippets('edit_save_button')}" style="padding:4px 8px; font-size:12px;">💾</button>
+            <button class="btn secondary" type="button" title="${tSnippets('edit_cancel_button')}" style="padding:4px 8px; font-size:12px;">✕</button>
           </div>
         </div>
       `;

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -262,7 +262,7 @@ render_admin_header(t('admin.text_snippets.title'));
           </div>
           <div style="flex:1 1 100%; min-width:240px; width:100%; max-width:100%;">
             <label class="label">${tSnippets('edit_content_label')}</label>
-            <textarea class="input" rows="4">${snippet.content}</textarea>
+            <textarea class="input" rows="4" style="width:100%;">${snippet.content}</textarea>
           </div>
           <div style="display:flex; gap:4px; align-items:center; margin-left:auto;">
             <button class="btn secondary" type="button" style="padding:4px 8px;">${tSnippets('edit_save_button')}</button>

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -131,6 +131,19 @@ render_admin_header(t('admin.text_snippets.title'));
     return cat && cat.trim() !== '' ? cat : tSnippets('no_category');
   }
 
+  function escHtml(s){
+    return String(s ?? '').replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+  }
+
+  function formatPipeItalic(text){
+    const raw = String(text ?? '');
+    const idx = raw.indexOf('|');
+    if (idx < 0) return escHtml(raw);
+    const left = escHtml(raw.slice(0, idx + 1));
+    const right = escHtml(raw.slice(idx + 1));
+    return `${left}<i>${right}</i>`;
+  }
+
   function createSnippetRow(snippet){
     const row = document.createElement('div');
     row.className = 'del-row';
@@ -138,9 +151,9 @@ render_admin_header(t('admin.text_snippets.title'));
     row.draggable = true;
     row.innerHTML = `
       <div class="l">
-        <div class="t">${snippet.title ? snippet.title : tSnippets('untitled')}</div>
+        <div class="t">${snippet.title ? formatPipeItalic(snippet.title) : escHtml(tSnippets('untitled'))}</div>
         <div class="s">${snippet.created_by_name || tSnippets('created_by_fallback')}${snippet.is_generated ? ' · ' + tSnippets('generated_badge') : ''}</div>
-        <div class="s" style="white-space:pre-wrap;">${snippet.content}</div>
+        <div class="s" style="white-space:pre-wrap;">${formatPipeItalic(snippet.content)}</div>
       </div>
       <div style="display:flex; gap:6px; align-items:center; flex-wrap:wrap; justify-content:flex-end;">
         <button class="btn secondary" type="button">${tSnippets('edit_button')}</button>
@@ -243,7 +256,7 @@ render_admin_header(t('admin.text_snippets.title'));
       box.innerHTML = `
         <div class="row" style="align-items:center; justify-content:space-between; gap:10px;">
           <div style="display:flex; gap:8px; align-items:center;">
-            <div style="font-weight:800;">${categoryLabel(cat)}</div>
+            <div style="font-weight:800;">${formatPipeItalic(categoryLabel(cat))}</div>
             <div class="pill-mini">${tfmtSnippets('pill_count', { count: String((grouped.get(cat) || []).length) })}</div>
           </div>
           <div class="muted" style="font-size:12px;">${tSnippets('drag_hint')}</div>

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -26,8 +26,9 @@ render_admin_header(t('admin.text_snippets.title'));
     <div style="flex:1; min-width:200px;">
       <label class="label"><?=h(t('admin.text_snippets.category_label'))?></label>
       <select class="input" id="tsCategory" style="width:100%;">
-        <option value=""><?=h(t('admin.text_snippets.category_placeholder'))?></option>
+        <option value="">- ohne Kategorie -</option>
       </select>
+      <div class="muted2" id="tsCategoryPreview" style="margin-top:4px;"></div>
     </div>
     <div style="flex:2; min-width:260px;">
       <label class="label"><?=h(t('admin.text_snippets.content_label'))?></label>
@@ -103,6 +104,7 @@ render_admin_header(t('admin.text_snippets.title'));
   const tsList = document.getElementById('tsList');
   const tsStatus = document.getElementById('tsStatus');
   const tsCategory = document.getElementById('tsCategory');
+  const tsCategoryPreview = document.getElementById('tsCategoryPreview');
   const tsNewGroup = document.getElementById('tsNewGroup');
   const tsAddGroup = document.getElementById('tsAddGroup');
 
@@ -147,7 +149,7 @@ render_admin_header(t('admin.text_snippets.title'));
   function refreshCategorySelect(current = null){
     if (!tsCategory) return;
     const keep = current === null ? String(tsCategory.value || '') : String(current || '');
-    tsCategory.innerHTML = `<option value="">${escHtml(tSnippets('category_placeholder') || '') || 'optional'}</option>`;
+    tsCategory.innerHTML = `<option value="">- ohne Kategorie -</option>`;
     allCategories().forEach(cat => {
       const opt = document.createElement('option');
       opt.value = cat;
@@ -156,6 +158,13 @@ render_admin_header(t('admin.text_snippets.title'));
     });
     tsCategory.value = keep;
     if (tsCategory.value !== keep) tsCategory.value = '';
+    refreshCategoryPreview();
+  }
+
+  function refreshCategoryPreview(){
+    if (!tsCategoryPreview || !tsCategory) return;
+    const v = String(tsCategory.value || '').trim();
+    tsCategoryPreview.innerHTML = v ? `Vorschau: ${formatPipeItalic(v)}` : '<i>- ohne Kategorie -</i>';
   }
 
   function escHtml(s){
@@ -177,7 +186,7 @@ render_admin_header(t('admin.text_snippets.title'));
     sel.style.width = '100%';
     const none = document.createElement('option');
     none.value = '';
-    none.textContent = tSnippets('category_placeholder') || 'optional';
+    none.textContent = '- ohne Kategorie -';
     sel.appendChild(none);
     allCategories().forEach(cat => {
       const opt = document.createElement('option');
@@ -187,6 +196,14 @@ render_admin_header(t('admin.text_snippets.title'));
     });
     sel.value = String(current || '');
     if (sel.value !== String(current || '')) sel.value = '';
+    sel.addEventListener('change', () => {
+      const host = sel.closest('.edit-cat-slot');
+      const pv = host ? host.querySelector('.cat-preview') : null;
+      if (pv) {
+        const val = String(sel.value || '').trim();
+        pv.innerHTML = val ? formatPipeItalic(val) : '<i>- ohne Kategorie -</i>';
+      }
+    });
     return sel;
   }
 
@@ -241,6 +258,7 @@ render_admin_header(t('admin.text_snippets.title'));
           </div>
           <div style="flex:1; min-width:180px;" class="edit-cat-slot">
             <label class="label">${tSnippets('edit_category_label')}</label>
+            <div class="muted2 cat-preview" style="margin-top:4px;"></div>
           </div>
           <div style="flex:2; min-width:240px;">
             <label class="label">${tSnippets('edit_content_label')}</label>
@@ -257,6 +275,11 @@ render_admin_header(t('admin.text_snippets.title'));
       const catSlot = panel.querySelector('.edit-cat-slot');
       const categoryInput = createCategorySelect(snippet.category || '');
       catSlot.appendChild(categoryInput);
+      const catPreview = catSlot.querySelector('.cat-preview');
+      if (catPreview) {
+        const val = String(categoryInput.value || '').trim();
+        catPreview.innerHTML = val ? formatPipeItalic(val) : '<i>- ohne Kategorie -</i>';
+      }
       const [saveEditBtn, cancelBtn] = panel.querySelectorAll('button');
 
       saveEditBtn.addEventListener('click', async () => {
@@ -432,6 +455,8 @@ render_admin_header(t('admin.text_snippets.title'));
     render(state.snippets);
     showStatus(tSnippets('status_group_created'));
   });
+
+  tsCategory?.addEventListener('change', refreshCategoryPreview);
 
   load();
 })();

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -219,10 +219,8 @@ render_admin_header(t('admin.text_snippets.title'));
     row.innerHTML = `
       <div class="l" style="position:relative; padding-right:130px;">
         <div style="position:absolute; top:0; right:0; font-size:11px; font-weight:700; background:#eef2ff; color:#3730a3; border:1px solid #c7d2fe; border-radius:999px; padding:2px 8px; max-width:120px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">${snippet.created_by_name || tSnippets('created_by_fallback')}${snippet.is_generated ? ' · ' + tSnippets('generated_badge') : ''}</div>
-        <div class="s" style="font-size:11px; letter-spacing:.02em; text-transform:uppercase; color:#64748b;">Überschrift</div>
-        <div class="t" style="margin-bottom:4px; line-height:1.25;">${snippet.title ? formatPipeItalic(snippet.title) : escHtml(tSnippets('untitled'))}</div>
-        <div class="s" style="font-size:11px; letter-spacing:.02em; text-transform:uppercase; color:#64748b;">Text</div>
-        <div class="s" style="white-space:pre-wrap; line-height:1.3;">${formatPipeItalic(snippet.content)}</div>
+        <div class="t" style="margin-bottom:3px; line-height:1.2; font-size:14px; font-weight:800; color:#0f172a;">${snippet.title ? formatPipeItalic(snippet.title) : escHtml(tSnippets('untitled'))}</div>
+        <div class="s" style="white-space:pre-wrap; line-height:1.3; color:#334155;">${formatPipeItalic(snippet.content)}</div>
       </div>
       <div style="display:flex; gap:4px; align-items:center; flex-wrap:wrap; justify-content:flex-end;">
         <button class="btn secondary" type="button">${tSnippets('edit_button')}</button>

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -339,6 +339,7 @@ render_admin_header(t('admin.text_snippets.title'));
             <div style="font-weight:800;">${formatPipeItalic(categoryLabel(cat))}</div>
             <div class="pill-mini">${tfmtSnippets('pill_count', { count: String((grouped.get(cat) || []).length) })}</div>
             <button class="btn secondary js-rename-cat" type="button" data-cat="${escHtml(cat)}" style="padding:4px 8px;">Umbenennen</button>
+            <button class="btn danger js-delete-cat" type="button" data-cat="${escHtml(cat)}" style="padding:4px 8px;">Kategorie löschen</button>
           </div>
           <div class="muted" style="font-size:12px;">${tSnippets('drag_hint')}</div>
         </div>
@@ -347,6 +348,7 @@ render_admin_header(t('admin.text_snippets.title'));
 
       const zone = box.querySelector('.drop-zone');
       const renameBtn = box.querySelector('.js-rename-cat');
+      const deleteBtn = box.querySelector('.js-delete-cat');
       renameBtn?.addEventListener('click', async (e) => {
         e.stopPropagation();
         const oldCat = String(cat || '');
@@ -359,6 +361,26 @@ render_admin_header(t('admin.text_snippets.title'));
           for (const s of rows) await api('move', { id: s.id, category: targetCat });
           state.customGroups.delete(oldCat);
           if (targetCat) state.customGroups.add(targetCat);
+          showStatus(tSnippets('status_group_changed'));
+          await load();
+        } catch (err) {
+          alert(err.message || tSnippets('group_change_failed'));
+        }
+      });
+      deleteBtn?.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const oldCat = String(cat || '');
+        const rows = grouped.get(cat) || [];
+        if (!rows.length) {
+          state.customGroups.delete(oldCat);
+          render(state.snippets);
+          return;
+        }
+        const ok = window.confirm(`Kategorie "${oldCat || tSnippets('no_category')}" wirklich löschen? Alle enthaltenen Bausteine werden auf "- ohne Kategorie -" gesetzt.`);
+        if (!ok) return;
+        try {
+          for (const s of rows) await api('move', { id: s.id, category: '' });
+          state.customGroups.delete(oldCat);
           showStatus(tSnippets('status_group_changed'));
           await load();
         } catch (err) {

--- a/admin/text_snippets.php
+++ b/admin/text_snippets.php
@@ -212,20 +212,20 @@ render_admin_header(t('admin.text_snippets.title'));
     row.className = 'del-row';
     row.style.border = '1px solid var(--border)';
     row.style.borderRadius = '10px';
-    row.style.padding = '10px';
+    row.style.padding = '8px';
     row.style.background = '#fff';
     row.style.cursor = 'grab';
     row.draggable = true;
     row.innerHTML = `
       <div class="l">
         <div class="s" style="font-size:11px; letter-spacing:.02em; text-transform:uppercase; color:#64748b;">Überschrift</div>
-        <div class="t" style="margin-bottom:6px;">${snippet.title ? formatPipeItalic(snippet.title) : escHtml(tSnippets('untitled'))}</div>
+        <div class="t" style="margin-bottom:4px; line-height:1.25;">${snippet.title ? formatPipeItalic(snippet.title) : escHtml(tSnippets('untitled'))}</div>
         <div class="s" style="font-size:11px; letter-spacing:.02em; text-transform:uppercase; color:#64748b;">Autor</div>
-        <div class="s" style="margin-bottom:6px; font-weight:600;">${snippet.created_by_name || tSnippets('created_by_fallback')}${snippet.is_generated ? ' · ' + tSnippets('generated_badge') : ''}</div>
+        <div class="s" style="margin-bottom:4px; font-weight:600; line-height:1.2;">${snippet.created_by_name || tSnippets('created_by_fallback')}${snippet.is_generated ? ' · ' + tSnippets('generated_badge') : ''}</div>
         <div class="s" style="font-size:11px; letter-spacing:.02em; text-transform:uppercase; color:#64748b;">Text</div>
-        <div class="s" style="white-space:pre-wrap; line-height:1.4;">${formatPipeItalic(snippet.content)}</div>
+        <div class="s" style="white-space:pre-wrap; line-height:1.3;">${formatPipeItalic(snippet.content)}</div>
       </div>
-      <div style="display:flex; gap:6px; align-items:center; flex-wrap:wrap; justify-content:flex-end;">
+      <div style="display:flex; gap:4px; align-items:center; flex-wrap:wrap; justify-content:flex-end;">
         <button class="btn secondary" type="button">${tSnippets('edit_button')}</button>
         <button class="btn danger" type="button">${tSnippets('delete_button')}</button>
       </div>
@@ -252,7 +252,7 @@ render_admin_header(t('admin.text_snippets.title'));
       const panel = document.createElement('div');
       panel.className = 'card';
       panel.classList.add('edit-panel');
-      panel.style.marginTop = '8px';
+      panel.style.marginTop = '6px';
       panel.innerHTML = `
         <div class="row" style="gap:8px; align-items:flex-end; flex-wrap:wrap;">
           <div style="flex:1; min-width:180px;">
@@ -332,7 +332,7 @@ render_admin_header(t('admin.text_snippets.title'));
       box.className = 'card';
       box.dataset.category = cat;
       box.style.border = '1px solid var(--border)';
-      box.style.borderRadius = '12px';
+      box.style.borderRadius = '10px';
       box.style.background = '#f8fafc';
       box.innerHTML = `
         <div class="row" style="align-items:center; justify-content:space-between; gap:10px;">
@@ -343,7 +343,7 @@ render_admin_header(t('admin.text_snippets.title'));
           </div>
           <div class="muted" style="font-size:12px;">${tSnippets('drag_hint')}</div>
         </div>
-        <div class="drop-zone" style="margin-top:10px; display:flex; flex-direction:column; gap:8px;"></div>
+        <div class="drop-zone" style="margin-top:8px; display:flex; flex-direction:column; gap:6px;"></div>
       `;
 
       const zone = box.querySelector('.drop-zone');

--- a/shared/text_snippets.php
+++ b/shared/text_snippets.php
@@ -12,8 +12,8 @@ function text_snippet_category_id(string $category): string {
     : strtolower($category);
   $crc = crc32($norm);
   $hash = base_convert(sprintf('%u', $crc), 10, 36);
-  $hash = strtolower(str_pad($hash, 6, '0', STR_PAD_LEFT));
-  return 'k-' . substr($hash, 0, 6);
+  $hash = strtolower(str_pad($hash, 7, '0', STR_PAD_LEFT));
+  return 'k-' . $hash;
 }
 
 function text_snippet_base_templates(): array {

--- a/shared/text_snippets.php
+++ b/shared/text_snippets.php
@@ -3,6 +3,19 @@
 // Utilities for managing reusable text snippets.
 declare(strict_types=1);
 
+function text_snippet_category_id(string $category): string {
+  $category = trim($category);
+  if ($category === '') return 'k-allgem';
+
+  $norm = function_exists('mb_strtolower')
+    ? mb_strtolower($category, 'UTF-8')
+    : strtolower($category);
+  $crc = crc32($norm);
+  $hash = base_convert(sprintf('%u', $crc), 10, 36);
+  $hash = strtolower(str_pad($hash, 6, '0', STR_PAD_LEFT));
+  return 'k-' . substr($hash, 0, 6);
+}
+
 function text_snippet_base_templates(): array {
   return [
     ['category' => 'Schülerziele', 'title' => 'Lesekompetenz stärken', 'content' => 'vertieft seine Lesefertigkeit durch regelmäßiges Vorlesen, Gesprächsrunden und gezielte Lesestrategien.'],
@@ -42,6 +55,7 @@ function text_snippets_list(PDO $pdo): array {
       'id' => (int)$r['id'],
       'title' => (string)($r['title'] ?? ''),
       'category' => (string)($r['category'] ?? ''),
+      'category_id' => text_snippet_category_id((string)($r['category'] ?? '')),
       'content' => (string)($r['content'] ?? ''),
       'created_by' => $r['created_by'] !== null ? (int)$r['created_by'] : null,
       'created_by_name' => (string)($r['display_name'] ?? ''),
@@ -67,6 +81,7 @@ function text_snippet_find(PDO $pdo, int $id): ?array {
     'id' => (int)$row['id'],
     'title' => (string)($row['title'] ?? ''),
     'category' => (string)($row['category'] ?? ''),
+    'category_id' => text_snippet_category_id((string)($row['category'] ?? '')),
     'content' => (string)($row['content'] ?? ''),
     'created_by' => $row['created_by'] !== null ? (int)$row['created_by'] : null,
     'created_by_name' => (string)($row['display_name'] ?? ''),
@@ -117,6 +132,7 @@ function text_snippet_save(PDO $pdo, int $userId, string $title, string $categor
     'id' => $id,
     'title' => $title,
     'category' => $category,
+    'category_id' => text_snippet_category_id($category),
     'content' => $content,
     'created_by' => $userId,
     'created_by_name' => '',
@@ -152,6 +168,7 @@ function text_snippet_update(PDO $pdo, int $id, int $userId, string $title, stri
     'id' => $id,
     'title' => $title,
     'category' => $category,
+    'category_id' => text_snippet_category_id($category),
     'content' => $content,
     'created_by' => $userId,
     'created_by_name' => '',
@@ -173,6 +190,7 @@ function text_snippet_move(PDO $pdo, int $id, string $category): array {
     'id' => $id,
     'title' => '',
     'category' => $category,
+    'category_id' => text_snippet_category_id($category),
     'content' => '',
     'created_by' => null,
     'created_by_name' => '',

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -2628,6 +2628,8 @@ try {
         'child_only' => $forceChildOnly ? 1 : 0,
         'system_bound' => $isSystemBound ? 1 : 0,
         'child_field_id' => $childFieldId,
+        'snippet_categories' => snippet_categories_from_meta($meta),
+        'snippet_category_ids' => snippet_category_ids_from_meta($meta),
       ];
       $fieldsById[$fid] = true;
     };

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -1804,15 +1804,19 @@ function load_teacher_values_for_user(
       if ($free['has_free_text']) {
         $classText = (string)$free['class_text'];
         $delegateText = (string)$free['delegate_text'];
+        $delegateTexts = is_array($free['delegate_texts'] ?? null) ? $free['delegate_texts'] : [];
         $textCombined = combine_free_text($classText, $delegateText);
         $isDelegate = in_array($uid, $assignedUsers, true);
-        $textOwn = ($isDelegate && !$isClassTeacher) ? $delegateText : $classText;
+        $textOwn = ($isDelegate && !$isClassTeacher)
+          ? (string)($delegateTexts[(string)$uid] ?? '')
+          : $classText;
         $combined[$rid][(string)$fid] = $textCombined;
         $own[$rid][(string)$fid] = $textOwn;
         if (!isset($parts[$rid])) $parts[$rid] = [];
         $parts[$rid][(string)$fid] = [
           'class_text' => $classText,
           'delegate_text' => $delegateText,
+          'delegate_texts' => $delegateTexts,
           'delegate_user_id' => count($assignedUsers) === 1 ? (int)$assignedUsers[0] : 0,
           'delegate_user_ids' => $assignedUsers,
         ];

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -1075,27 +1075,46 @@ function is_free_text_field(string $fieldType, int $isMultiline): bool {
 
 function free_text_parts_from_json(?string $valueJsonRaw): array {
   if (!$valueJsonRaw) {
-    return ['has_free_text' => false, 'class_text' => '', 'delegate_text' => '', 'delegate_user_id' => 0];
+    return ['has_free_text' => false, 'class_text' => '', 'delegate_text' => '', 'delegate_user_id' => 0, 'delegate_texts' => []];
   }
   $j = json_decode($valueJsonRaw, true);
   if (!is_array($j) || !isset($j['free_text']) || !is_array($j['free_text'])) {
-    return ['has_free_text' => false, 'class_text' => '', 'delegate_text' => '', 'delegate_user_id' => 0];
+    return ['has_free_text' => false, 'class_text' => '', 'delegate_text' => '', 'delegate_user_id' => 0, 'delegate_texts' => []];
   }
   $ft = $j['free_text'];
+  $delegateTexts = [];
+  if (isset($ft['delegate_texts']) && is_array($ft['delegate_texts'])) {
+    foreach ($ft['delegate_texts'] as $uid => $txt) {
+      $id = (int)$uid;
+      if ($id <= 0) continue;
+      $delegateTexts[(string)$id] = (string)$txt;
+    }
+  }
+  $delegateText = (string)($ft['delegate_text'] ?? '');
+  if ($delegateText === '' && $delegateTexts) {
+    $parts = [];
+    foreach ($delegateTexts as $txt) {
+      $t = trim((string)$txt);
+      if ($t !== '') $parts[] = $t;
+    }
+    $delegateText = implode("\n\n", $parts);
+  }
   return [
     'has_free_text' => true,
     'class_text' => (string)($ft['class_text'] ?? ''),
-    'delegate_text' => (string)($ft['delegate_text'] ?? ''),
+    'delegate_text' => $delegateText,
     'delegate_user_id' => (int)($ft['delegate_user_id'] ?? 0),
+    'delegate_texts' => $delegateTexts,
   ];
 }
 
-function build_free_text_json(string $classText, string $delegateText, int $delegateUserId): string {
+function build_free_text_json(string $classText, string $delegateText, int $delegateUserId, array $delegateTexts = []): string {
   return json_encode([
     'free_text' => [
       'class_text' => $classText,
       'delegate_text' => $delegateText,
       'delegate_user_id' => $delegateUserId,
+      'delegate_texts' => $delegateTexts,
     ],
   ], JSON_UNESCAPED_UNICODE);
 }
@@ -1149,20 +1168,31 @@ function save_free_text_value(
 
     $existingClass = '';
     $existingDelegate = '';
+    $existingDelegateTexts = [];
     if ($row) {
       $free = free_text_parts_from_json($row['value_json'] !== null ? (string)$row['value_json'] : null);
       if ($free['has_free_text']) {
         $existingClass = (string)($free['class_text'] ?? '');
         $existingDelegate = (string)($free['delegate_text'] ?? '');
+        $existingDelegateTexts = is_array($free['delegate_texts'] ?? null) ? $free['delegate_texts'] : [];
       } else {
         $existingClass = (string)($row['value_text'] ?? '');
       }
     }
 
-    if ($isDelegate) $existingDelegate = $delegateText;
-    else $existingClass = $classText;
+    if ($isDelegate) {
+      $existingDelegateTexts[(string)$userId] = $delegateText;
+    } else {
+      $existingClass = $classText;
+    }
+    $delegateParts = [];
+    foreach ($existingDelegateTexts as $txt) {
+      $t = trim((string)$txt);
+      if ($t !== '') $delegateParts[] = $t;
+    }
+    $existingDelegate = implode("\n\n", $delegateParts);
 
-    $valueJson = build_free_text_json($existingClass, $existingDelegate, $delegateUserId);
+    $valueJson = build_free_text_json($existingClass, $existingDelegate, $delegateUserId, $existingDelegateTexts);
     $valueText = combine_free_text($existingClass, $existingDelegate);
     if (trim($valueText) === '') $valueText = null;
 

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -57,6 +57,51 @@ function option_list_id_from_meta(array $meta): int {
   return (int)$tid;
 }
 
+function snippet_categories_from_meta(array $meta): ?array {
+  $raw = $meta['snippet_categories'] ?? null;
+  if ($raw === null) return null;
+
+  $cats = [];
+  if (is_string($raw)) {
+    foreach (preg_split('/[,\n;]/', $raw) ?: [] as $part) {
+      $cat = trim((string)$part);
+      if ($cat !== '') $cats[] = $cat;
+    }
+  } elseif (is_array($raw)) {
+    foreach ($raw as $part) {
+      $cat = trim((string)$part);
+      if ($cat !== '') $cats[] = $cat;
+    }
+  } else {
+    return null;
+  }
+
+  $cats = array_values(array_unique($cats));
+  return $cats ?: [];
+}
+
+function snippet_category_ids_from_meta(array $meta): ?array {
+  $raw = $meta['snippet_category_ids'] ?? ($meta['snippet_categories_ids'] ?? null);
+  if ($raw === null) return null;
+
+  $ids = [];
+  if (is_string($raw)) {
+    foreach (preg_split('/[,\n;]/', $raw) ?: [] as $part) {
+      $id = trim((string)$part);
+      if ($id !== '') $ids[] = $id;
+    }
+  } elseif (is_array($raw)) {
+    foreach ($raw as $part) {
+      $id = trim((string)$part);
+      if ($id !== '') $ids[] = $id;
+    }
+  } else {
+    return null;
+  }
+  $ids = array_values(array_unique($ids));
+  return $ids ?: [];
+}
+
 function resolve_icon_urls(PDO $pdo, array $iconIds, array &$cache = []): array {
   $iconIds = array_values(array_unique(array_filter(array_map('intval', $iconIds), fn($x)=>$x>0)));
   $iconIds = array_values(array_filter($iconIds, fn($id) => !isset($cache[$id])));
@@ -2021,6 +2066,8 @@ try {
         'is_multiline' => (int)($f0['is_multiline'] ?? 0),
         'options' => $optsTeacher,
         'can_edit' => $canEditClassField ? 1 : 0,
+        'snippet_categories' => snippet_categories_from_meta($m0),
+        'snippet_category_ids' => snippet_category_ids_from_meta($m0),
       ];
     }
 
@@ -2100,6 +2147,8 @@ try {
         'subgroup' => $gParts['subgroup'],
         'subgroup_title_en' => (string)($meta['subgroup_title_en'] ?? ''),
         'can_edit' => $canEditField ? 1 : 0,
+        'snippet_categories' => snippet_categories_from_meta($meta),
+        'snippet_category_ids' => snippet_category_ids_from_meta($meta),
         'child' => $child ? [
           'id' => (int)$child['id'],
           'field_name' => (string)($child['field_name'] ?? ''),
@@ -2108,6 +2157,8 @@ try {
           'help_text' => (string)($child['help_text'] ?? ''),
           'is_multiline' => (int)($child['is_multiline'] ?? 0),
           'options' => $child['options'],
+          'snippet_categories' => snippet_categories_from_meta(meta_read($child['meta_json'] ?? null)),
+          'snippet_category_ids' => snippet_category_ids_from_meta(meta_read($child['meta_json'] ?? null)),
         ] : null,
       ];
     }

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -2695,8 +2695,18 @@ try {
     }
     if ($classReportInstanceId > 0 && $classFieldIds) {
       $classFieldMap = array_intersect_key($fieldMapInput, array_flip($classFieldIds));
-      $vals = load_input_values($pdo, [$classReportInstanceId], $classFieldMap, 'teacher');
-      $classVals = $vals[(string)$classReportInstanceId] ?? [];
+      $classTeacherValues = load_teacher_values_for_user(
+        $pdo,
+        [$classReportInstanceId],
+        $classFieldMap,
+        $delegations,
+        $u,
+        $classId,
+        $schoolYear,
+        $periodLabel,
+        $lang
+      );
+      $classVals = $classTeacherValues['own'][(string)$classReportInstanceId] ?? [];
       $systemVals = load_input_values($pdo, [$classReportInstanceId], $classFieldMap, 'system');
       $classSystemVals = $systemVals[(string)$classReportInstanceId] ?? [];
       if ($classSystemVals) {

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -4561,7 +4561,22 @@ render_teacher_header($pageTitle);
 
   function openSnippetMenu(x, y, target){
     lastSnippetTarget = target || lastSnippetTarget;
-    const list = state.text_snippets || [];
+    const allSnippets = state.text_snippets || [];
+    const fieldId = Number(lastSnippetTarget?.getAttribute?.('data-field-id') || '0');
+    const fieldDef = fieldId > 0 ? state.fieldMap?.[String(fieldId)] : null;
+    const allowedCategoryIds = Array.isArray(fieldDef?.snippet_category_ids)
+      ? fieldDef.snippet_category_ids.map(c => String(c || '').trim()).filter(Boolean)
+      : null;
+    const allowedCategories = Array.isArray(fieldDef?.snippet_categories)
+      ? fieldDef.snippet_categories.map(c => String(c || '').trim()).filter(Boolean)
+      : null;
+    const list = allSnippets.filter(s => {
+      const cat = s?.category && String(s.category).trim() !== '' ? String(s.category).trim() : tEntry('snippet_default_category');
+      const catId = String(s?.category_id || '').trim();
+      if (allowedCategoryIds !== null) return catId !== '' && allowedCategoryIds.includes(catId);
+      if (allowedCategories !== null) return allowedCategories.includes(cat);
+      return true;
+    });
     snippetMenu.innerHTML = '';
 
     const trimmedSel = (lastSnippetSelection || '').trim();

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -4679,7 +4679,7 @@ render_teacher_header($pageTitle);
         grouped[cat].push(s);
       });
       const html = Object.entries(grouped).map(([cat, items]) => {
-        const rows = items.map(s => `<li><strong>${fmtPipeItalic(s.title || tEntry('snippet_untitled'))}</strong><br>${fmtPipeItalic(String(s.content || ''))}</li>`).join('');
+        const rows = items.map(s => `<li><strong>${fmtPipeItalic(s.title || tEntry('snippet_untitled'))}</strong>${fmtPipeItalic(String(s.content || ''))}</li>`).join('');
         return `<h3>${fmtPipeItalic(cat)}</h3><ul>${rows}</ul>`;
       }).join('');
       const w = window.open('', '_blank', 'width=900,height=700');

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -3126,6 +3126,17 @@ render_teacher_header($pageTitle);
   }
 
   function teacherEditVal(reportId, fieldId){
+    const part = delegatedEditPart(fieldId);
+    if (part) {
+      const rid = isClassFieldId(fieldId) ? classReportId() : Number(reportId || 0);
+      const parts = state.values_teacher_parts[String(rid)]?.[String(fieldId)];
+      if (parts && typeof parts === 'object') {
+        return part === 'delegate'
+          ? String(parts.delegate_text ?? '')
+          : String(parts.class_text ?? '');
+      }
+      return '';
+    }
     if (isClassFieldId(fieldId)) {
       const rid = classReportId();
       const r = state.values_teacher_own[String(rid)] || {};

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -4679,7 +4679,17 @@ render_teacher_header($pageTitle);
       const w = window.open('', '_blank', 'width=900,height=700');
       if (!w) return;
       w.document.open();
-      w.document.write(`<!doctype html><html><head><meta charset="utf-8"><title>Textbaustein-Übersicht</title><style>body{font-family:Arial,sans-serif;padding:20px;}h3{margin:14px 0 6px;}ul{margin:0 0 14px 20px;}li{margin:0 0 10px;white-space:pre-wrap;}</style></head><body><h1>Textbaustein-Übersicht</h1>${html || '<p>Keine Bausteine vorhanden.</p>'}</body></html>`);
+      w.document.write(`<!doctype html><html><head><meta charset="utf-8"><title>Textbaustein-Übersicht</title><style>
+        body{font-family:Inter,Arial,sans-serif;padding:18px;color:#1f2937;font-size:12px;line-height:1.4;background:#f8fafc;}
+        .sheet{max-width:900px;margin:0 auto;background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:16px 18px;}
+        h1{margin:0 0 4px;font-size:18px;line-height:1.2;}
+        .sub{margin:0 0 12px;color:#6b7280;font-size:11px;}
+        h3{margin:14px 0 6px;font-size:13px;padding-bottom:4px;border-bottom:1px solid #e5e7eb;}
+        ul{margin:0;padding:0;list-style:none;}
+        li{margin:0 0 8px;padding:8px 10px;border:1px solid #e5e7eb;border-radius:8px;background:#fcfcfd;white-space:pre-wrap;}
+        li strong{display:block;font-size:12px;margin-bottom:3px;color:#111827;}
+        @media print{body{background:#fff;padding:0}.sheet{border:none;border-radius:0;padding:0;max-width:none}li{break-inside:avoid;page-break-inside:avoid}}
+      </style></head><body><div class="sheet"><h1>Textbaustein-Übersicht</h1><p class="sub">Verfügbare Bausteine für das aktuell gewählte Feld</p>${html || '<p>Keine Bausteine vorhanden.</p>'}</div></body></html>`);
       w.document.close();
       w.addEventListener('load', () => {
         w.focus();

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -4676,12 +4676,15 @@ render_teacher_header($pageTitle);
         const rows = items.map(s => `<li><strong>${esc(s.title || tEntry('snippet_untitled'))}</strong><br>${esc(String(s.content || ''))}</li>`).join('');
         return `<h3>${esc(cat)}</h3><ul>${rows}</ul>`;
       }).join('');
-      const w = window.open('', '_blank', 'noopener,noreferrer,width=900,height=700');
+      const w = window.open('', '_blank', 'width=900,height=700');
       if (!w) return;
+      w.document.open();
       w.document.write(`<!doctype html><html><head><meta charset="utf-8"><title>Textbaustein-Übersicht</title><style>body{font-family:Arial,sans-serif;padding:20px;}h3{margin:14px 0 6px;}ul{margin:0 0 14px 20px;}li{margin:0 0 10px;white-space:pre-wrap;}</style></head><body><h1>Textbaustein-Übersicht</h1>${html || '<p>Keine Bausteine vorhanden.</p>'}</body></html>`);
       w.document.close();
-      w.focus();
-      w.print();
+      w.addEventListener('load', () => {
+        w.focus();
+        w.print();
+      }, { once: true });
     });
     printWrap.appendChild(printBtn);
     snippetMenu.appendChild(printWrap);

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -1880,8 +1880,8 @@ render_teacher_header($pageTitle);
   .snippet-card .c{ color:var(--muted); font-size:12px; }
   .snippet-card .txt{ white-space:pre-wrap; }
   .snippet-menu{ position:absolute; z-index:9999; background:#fff; border:1px solid var(--border); box-shadow:0 8px 24px rgba(0,0,0,0.16); border-radius:12px; padding:10px; min-width:260px; max-width:360px; max-height:60vh; overflow:auto; }
-  .snippet-menu h4{ margin:4px 0; font-size:14px; border-top: solid lightgray; padding-top: 5px; }
-  .snippet-menu .item{ padding:6px 8px; border-radius:8px; cursor:pointer; }
+  .snippet-menu h4{ margin:3px 0; font-size:12px; border-top: solid lightgray; padding-top: 4px; }
+  .snippet-menu .item{ padding:5px 7px; border-radius:7px; cursor:pointer; }
   .snippet-menu .item:hover{ background: rgba(0,0,0,0.04); }
   .snippet-save{ border:1px dashed var(--border); border-radius:10px; padding:8px; display:flex; flex-direction:column; gap:6px; position: sticky;
     top: 0;
@@ -4654,7 +4654,7 @@ render_teacher_header($pageTitle);
         items.forEach(s => {
           const div = document.createElement('div');
           div.className = 'item';
-          div.innerHTML = `<div style="font-size:14px;font-weight:900;">${fmtPipeItalic(s.title || tEntry('snippet_untitled'))}</div><div class="muted" style="font-size:12px;">${fmtPipeItalic((s.content || '').slice(0, 120))}</div>`;
+          div.innerHTML = `<div style="font-size:12px;font-weight:800; line-height:1.2;">${fmtPipeItalic(s.title || tEntry('snippet_untitled'))}</div><div class="muted" style="font-size:11px; line-height:1.25;">${fmtPipeItalic((s.content || '').slice(0, 120))}</div>`;
           div.addEventListener('click', () => {
             insertSnippetText(target, s.content || '');
             hideSnippetMenu();

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -4657,6 +4657,34 @@ render_teacher_header($pageTitle);
         });
       });
     }
+    const printWrap = document.createElement('div');
+    printWrap.style.marginTop = '10px';
+    printWrap.style.paddingTop = '8px';
+    printWrap.style.borderTop = '1px solid var(--border)';
+    const printBtn = document.createElement('button');
+    printBtn.type = 'button';
+    printBtn.className = 'btn secondary';
+    printBtn.textContent = 'Übersicht drucken';
+    printBtn.addEventListener('click', () => {
+      const grouped = {};
+      list.forEach(s => {
+        const cat = s.category && String(s.category).trim() !== '' ? String(s.category) : tEntry('snippet_default_category');
+        if (!grouped[cat]) grouped[cat] = [];
+        grouped[cat].push(s);
+      });
+      const html = Object.entries(grouped).map(([cat, items]) => {
+        const rows = items.map(s => `<li><strong>${esc(s.title || tEntry('snippet_untitled'))}</strong><br>${esc(String(s.content || ''))}</li>`).join('');
+        return `<h3>${esc(cat)}</h3><ul>${rows}</ul>`;
+      }).join('');
+      const w = window.open('', '_blank', 'noopener,noreferrer,width=900,height=700');
+      if (!w) return;
+      w.document.write(`<!doctype html><html><head><meta charset="utf-8"><title>Textbaustein-Übersicht</title><style>body{font-family:Arial,sans-serif;padding:20px;}h3{margin:14px 0 6px;}ul{margin:0 0 14px 20px;}li{margin:0 0 10px;white-space:pre-wrap;}</style></head><body><h1>Textbaustein-Übersicht</h1>${html || '<p>Keine Bausteine vorhanden.</p>'}</body></html>`);
+      w.document.close();
+      w.focus();
+      w.print();
+    });
+    printWrap.appendChild(printBtn);
+    snippetMenu.appendChild(printWrap);
     snippetMenu.style.display = 'block';
     // anchor to page coordinates so menu scrolls with content
     const px = Number(x || 0);

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -1255,8 +1255,9 @@ render_teacher_header($pageTitle);
     </div>
     <div style="flex:1; min-width:200px;">
       <label class="label"><?=h(t('teacher.entry.snippets.category_label'))?></label>
-      <input class="input" id="snippetCategory" list="snippetCategoryList" type="text" placeholder="<?=h(t('teacher.entry.snippets.category_placeholder'))?>" style="width:100%;">
-      <datalist id="snippetCategoryList"></datalist>
+      <select class="input" id="snippetCategory" style="width:100%;">
+        <option value=""><?=h(t('teacher.entry.snippets.category_placeholder'))?></option>
+      </select>
     </div>
     <div style="display:flex; gap:8px; flex-wrap:wrap; align-items:center;">
       <button class="btn" type="button" id="btnSnippetSave" disabled><?=h(t('teacher.entry.snippets.save'))?></button>
@@ -2270,7 +2271,6 @@ render_teacher_header($pageTitle);
   const btnSnippetSave = document.getElementById('btnSnippetSave');
   const btnSnippetToggle = document.getElementById('btnSnippetToggle');
   const btnSnippetClose = document.getElementById('btnSnippetClose');
-  const snippetCategoryList = document.getElementById('snippetCategoryList');
 
   const dlgAi = document.getElementById('dlgAi');
   const aiBackdrop = document.querySelector('#dlgAi .modal-backdrop');
@@ -4332,15 +4332,23 @@ render_teacher_header($pageTitle);
   }
 
   function refreshSnippetCategoryList(){
-    if (!snippetCategoryList) return;
+    if (!snippetCategory) return;
     const cats = new Set();
     (state.text_snippets || []).forEach(s => { if (s.category) cats.add(String(s.category)); });
-    snippetCategoryList.innerHTML = '';
+    const currentVal = String(snippetCategory.value || '');
+    snippetCategory.innerHTML = '';
+    const emptyOpt = document.createElement('option');
+    emptyOpt.value = '';
+    emptyOpt.textContent = tEntry('snippet_menu_category_placeholder');
+    snippetCategory.appendChild(emptyOpt);
     cats.forEach(c => {
       const opt = document.createElement('option');
       opt.value = c;
-      snippetCategoryList.appendChild(opt);
+      opt.textContent = c;
+      snippetCategory.appendChild(opt);
     });
+    snippetCategory.value = currentVal;
+    if (snippetCategory.value !== currentVal) snippetCategory.value = '';
   }
 
   function insertSnippetText(target, text){
@@ -4590,12 +4598,22 @@ render_teacher_header($pageTitle);
         <div class="muted" style="font-size:12px;">${esc(preview)}</div>
         <div class="row" style="align-items:center;">
           <input class="input" type="text" placeholder="${esc(tEntry('snippet_menu_title_placeholder'))}" style="flex:1; min-width:180px;">
-          <input class="input" type="text" placeholder="${esc(tEntry('snippet_menu_category_placeholder'))}" style="flex:1; min-width:160px;">
+          <select class="input" style="flex:1; min-width:160px;"><option value="">${esc(tEntry('snippet_menu_category_placeholder'))}</option></select>
           <button class="btn" type="button">${esc(tEntry('snippet_menu_save'))}</button>
         </div>
       `;
       const titleInput = saveBox.querySelector('input');
-      const catInput = saveBox.querySelectorAll('input')[1] || null;
+      const catInput = saveBox.querySelector('select');
+      if (catInput) {
+        const cats = new Set();
+        (state.text_snippets || []).forEach(s => { if (s.category) cats.add(String(s.category)); });
+        cats.forEach(c => {
+          const opt = document.createElement('option');
+          opt.value = c;
+          opt.textContent = c;
+          catInput.appendChild(opt);
+        });
+      }
       const saveBtn = saveBox.querySelector('button');
       saveBtn?.addEventListener('click', async () => {
         const title = titleInput ? String(titleInput.value || '').trim() : '';

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -2416,6 +2416,12 @@ render_teacher_header($pageTitle);
   function dbg(...args){ if (DEBUG) console.log('[LEB entry]', ...args); }
 
   function esc(s){ return String(s ?? '').replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m])); }
+  function fmtPipeItalic(s){
+    const raw = String(s ?? '');
+    const idx = raw.indexOf('|');
+    if (idx < 0) return esc(raw);
+    return `${esc(raw.slice(0, idx + 1))}<i>${esc(raw.slice(idx + 1))}</i>`;
+  }
   function normalize(s){ return String(s ?? '').toLowerCase().trim(); }
 
   function groupFilterValue(groupKey, subgroup){
@@ -4389,10 +4395,10 @@ render_teacher_header($pageTitle);
         card.className = 'snippet-card';
         card.innerHTML = `
           <div class="h">
-            <div style="font-weight:800;">${esc(s.title || tEntry('snippet_untitled'))}</div>
+            <div style="font-weight:800;">${fmtPipeItalic(s.title || tEntry('snippet_untitled'))}</div>
             <span class="pill-mini">${esc(cat)}</span>
           </div>
-          <div class="txt">${esc(s.content || '')}</div>
+          <div class="txt">${fmtPipeItalic(s.content || '')}</div>
           <div class="c">${esc(s.created_by_name || '')}${s.is_generated ? ` · ${esc(tEntry('snippet_generated'))}` : ''}</div>
           <div style="display:flex; gap:6px; flex-wrap:wrap;">
             <button class="btn secondary" type="button">${esc(tEntry('snippet_insert_current'))}</button>
@@ -4643,12 +4649,12 @@ render_teacher_header($pageTitle);
       });
       Object.entries(grouped).forEach(([cat, items]) => {
         const h = document.createElement('h4');
-        h.textContent = cat;
+        h.innerHTML = fmtPipeItalic(cat);
         snippetMenu.appendChild(h);
         items.forEach(s => {
           const div = document.createElement('div');
           div.className = 'item';
-          div.innerHTML = `<div style="font-size:14px;font-weight:900;">${esc(s.title || tEntry('snippet_untitled'))}</div><div class="muted" style="font-size:12px;">${esc((s.content || '').slice(0, 120))}</div>`;
+          div.innerHTML = `<div style="font-size:14px;font-weight:900;">${fmtPipeItalic(s.title || tEntry('snippet_untitled'))}</div><div class="muted" style="font-size:12px;">${fmtPipeItalic((s.content || '').slice(0, 120))}</div>`;
           div.addEventListener('click', () => {
             insertSnippetText(target, s.content || '');
             hideSnippetMenu();
@@ -4673,8 +4679,8 @@ render_teacher_header($pageTitle);
         grouped[cat].push(s);
       });
       const html = Object.entries(grouped).map(([cat, items]) => {
-        const rows = items.map(s => `<li><strong>${esc(s.title || tEntry('snippet_untitled'))}</strong><br>${esc(String(s.content || ''))}</li>`).join('');
-        return `<h3>${esc(cat)}</h3><ul>${rows}</ul>`;
+        const rows = items.map(s => `<li><strong>${fmtPipeItalic(s.title || tEntry('snippet_untitled'))}</strong><br>${fmtPipeItalic(String(s.content || ''))}</li>`).join('');
+        return `<h3>${fmtPipeItalic(cat)}</h3><ul>${rows}</ul>`;
       }).join('');
       const w = window.open('', '_blank', 'width=900,height=700');
       if (!w) return;

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -4687,7 +4687,7 @@ render_teacher_header($pageTitle);
         h3{margin:14px 0 6px;font-size:13px;padding-bottom:4px;border-bottom:1px solid #e5e7eb;}
         ul{margin:0;padding:0;list-style:none;}
         li{margin:0 0 8px;padding:8px 10px;border:1px solid #e5e7eb;border-radius:8px;background:#fcfcfd;white-space:pre-wrap;}
-        li strong{display:block;font-size:12px;margin-bottom:3px;color:#111827;}
+        li strong{display:block;font-size:12px;margin-bottom:1px;color:#111827;}
         @media print{body{background:#fff;padding:0}.sheet{border:none;border-radius:0;padding:0;max-width:none}li{break-inside:avoid;page-break-inside:avoid}}
       </style></head><body><div class="sheet"><h1>Textbaustein-Übersicht</h1><p class="sub">Verfügbare Bausteine für das aktuell gewählte Feld</p>${html || '<p>Keine Bausteine vorhanden.</p>'}</div></body></html>`);
       w.document.close();

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -3131,6 +3131,10 @@ render_teacher_header($pageTitle);
       const rid = isClassFieldId(fieldId) ? classReportId() : Number(reportId || 0);
       const parts = state.values_teacher_parts[String(rid)]?.[String(fieldId)];
       if (parts && typeof parts === 'object') {
+        if (part === 'delegate' && parts.delegate_texts && typeof parts.delegate_texts === 'object') {
+          const own = parts.delegate_texts[String(CURRENT_USER_ID)];
+          return String(own ?? '');
+        }
         return part === 'delegate'
           ? String(parts.delegate_text ?? '')
           : String(parts.class_text ?? '');

--- a/teacher/entry.php
+++ b/teacher/entry.php
@@ -1832,6 +1832,14 @@ render_teacher_header($pageTitle);
   .combined-inline{ margin-top:8px; padding:10px; border:1px dashed var(--border); border-radius:10px; background:#fafafa; }
   .combined-inline-label{ font-size:12px; text-transform:uppercase; letter-spacing:.02em; color:#6b6b6b; margin-bottom:4px; }
   .combined-inline-text{ font-size:14px; line-height:1.5; }
+  .combined-inline-text .delegate-part,
+  .combined-tip-bubble .delegate-part{
+    background: rgba(255, 193, 7, 0.25);
+    border-left: 3px solid #f59e0b;
+    padding: 1px 4px;
+    border-radius: 4px;
+    display: inline-block;
+  }
 
   #itemTable { table-layout: auto; width: max-content; }
   .grade-table-wrap{ margin-top:12px; border:1px solid var(--border); border-radius:12px; }
@@ -3085,6 +3093,18 @@ render_teacher_header($pageTitle);
     return parts.join('\n\n');
   }
 
+  function combineTextPartsHtml(classText, delegateText, highlightDelegate){
+    const ct = String(classText ?? '').replace(/\s+$/, '');
+    const dt = String(delegateText ?? '').replace(/\s+$/, '');
+    const parts = [];
+    if (ct.trim() !== '') parts.push(esc(ct).replace(/\n/g, '<br>'));
+    if (dt.trim() !== '') {
+      const raw = esc(dt).replace(/\n/g, '<br>');
+      parts.push(highlightDelegate ? `<span class="delegate-part">${raw}</span>` : raw);
+    }
+    return parts.join('<br><br>');
+  }
+
   function teacherVal(reportId, fieldId){
     if (isClassFieldId(fieldId)) {
       const rid = classReportId();
@@ -3173,10 +3193,16 @@ render_teacher_header($pageTitle);
         ? state.fieldMap[String(field.id)]._delegated_user_ids.map(x => Number(x)).filter(x => x > 0)
         : []);
     if (!delegatedUserIds.length) return '';
-    const combined = teacherVal(reportId, field.id);
-    const html = combined
-      ? esc(String(combined)).replace(/\n/g, '<br>')
-      : '<span class="muted">—</span>';
+    const rid = isClassFieldId(field.id) ? classReportId() : reportId;
+    const parts = state.values_teacher_parts[String(rid)]?.[String(field.id)] || null;
+    const hasParts = !!parts;
+    const highlightDelegate = !DELEGATED_MODE && !!(state.is_class_teacher);
+    const html = hasParts
+      ? combineTextPartsHtml(parts.class_text ?? '', parts.delegate_text ?? '', highlightDelegate)
+      : (() => {
+          const combined = teacherVal(reportId, field.id);
+          return combined ? esc(String(combined)).replace(/\n/g, '<br>') : '<span class="muted">—</span>';
+        })();
     if (DELEGATED_MODE) {
       return `
         <div class="combined-inline">

--- a/teacher/pdf_entry.php
+++ b/teacher/pdf_entry.php
@@ -421,6 +421,7 @@ $studentName = trim((string)($student['first_name'] ?? '') . ' ' . (string)($stu
   let activeSaves = 0;
   let renderTimer = null;
   let lastSnippetTarget = null;
+  let lastSnippetField = null;
   const snippetMenu = document.createElement('div');
   snippetMenu.className = 'snippet-menu';
   snippetMenu.style.display = 'none';
@@ -911,6 +912,7 @@ $studentName = trim((string)($student['first_name'] ?? '') . ' ' . (string)($stu
       el.addEventListener('contextmenu', (ev) => {
         ev.preventDefault();
         lastSnippetTarget = el;
+        lastSnippetField = field;
         openSnippetMenu(ev.pageX ?? (ev.clientX + window.scrollX), ev.pageY ?? (ev.clientY + window.scrollY));
       });
     }
@@ -939,7 +941,20 @@ $studentName = trim((string)($student['first_name'] ?? '') . ' ' . (string)($stu
     el.dispatchEvent(new Event('input', { bubbles: true }));
   }
   function openSnippetMenu(x, y){
-    const list = Array.isArray(state?.text_snippets) ? state.text_snippets : [];
+    const all = Array.isArray(state?.text_snippets) ? state.text_snippets : [];
+    const allowedIds = Array.isArray(lastSnippetField?.snippet_category_ids)
+      ? lastSnippetField.snippet_category_ids.map(x => String(x || '').trim()).filter(Boolean)
+      : null;
+    const allowedCats = Array.isArray(lastSnippetField?.snippet_categories)
+      ? lastSnippetField.snippet_categories.map(x => String(x || '').trim()).filter(Boolean)
+      : null;
+    const list = all.filter(s => {
+      const cat = s?.category && String(s.category).trim() !== '' ? String(s.category).trim() : 'Allgemein';
+      const catId = String(s?.category_id || '').trim();
+      if (allowedIds !== null) return catId !== '' && allowedIds.includes(catId);
+      if (allowedCats !== null) return allowedCats.includes(cat);
+      return true;
+    });
     snippetMenu.innerHTML = '';
     if (!list.length) {
       snippetMenu.innerHTML = '<div class="muted">Keine Textbausteine vorhanden.</div>';

--- a/teacher/pdf_entry.php
+++ b/teacher/pdf_entry.php
@@ -305,6 +305,10 @@ $studentName = trim((string)($student['first_name'] ?? '') . ' ' . (string)($stu
     color: #2b4a77;
     text-align: center;
   }
+  .snippet-menu{ position:absolute; z-index:9999; background:#fff; border:1px solid var(--border); box-shadow:0 8px 24px rgba(0,0,0,0.16); border-radius:10px; padding:8px; min-width:240px; max-width:360px; max-height:60vh; overflow:auto; }
+  .snippet-menu h4{ margin:4px 0; font-size:12px; border-top:1px solid #e5e7eb; padding-top:4px; }
+  .snippet-menu .item{ padding:5px 7px; border-radius:7px; cursor:pointer; }
+  .snippet-menu .item:hover{ background: rgba(0,0,0,0.04); }
 </style>
 
 <div class="pdf-entry-wrap">
@@ -416,6 +420,11 @@ $studentName = trim((string)($student['first_name'] ?? '') . ' ' . (string)($stu
   const pendingSaves = new Map();
   let activeSaves = 0;
   let renderTimer = null;
+  let lastSnippetTarget = null;
+  const snippetMenu = document.createElement('div');
+  snippetMenu.className = 'snippet-menu';
+  snippetMenu.style.display = 'none';
+  document.body.appendChild(snippetMenu);
   let showStudentValues = false;
   let allowStudentEdit = false;
   let isDelegatedView = false;
@@ -897,6 +906,14 @@ $studentName = trim((string)($student['first_name'] ?? '') . ' ' . (string)($stu
     }
 
     wrapper.appendChild(el);
+    const tag = (el && el.tagName) ? el.tagName.toLowerCase() : '';
+    if (canEdit && (tag === 'textarea' || tag === 'input')) {
+      el.addEventListener('contextmenu', (ev) => {
+        ev.preventDefault();
+        lastSnippetTarget = el;
+        openSnippetMenu(ev.pageX ?? (ev.clientX + window.scrollX), ev.pageY ?? (ev.clientY + window.scrollY));
+      });
+    }
     if (type === 'date' && canEdit) {
       initDatePicker(el, field);
     }
@@ -908,6 +925,47 @@ $studentName = trim((string)($student['first_name'] ?? '') . ' ' . (string)($stu
       wrapper.appendChild(delegate);
     }
     return wrapper;
+  }
+
+  function hideSnippetMenu(){ snippetMenu.style.display = 'none'; }
+  function insertSnippetText(text){
+    const el = lastSnippetTarget;
+    if (!el) return;
+    const snippet = String(text ?? '');
+    const start = typeof el.selectionStart === 'number' ? el.selectionStart : (el.value || '').length;
+    const end = typeof el.selectionEnd === 'number' ? el.selectionEnd : start;
+    const val = String(el.value || '');
+    el.value = val.slice(0, start) + snippet + val.slice(end);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+  function openSnippetMenu(x, y){
+    const list = Array.isArray(state?.text_snippets) ? state.text_snippets : [];
+    snippetMenu.innerHTML = '';
+    if (!list.length) {
+      snippetMenu.innerHTML = '<div class="muted">Keine Textbausteine vorhanden.</div>';
+    } else {
+      const grouped = {};
+      list.forEach(s => {
+        const cat = s?.category && String(s.category).trim() !== '' ? String(s.category) : 'Allgemein';
+        if (!grouped[cat]) grouped[cat] = [];
+        grouped[cat].push(s);
+      });
+      Object.entries(grouped).forEach(([cat, items]) => {
+        const h = document.createElement('h4');
+        h.textContent = cat;
+        snippetMenu.appendChild(h);
+        items.forEach(s => {
+          const div = document.createElement('div');
+          div.className = 'item';
+          div.innerHTML = `<div style="font-size:12px;font-weight:800;">${String(s.title || '(ohne Titel)').replace(/[<>&"']/g, '')}</div><div class="muted" style="font-size:11px;">${String((s.content || '').slice(0, 120)).replace(/[<>&"']/g, '')}</div>`;
+          div.addEventListener('click', () => { insertSnippetText(s.content || ''); hideSnippetMenu(); });
+          snippetMenu.appendChild(div);
+        });
+      });
+    }
+    snippetMenu.style.display = 'block';
+    snippetMenu.style.left = `${Number(x || 0)}px`;
+    snippetMenu.style.top = `${Number(y || 0)}px`;
   }
 
   function isTextField(field){
@@ -1221,6 +1279,10 @@ $studentName = trim((string)($student['first_name'] ?? '') . ' ' . (string)($stu
     try {
       const data = await api('load_pdf', { class_id: classId, student_id: studentId });
       state = data;
+      try {
+        const sj = await api('snippets_list', {});
+        state.text_snippets = sj.snippets || [];
+      } catch(_e) {}
       isDelegatedView = Boolean(data?.delegated_view);
       if (state && Array.isArray(state.fields)) {
         state.all_fields = state.fields.slice();
@@ -1262,6 +1324,10 @@ $studentName = trim((string)($student['first_name'] ?? '') . ' ' . (string)($stu
     if (document.visibilityState === 'hidden') {
       flushPendingSaves();
     }
+  });
+  document.addEventListener('click', (ev) => {
+    if (ev.target && snippetMenu.contains(ev.target)) return;
+    hideSnippetMenu();
   });
 
   window.addEventListener('beforeunload', () => {


### PR DESCRIPTION
### Motivation
- Provide a way for admins to assign which text-snippet categories are available per multiline field and make those category identifiers available to frontend UIs and APIs.

### Description
- Add a snippet category modal and UI controls to `admin/template_fields.php` allowing selection of snippet categories for multiline fields, including a button per multiline field and a dialog (`#snippetCategoryModal`).
- Implement client-side API integration in `admin/template_fields.php` with `textSnippetsPost`, `fetchSnippetCategories`, `openSnippetCategoryModal`, and modal close handling to persist selected `snippet_category_ids` into field meta and mark fields dirty for saving; add `textSnippetsApiUrl` constant and a client-side cache for categories.
- Extend `shared/text_snippets.php` with `text_snippet_category_id()` to generate stable category IDs and include `category_id` in snippet listing and individual snippet responses, and ensure saved/updated/moved snippets return the `category_id`.
- Add helpers in `teacher/ajax/entry_api.php` (`snippet_categories_from_meta` and `snippet_category_ids_from_meta`) and annotate class/teacher field responses with `snippet_categories` and `snippet_category_ids` so the teacher UI can restrict visible snippets per-field.
- Update `teacher/entry.php` snippet menu logic to filter available snippets by allowed category names or category IDs derived from the field definition.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d2fd9114832e87b9fd01e9787315)