### PR TITLE
Add teacher dashboard notifications with opt-in email summaries and cron

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -2081,6 +2081,7 @@ function teacher_notification_summary(PDO $pdo, int $userId): array {
 function build_teacher_notification_email(string $name, array $summary, string $lang = 'de'): string {
   $safeName = h($name);
   $lang = strtolower(trim($lang)) === 'en' ? 'en' : 'de';
+  $isEn = ($lang === 'en');
   $open = (int)($summary['tasks_open'] ?? 0);
   $total = (int)($summary['tasks_total'] ?? 0);
   $delegations = (int)($summary['delegations_open'] ?? 0);
@@ -2109,19 +2110,19 @@ function build_teacher_notification_email(string $name, array $summary, string $
 
   return '<div style="font-family:Inter,Segoe UI,Arial,sans-serif;background:#f3f4f6;padding:20px;">'
     . '<div style="max-width:760px;margin:0 auto;background:#fff;border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;">'
-    . '<div style="background:#0b57d0;color:#fff;padding:16px 20px;"><h2 style="margin:0;font-size:20px;">' . ($lang === 'en' ? 'LEB Tool notification' : 'LEB-Tool Benachrichtigung') . '</h2></div>'
+    . '<div style="background:#0b57d0;color:#fff;padding:16px 20px;"><h2 style="margin:0;font-size:20px;">' . ($isEn ? 'LEB Tool notification' : 'LEB-Tool Benachrichtigung') . '</h2></div>'
     . '<div style="padding:18px 20px;color:#111827;line-height:1.5;">'
-    . '<p style="margin:0 0 10px;">Hallo ' . $safeName . ',</p>'
-    . '<p style="margin:0 0 16px;">hier ist dein aktueller Überblick:</p>'
+    . '<p style="margin:0 0 10px;">' . ($isEn ? 'Hello ' : 'Hallo ') . $safeName . ',</p>'
+    . '<p style="margin:0 0 16px;">' . ($isEn ? 'here is your current overview:' : 'hier ist dein aktueller Überblick:') . '</p>'
     . '<div style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:16px;">'
-    . '<span style="background:#e8f0fe;color:#0b57d0;border-radius:999px;padding:6px 10px;font-size:13px;">Offene Delegationen: <strong>' . $delegations . '</strong></span>'
-    . '<span style="background:#eefbf2;color:#1e8e3e;border-radius:999px;padding:6px 10px;font-size:13px;">Offene Lehrkrafteingaben: <strong>' . $open . ' / ' . $total . '</strong></span>'
+    . '<span style="background:#e8f0fe;color:#0b57d0;border-radius:999px;padding:6px 10px;font-size:13px;">' . ($isEn ? 'Open delegations' : 'Offene Delegationen') . ': <strong>' . $delegations . '</strong></span>'
+    . '<span style="background:#eefbf2;color:#1e8e3e;border-radius:999px;padding:6px 10px;font-size:13px;">' . ($isEn ? 'Open teacher entries' : 'Offene Lehrkrafteingaben') . ': <strong>' . $open . ' / ' . $total . '</strong></span>'
     . '</div>'
-    . '<h3 style="margin:16px 0 8px;font-size:16px;">Nach Klasse</h3>'
-    . '<table style="width:100%;border-collapse:collapse;font-size:14px;"><thead><tr><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">Klasse</th><th style="text-align:right;padding:8px;border-bottom:2px solid #e5e7eb;">Delegationen offen</th><th style="text-align:right;padding:8px;border-bottom:2px solid #e5e7eb;">Lehrkrafteingaben offen</th></tr></thead><tbody>' . $classRows . '</tbody></table>'
-    . '<h3 style="margin:18px 0 8px;font-size:16px;">Alle Fristen</h3>'
-    . '<table style="width:100%;border-collapse:collapse;font-size:14px;"><thead><tr><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">Bereich</th><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">Schuljahr · Halbjahr</th><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">Fällig am</th></tr></thead><tbody>' . $deadlineRows . '</tbody></table>'
-    . '<p style="margin:16px 0 0;color:#6b7280;font-size:12px;">Diese Nachricht wurde automatisch vom LEB-Tool erzeugt.</p>'
+    . '<h3 style="margin:16px 0 8px;font-size:16px;">' . ($isEn ? 'By class' : 'Nach Klasse') . '</h3>'
+    . '<table style="width:100%;border-collapse:collapse;font-size:14px;"><thead><tr><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Class' : 'Klasse') . '</th><th style="text-align:right;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Open delegations' : 'Delegationen offen') . '</th><th style="text-align:right;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Open teacher entries' : 'Lehrkrafteingaben offen') . '</th></tr></thead><tbody>' . $classRows . '</tbody></table>'
+    . '<h3 style="margin:18px 0 8px;font-size:16px;">' . ($isEn ? 'All deadlines' : 'Alle Fristen') . '</h3>'
+    . '<table style="width:100%;border-collapse:collapse;font-size:14px;"><thead><tr><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Area' : 'Bereich') . '</th><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'School year · term' : 'Schuljahr · Halbjahr') . '</th><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Due at' : 'Fällig am') . '</th></tr></thead><tbody>' . $deadlineRows . '</tbody></table>'
+    . '<p style="margin:16px 0 0;color:#6b7280;font-size:12px;">' . ($isEn ? 'This message was generated automatically by LEB Tool.' : 'Diese Nachricht wurde automatisch vom LEB-Tool erzeugt.') . '</p>'
     . '</div></div></div>';
 }
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1140,6 +1140,8 @@ function ensure_schema(PDO $pdo): void {
 " .
         "  confirmation_pending TINYINT(1) NOT NULL DEFAULT 0,
 " .
+        "  last_summary_hash VARCHAR(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+" .
         "  last_email_sent_at DATETIME DEFAULT NULL,
 " .
         "  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1152,6 +1154,9 @@ function ensure_schema(PDO $pdo): void {
       );
     } elseif (!db_has_column($pdo, 'teacher_notification_preferences', 'notification_lang')) {
       $pdo->exec("ALTER TABLE teacher_notification_preferences ADD COLUMN notification_lang VARCHAR(5) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'de' AFTER wants_email");
+    }
+    if (db_has_table($pdo, 'teacher_notification_preferences') && !db_has_column($pdo, 'teacher_notification_preferences', 'last_summary_hash')) {
+      $pdo->exec("ALTER TABLE teacher_notification_preferences ADD COLUMN last_summary_hash VARCHAR(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL AFTER confirmation_pending");
     }
 
 
@@ -2104,7 +2109,7 @@ function build_teacher_notification_email(string $name, array $summary, string $
     $deadlineRows .= '<tr>'
       . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h((string)($d['type_label'] ?? '')) . '</td>'
       . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h((string)($d['school_year'] ?? '')) . ' · ' . h((string)($d['period_label'] ?? '')) . '</td>'
-      . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h((($tmp = db_datetime_to_user_datetime((string)($d['due_at'] ?? ''))) ? $tmp->format($lang === 'en' ? 'Y-m-d H:i' : 'd.m.Y H:i') : '–')) . '</td>'
+      . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h((($tmp = db_datetime_to_user_datetime((string)($d['due_at'] ?? ''))) ? $tmp->format($lang === 'en' ? 'Y-m-d' : 'd.m.Y') : '–')) . '</td>'
       . '</tr>';
   }
   if ($deadlineRows === '') $deadlineRows = '<tr><td colspan="3" style="padding:8px;color:#6b7280;">' . ($lang === 'en' ? 'No deadlines set.' : 'Keine Fristen gesetzt.') . '</td></tr>';
@@ -2122,7 +2127,7 @@ function build_teacher_notification_email(string $name, array $summary, string $
     . '<h3 style="margin:16px 0 8px;font-size:16px;">' . ($isEn ? 'By class' : 'Nach Klasse') . '</h3>'
     . '<table style="width:100%;border-collapse:collapse;font-size:14px;"><thead><tr><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Class' : 'Klasse') . '</th><th style="text-align:right;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Open delegations' : 'Delegationen offen') . '</th><th style="text-align:right;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Open teacher entries' : 'Lehrkrafteingaben offen') . '</th></tr></thead><tbody>' . $classRows . '</tbody></table>'
     . '<h3 style="margin:18px 0 8px;font-size:16px;">' . ($isEn ? 'All deadlines' : 'Alle Fristen') . '</h3>'
-    . '<table style="width:100%;border-collapse:collapse;font-size:14px;"><thead><tr><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Area' : 'Bereich') . '</th><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'School year · term' : 'Schuljahr · Halbjahr') . '</th><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Due at' : 'Fällig am') . '</th></tr></thead><tbody>' . $deadlineRows . '</tbody></table>'
+    . '<table style="width:100%;border-collapse:collapse;font-size:14px;"><thead><tr style="border-bottom:2px solid #e5e7eb;"><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Area' : 'Bereich') . '</th><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'School year · term' : 'Schuljahr · Halbjahr') . '</th><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">' . ($isEn ? 'Due date' : 'Fällig am') . '</th></tr></thead><tbody>' . $deadlineRows . '</tbody></table>'
     . '<p style="margin:16px 0 0;color:#6b7280;font-size:12px;">' . ($isEn ? 'This message was generated automatically by LEB Tool.' : 'Diese Nachricht wurde automatisch vom LEB-Tool erzeugt.') . '</p>'
     . '</div></div></div>';
 }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/shared/translations.php';
 require_once __DIR__ . '/shared/signatures.php';
 
 $configPath = getenv('APP_CONFIG_FILE') ?: (__DIR__ . '/config.php');
-define('APP_CONFIG_PATH', $configPath);
+if (!defined('APP_CONFIG_PATH')) define('APP_CONFIG_PATH', $configPath);
 if (!file_exists(APP_CONFIG_PATH)) {
   // install not completed
   header('Location: install.php');
@@ -19,17 +19,20 @@ $https = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || (($_SERVE
 $cookiePath = (string)($config['app']['base_path'] ?? '/');
 $cookiePath = '/' . ltrim($cookiePath, '/');
 $cookiePath = rtrim($cookiePath, '/') ?: '/';
-session_set_cookie_params([
-  'lifetime' => 0,
-  'path' => $cookiePath,
-  'domain' => '',
-  'secure' => $https,
-  'httponly' => true,
-  'samesite' => 'Lax',
-]);
-
-session_name($config['app']['session_name'] ?? 'legtool_sess');
-session_start();
+if (session_status() === PHP_SESSION_NONE) {
+  if (!headers_sent()) {
+    session_set_cookie_params([
+      'lifetime' => 0,
+      'path' => $cookiePath,
+      'domain' => '',
+      'secure' => $https,
+      'httponly' => true,
+      'samesite' => 'Lax',
+    ]);
+    session_name($config['app']['session_name'] ?? 'legtool_sess');
+  }
+  @session_start();
+}
 
 // Prevent browser "confirm form resubmission" prompt on reload by replacing history state.
 ob_start(function (string $buffer): string {
@@ -1132,6 +1135,8 @@ function ensure_schema(PDO $pdo): void {
 " .
         "  wants_email TINYINT(1) NOT NULL DEFAULT 0,
 " .
+        "  notification_lang VARCHAR(5) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'de',
+" .
         "  confirmation_pending TINYINT(1) NOT NULL DEFAULT 0,
 " .
         "  last_email_sent_at DATETIME DEFAULT NULL,
@@ -1144,6 +1149,8 @@ function ensure_schema(PDO $pdo): void {
 " .
         ") CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
       );
+    } elseif (!db_has_column($pdo, 'teacher_notification_preferences', 'notification_lang')) {
+      $pdo->exec("ALTER TABLE teacher_notification_preferences ADD COLUMN notification_lang VARCHAR(5) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'de' AFTER wants_email");
     }
 
 
@@ -2071,8 +2078,9 @@ function teacher_notification_summary(PDO $pdo, int $userId): array {
   return $out;
 }
 
-function build_teacher_notification_email(string $name, array $summary): string {
+function build_teacher_notification_email(string $name, array $summary, string $lang = 'de'): string {
   $safeName = h($name);
+  $lang = strtolower(trim($lang)) === 'en' ? 'en' : 'de';
   $open = (int)($summary['tasks_open'] ?? 0);
   $total = (int)($summary['tasks_total'] ?? 0);
   $delegations = (int)($summary['delegations_open'] ?? 0);
@@ -2087,21 +2095,21 @@ function build_teacher_notification_email(string $name, array $summary): string 
       . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right;">' . (int)($c['tasks_open'] ?? 0) . ' / ' . (int)($c['tasks_total'] ?? 0) . '</td>'
       . '</tr>';
   }
-  if ($classRows === '') $classRows = '<tr><td colspan="3" style="padding:8px;color:#6b7280;">Keine Klassen zugeordnet.</td></tr>';
+  if ($classRows === '') $classRows = '<tr><td colspan="3" style="padding:8px;color:#6b7280;">' . ($lang === 'en' ? 'No classes assigned.' : 'Keine Klassen zugeordnet.') . '</td></tr>';
 
   $deadlineRows = '';
   foreach ($deadlines as $d) {
     $deadlineRows .= '<tr>'
       . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h((string)($d['type_label'] ?? '')) . '</td>'
       . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h((string)($d['school_year'] ?? '')) . ' · ' . h((string)($d['period_label'] ?? '')) . '</td>'
-      . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h(render_local_datetime((string)($d['due_at'] ?? ''), 'd.m.Y H:i', '–')) . '</td>'
+      . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h((($tmp = db_datetime_to_user_datetime((string)($d['due_at'] ?? ''))) ? $tmp->format($lang === 'en' ? 'Y-m-d H:i' : 'd.m.Y H:i') : '–')) . '</td>'
       . '</tr>';
   }
-  if ($deadlineRows === '') $deadlineRows = '<tr><td colspan="3" style="padding:8px;color:#6b7280;">Keine Fristen gesetzt.</td></tr>';
+  if ($deadlineRows === '') $deadlineRows = '<tr><td colspan="3" style="padding:8px;color:#6b7280;">' . ($lang === 'en' ? 'No deadlines set.' : 'Keine Fristen gesetzt.') . '</td></tr>';
 
   return '<div style="font-family:Inter,Segoe UI,Arial,sans-serif;background:#f3f4f6;padding:20px;">'
     . '<div style="max-width:760px;margin:0 auto;background:#fff;border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;">'
-    . '<div style="background:#0b57d0;color:#fff;padding:16px 20px;"><h2 style="margin:0;font-size:20px;">LEB-Tool Benachrichtigung</h2></div>'
+    . '<div style="background:#0b57d0;color:#fff;padding:16px 20px;"><h2 style="margin:0;font-size:20px;">' . ($lang === 'en' ? 'LEB Tool notification' : 'LEB-Tool Benachrichtigung') . '</h2></div>'
     . '<div style="padding:18px 20px;color:#111827;line-height:1.5;">'
     . '<p style="margin:0 0 10px;">Hallo ' . $safeName . ',</p>'
     . '<p style="margin:0 0 16px;">hier ist dein aktueller Überblick:</p>'

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1971,7 +1971,7 @@ function teacher_notification_summary(PDO $pdo, int $userId): array {
   ];
   if ($userId <= 0) return $out;
 
-  $st = $pdo->prepare("SELECT COUNT(*) FROM class_group_delegations WHERE user_id=?");
+  $st = $pdo->prepare("SELECT COUNT(*) FROM class_group_delegations WHERE user_id=? AND status='open'");
   $st->execute([$userId]);
   $out['delegations_open'] = (int)($st->fetchColumn() ?: 0);
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -143,9 +143,10 @@ if ($basePath === '/') $basePath = '';
 define('APP_BASE_URL', $basePath);
 
 function app_config(bool $forceReload = false): array {
+  global $config;
   static $cfg = null;
-  if ($cfg !== null && !$forceReload) return $cfg;
-  $cfg = require APP_CONFIG_PATH;
+  if ($cfg === null) $cfg = is_array($config ?? null) ? $config : (require APP_CONFIG_PATH);
+  if ($forceReload) $cfg = require APP_CONFIG_PATH;
   return $cfg;
 }
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1123,6 +1123,30 @@ function ensure_schema(PDO $pdo): void {
     }
 
 
+    // --- teacher_notification_preferences: opt-in mail notifications
+    if (!db_has_table($pdo, 'teacher_notification_preferences')) {
+      $pdo->exec(
+        "CREATE TABLE teacher_notification_preferences (
+" .
+        "  user_id BIGINT UNSIGNED NOT NULL,
+" .
+        "  wants_email TINYINT(1) NOT NULL DEFAULT 0,
+" .
+        "  confirmation_pending TINYINT(1) NOT NULL DEFAULT 0,
+" .
+        "  last_email_sent_at DATETIME DEFAULT NULL,
+" .
+        "  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+" .
+        "  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+" .
+        "  PRIMARY KEY (user_id)
+" .
+        ") CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+      );
+    }
+
+
 
 
     // --- template_fields.field_type: ensure AG type is supported in DB enum
@@ -1936,6 +1960,80 @@ function send_email(string $to, string $subject, string $htmlBody): bool {
 // --------------------
 // Password reset tokens
 // --------------------
+
+
+function teacher_notification_summary(PDO $pdo, int $userId): array {
+  $out = [
+    'delegations_open' => 0,
+    'deadlines_soon' => 0,
+    'tasks_open' => 0,
+    'tasks_total' => 0,
+  ];
+  if ($userId <= 0) return $out;
+
+  $st = $pdo->prepare("SELECT COUNT(*) FROM class_group_delegations WHERE user_id=?");
+  $st->execute([$userId]);
+  $out['delegations_open'] = (int)($st->fetchColumn() ?: 0);
+
+  $assigned = $pdo->prepare("SELECT c.id, c.school_year, c.period_label FROM classes c JOIN user_class_assignments uca ON uca.class_id=c.id WHERE uca.user_id=? AND c.is_active=1");
+  $assigned->execute([$userId]);
+  $classes = $assigned->fetchAll(PDO::FETCH_ASSOC) ?: [];
+  if (!$classes) {
+    $out['tasks_open'] = $out['delegations_open'];
+    $out['tasks_total'] = $out['delegations_open'];
+    return $out;
+  }
+
+  $now = new DateTimeImmutable('now');
+  $in48 = $now->modify('+48 hours');
+  $seen = [];
+  foreach ($classes as $c) {
+    $year = (string)($c['school_year'] ?? '');
+    $period = normalize_class_period_label((string)($c['period_label'] ?? 'Standard'));
+    $key = $year . '|' . $period;
+    if (isset($seen[$key]) || $year === '') continue;
+    $seen[$key] = true;
+    foreach (fetch_submission_deadlines($pdo, $year, $period) as $row) {
+      $due = (string)($row['due_at'] ?? '');
+      if ($due === '') continue;
+      try { $dt = new DateTimeImmutable($due); } catch (Throwable $e) { continue; }
+      if ($dt >= $now && $dt <= $in48) $out['deadlines_soon']++;
+    }
+  }
+
+  $reports = $pdo->prepare("
+    SELECT COUNT(*) AS total, SUM(CASE WHEN ri.is_finalized=1 THEN 1 ELSE 0 END) AS done
+    FROM report_instances ri
+    JOIN students s ON s.id=ri.student_id
+    JOIN classes c ON c.id=s.class_id
+    JOIN user_class_assignments uca ON uca.class_id=c.id
+    WHERE uca.user_id=? AND c.is_active=1
+  ");
+  $reports->execute([$userId]);
+  $r = $reports->fetch(PDO::FETCH_ASSOC) ?: [];
+  $total = (int)($r['total'] ?? 0);
+  $done = (int)($r['done'] ?? 0);
+  $openReports = max(0, $total - $done);
+
+  $out['tasks_open'] = $openReports + $out['delegations_open'];
+  $out['tasks_total'] = $total + $out['delegations_open'];
+  return $out;
+}
+
+function build_teacher_notification_email(string $name, array $summary): string {
+  $safeName = h($name);
+  $open = (int)($summary['tasks_open'] ?? 0);
+  $total = (int)($summary['tasks_total'] ?? 0);
+  $delegations = (int)($summary['delegations_open'] ?? 0);
+  $deadlines = (int)($summary['deadlines_soon'] ?? 0);
+  return '<div style="font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial;line-height:1.4">'
+    ."<h2>Dashboard-Benachrichtigung</h2>"
+    ."<p>Hallo {$safeName},</p>"
+    ."<p>Kurzer Überblick:</p>"
+    ."<ul><li>Offene Delegationen: <strong>{$delegations}</strong></li><li>Fristen in den nächsten 48h: <strong>{$deadlines}</strong></li><li>Offene Aufgaben gesamt: <strong>{$open} von {$total}</strong></li></ul>"
+    ."<p>Bitte prüfe dein Dashboard für Details.</p></div>";
+}
+
 function create_password_reset_token(int $userId, int $hoursValid = 1, bool $invalidateOld = true): string {
   $pdo = db();
   if ($invalidateOld) {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -2001,18 +2001,27 @@ function teacher_notification_summary(PDO $pdo, int $userId): array {
     }
   }
 
-  $reports = $pdo->prepare("
-    SELECT COUNT(*) AS total, SUM(CASE WHEN ri.is_finalized=1 THEN 1 ELSE 0 END) AS done
-    FROM report_instances ri
-    JOIN students s ON s.id=ri.student_id
-    JOIN classes c ON c.id=s.class_id
-    JOIN user_class_assignments uca ON uca.class_id=c.id
-    WHERE uca.user_id=? AND c.is_active=1
-  ");
-  $reports->execute([$userId]);
-  $r = $reports->fetch(PDO::FETCH_ASSOC) ?: [];
-  $total = (int)($r['total'] ?? 0);
-  $done = (int)($r['done'] ?? 0);
+  $total = 0;
+  $done = 0;
+  try {
+    if (db_has_table($pdo, 'report_instances') && db_has_column($pdo, 'report_instances', 'status')) {
+      $reports = $pdo->prepare("
+        SELECT COUNT(*) AS total, SUM(CASE WHEN ri.status='locked' THEN 1 ELSE 0 END) AS done
+        FROM report_instances ri
+        JOIN students s ON s.id=ri.student_id
+        JOIN classes c ON c.id=s.class_id
+        JOIN user_class_assignments uca ON uca.class_id=c.id
+        WHERE uca.user_id=? AND c.is_active=1
+      ");
+      $reports->execute([$userId]);
+      $r = $reports->fetch(PDO::FETCH_ASSOC) ?: [];
+      $total = (int)($r['total'] ?? 0);
+      $done = (int)($r['done'] ?? 0);
+    }
+  } catch (Throwable $e) {
+    $total = 0;
+    $done = 0;
+  }
   $openReports = max(0, $total - $done);
 
   $out['tasks_open'] = $openReports + $out['delegations_open'];

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1965,67 +1965,109 @@ function send_email(string $to, string $subject, string $htmlBody): bool {
 function teacher_notification_summary(PDO $pdo, int $userId): array {
   $out = [
     'delegations_open' => 0,
-    'deadlines_soon' => 0,
     'tasks_open' => 0,
     'tasks_total' => 0,
+    'classes' => [],
+    'deadlines' => [],
   ];
   if ($userId <= 0) return $out;
 
-  $st = $pdo->prepare("SELECT COUNT(*) FROM class_group_delegations WHERE user_id=? AND status='open'");
-  $st->execute([$userId]);
-  $out['delegations_open'] = (int)($st->fetchColumn() ?: 0);
+  $classesSt = $pdo->prepare(
+    "SELECT c.id, c.school_year, c.period_label, c.grade_level, c.label, c.name
+"
+    . "FROM classes c
+"
+    . "JOIN user_class_assignments uca ON uca.class_id=c.id
+"
+    . "WHERE uca.user_id=? AND c.is_active=1
+"
+    . "ORDER BY c.school_year DESC, c.grade_level DESC, c.label ASC, c.name ASC"
+  );
+  $classesSt->execute([$userId]);
+  $classes = $classesSt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+  if (!$classes) return $out;
 
-  $assigned = $pdo->prepare("SELECT c.id, c.school_year, c.period_label FROM classes c JOIN user_class_assignments uca ON uca.class_id=c.id WHERE uca.user_id=? AND c.is_active=1");
-  $assigned->execute([$userId]);
-  $classes = $assigned->fetchAll(PDO::FETCH_ASSOC) ?: [];
-  if (!$classes) {
-    $out['tasks_open'] = $out['delegations_open'];
-    $out['tasks_total'] = $out['delegations_open'];
-    return $out;
+  $classIds = array_map(static fn(array $c): int => (int)$c['id'], $classes);
+  $in = implode(',', array_fill(0, count($classIds), '?'));
+
+  $delegationMap = [];
+  $dSt = $pdo->prepare(
+    "SELECT class_id, COUNT(*) AS c FROM class_group_delegations WHERE user_id=? AND status='open' AND class_id IN ($in) GROUP BY class_id"
+  );
+  $dSt->execute(array_merge([$userId], $classIds));
+  foreach ($dSt->fetchAll(PDO::FETCH_ASSOC) as $r) $delegationMap[(int)$r['class_id']] = (int)$r['c'];
+
+  $taskTotalMap = [];
+  $taskOpenMap = [];
+  if (db_has_table($pdo, 'report_instances') && db_has_column($pdo, 'report_instances', 'status')) {
+    $tSt = $pdo->prepare(
+      "SELECT s.class_id, COUNT(*) AS total, SUM(CASE WHEN ri.status='locked' THEN 0 ELSE 1 END) AS open
+"
+      . "FROM report_instances ri
+"
+      . "JOIN students s ON s.id=ri.student_id
+"
+      . "WHERE s.class_id IN ($in)
+"
+      . "GROUP BY s.class_id"
+    );
+    $tSt->execute($classIds);
+    foreach ($tSt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+      $cid = (int)$r['class_id'];
+      $taskTotalMap[$cid] = (int)$r['total'];
+      $taskOpenMap[$cid] = (int)$r['open'];
+    }
   }
 
-  $now = new DateTimeImmutable('now');
-  $in48 = $now->modify('+48 hours');
-  $seen = [];
+  $deadlineSeen = [];
   foreach ($classes as $c) {
+    $cid = (int)$c['id'];
+    $grade = $c['grade_level'] !== null ? (int)$c['grade_level'] : null;
+    $label = trim((string)($c['label'] ?? ''));
+    $name = trim((string)($c['name'] ?? ''));
+    $classLabel = ($grade !== null && $label !== '') ? ($grade . $label) : ($name !== '' ? $name : ('#' . $cid));
     $year = (string)($c['school_year'] ?? '');
     $period = normalize_class_period_label((string)($c['period_label'] ?? 'Standard'));
-    $key = $year . '|' . $period;
-    if (isset($seen[$key]) || $year === '') continue;
-    $seen[$key] = true;
-    foreach (fetch_submission_deadlines($pdo, $year, $period) as $row) {
-      $due = (string)($row['due_at'] ?? '');
-      if ($due === '') continue;
-      try { $dt = new DateTimeImmutable($due); } catch (Throwable $e) { continue; }
-      if ($dt >= $now && $dt <= $in48) $out['deadlines_soon']++;
+
+    $delegOpen = (int)($delegationMap[$cid] ?? 0);
+    $tasksOpen = max(0, (int)($taskOpenMap[$cid] ?? 0));
+    $tasksTotal = max(0, (int)($taskTotalMap[$cid] ?? 0));
+
+    $out['delegations_open'] += $delegOpen;
+    $out['tasks_open'] += $tasksOpen;
+    $out['tasks_total'] += $tasksTotal;
+
+    $out['classes'][] = [
+      'class_id' => $cid,
+      'class_label' => $classLabel,
+      'school_year' => $year,
+      'period_label' => $period,
+      'delegations_open' => $delegOpen,
+      'tasks_open' => $tasksOpen,
+      'tasks_total' => $tasksTotal,
+    ];
+
+    $deadlineKey = $year . '|' . $period;
+    if ($year === '' || isset($deadlineSeen[$deadlineKey])) continue;
+    $deadlineSeen[$deadlineKey] = true;
+    $rows = fetch_submission_deadlines($pdo, $year, $period);
+    foreach (submission_deadline_types() as $dKey => $meta) {
+      $row = $rows[$dKey] ?? null;
+      if (!$row || empty($row['due_at'])) continue;
+      $out['deadlines'][] = [
+        'school_year' => $year,
+        'period_label' => $period,
+        'type_key' => $dKey,
+        'type_label' => (string)($meta['label'] ?? $dKey),
+        'due_at' => (string)$row['due_at'],
+      ];
     }
   }
 
-  $total = 0;
-  $done = 0;
-  try {
-    if (db_has_table($pdo, 'report_instances') && db_has_column($pdo, 'report_instances', 'status')) {
-      $reports = $pdo->prepare("
-        SELECT COUNT(*) AS total, SUM(CASE WHEN ri.status='locked' THEN 1 ELSE 0 END) AS done
-        FROM report_instances ri
-        JOIN students s ON s.id=ri.student_id
-        JOIN classes c ON c.id=s.class_id
-        JOIN user_class_assignments uca ON uca.class_id=c.id
-        WHERE uca.user_id=? AND c.is_active=1
-      ");
-      $reports->execute([$userId]);
-      $r = $reports->fetch(PDO::FETCH_ASSOC) ?: [];
-      $total = (int)($r['total'] ?? 0);
-      $done = (int)($r['done'] ?? 0);
-    }
-  } catch (Throwable $e) {
-    $total = 0;
-    $done = 0;
-  }
-  $openReports = max(0, $total - $done);
+  usort($out['deadlines'], static function(array $a, array $b): int {
+    return strcmp((string)$a['due_at'], (string)$b['due_at']);
+  });
 
-  $out['tasks_open'] = $openReports + $out['delegations_open'];
-  $out['tasks_total'] = $total + $out['delegations_open'];
   return $out;
 }
 
@@ -2034,13 +2076,45 @@ function build_teacher_notification_email(string $name, array $summary): string 
   $open = (int)($summary['tasks_open'] ?? 0);
   $total = (int)($summary['tasks_total'] ?? 0);
   $delegations = (int)($summary['delegations_open'] ?? 0);
-  $deadlines = (int)($summary['deadlines_soon'] ?? 0);
-  return '<div style="font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial;line-height:1.4">'
-    ."<h2>Dashboard-Benachrichtigung</h2>"
-    ."<p>Hallo {$safeName},</p>"
-    ."<p>Kurzer Überblick:</p>"
-    ."<ul><li>Offene Delegationen: <strong>{$delegations}</strong></li><li>Fristen in den nächsten 48h: <strong>{$deadlines}</strong></li><li>Offene Aufgaben gesamt: <strong>{$open} von {$total}</strong></li></ul>"
-    ."<p>Bitte prüfe dein Dashboard für Details.</p></div>";
+  $classes = is_array($summary['classes'] ?? null) ? $summary['classes'] : [];
+  $deadlines = is_array($summary['deadlines'] ?? null) ? $summary['deadlines'] : [];
+
+  $classRows = '';
+  foreach ($classes as $c) {
+    $classRows .= '<tr>'
+      . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h((string)($c['class_label'] ?? '')) . '</td>'
+      . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right;">' . (int)($c['delegations_open'] ?? 0) . '</td>'
+      . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;text-align:right;">' . (int)($c['tasks_open'] ?? 0) . ' / ' . (int)($c['tasks_total'] ?? 0) . '</td>'
+      . '</tr>';
+  }
+  if ($classRows === '') $classRows = '<tr><td colspan="3" style="padding:8px;color:#6b7280;">Keine Klassen zugeordnet.</td></tr>';
+
+  $deadlineRows = '';
+  foreach ($deadlines as $d) {
+    $deadlineRows .= '<tr>'
+      . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h((string)($d['type_label'] ?? '')) . '</td>'
+      . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h((string)($d['school_year'] ?? '')) . ' · ' . h((string)($d['period_label'] ?? '')) . '</td>'
+      . '<td style="padding:8px;border-bottom:1px solid #e5e7eb;">' . h(render_local_datetime((string)($d['due_at'] ?? ''), 'd.m.Y H:i', '–')) . '</td>'
+      . '</tr>';
+  }
+  if ($deadlineRows === '') $deadlineRows = '<tr><td colspan="3" style="padding:8px;color:#6b7280;">Keine Fristen gesetzt.</td></tr>';
+
+  return '<div style="font-family:Inter,Segoe UI,Arial,sans-serif;background:#f3f4f6;padding:20px;">'
+    . '<div style="max-width:760px;margin:0 auto;background:#fff;border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;">'
+    . '<div style="background:#0b57d0;color:#fff;padding:16px 20px;"><h2 style="margin:0;font-size:20px;">LEB-Tool Benachrichtigung</h2></div>'
+    . '<div style="padding:18px 20px;color:#111827;line-height:1.5;">'
+    . '<p style="margin:0 0 10px;">Hallo ' . $safeName . ',</p>'
+    . '<p style="margin:0 0 16px;">hier ist dein aktueller Überblick:</p>'
+    . '<div style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:16px;">'
+    . '<span style="background:#e8f0fe;color:#0b57d0;border-radius:999px;padding:6px 10px;font-size:13px;">Offene Delegationen: <strong>' . $delegations . '</strong></span>'
+    . '<span style="background:#eefbf2;color:#1e8e3e;border-radius:999px;padding:6px 10px;font-size:13px;">Offene Lehrkrafteingaben: <strong>' . $open . ' / ' . $total . '</strong></span>'
+    . '</div>'
+    . '<h3 style="margin:16px 0 8px;font-size:16px;">Nach Klasse</h3>'
+    . '<table style="width:100%;border-collapse:collapse;font-size:14px;"><thead><tr><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">Klasse</th><th style="text-align:right;padding:8px;border-bottom:2px solid #e5e7eb;">Delegationen offen</th><th style="text-align:right;padding:8px;border-bottom:2px solid #e5e7eb;">Lehrkrafteingaben offen</th></tr></thead><tbody>' . $classRows . '</tbody></table>'
+    . '<h3 style="margin:18px 0 8px;font-size:16px;">Alle Fristen</h3>'
+    . '<table style="width:100%;border-collapse:collapse;font-size:14px;"><thead><tr><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">Bereich</th><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">Schuljahr · Halbjahr</th><th style="text-align:left;padding:8px;border-bottom:2px solid #e5e7eb;">Fällig am</th></tr></thead><tbody>' . $deadlineRows . '</tbody></table>'
+    . '<p style="margin:16px 0 0;color:#6b7280;font-size:12px;">Diese Nachricht wurde automatisch vom LEB-Tool erzeugt.</p>'
+    . '</div></div></div>';
 }
 
 function create_password_reset_token(int $userId, int $hoursValid = 1, bool $invalidateOld = true): string {

--- a/cron/teacher_notifications.php
+++ b/cron/teacher_notifications.php
@@ -15,7 +15,7 @@ if (!db_has_table($pdo, 'teacher_notification_preferences')) {
   cron_log_line('preferences table missing');
   exit(0);
 }
-$st = $pdo->query("SELECT p.user_id, p.confirmation_pending, p.notification_lang, u.email, u.display_name FROM teacher_notification_preferences p JOIN users u ON u.id=p.user_id WHERE p.wants_email=1 AND u.is_active=1 AND u.deleted_at IS NULL");
+$st = $pdo->query("SELECT p.user_id, p.confirmation_pending, p.notification_lang, p.last_summary_hash, p.last_email_sent_at, u.email, u.display_name FROM teacher_notification_preferences p JOIN users u ON u.id=p.user_id WHERE p.wants_email=1 AND u.is_active=1 AND u.deleted_at IS NULL");
 $rows = $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
 $sent = 0;
 foreach ($rows as $r) {
@@ -26,13 +26,26 @@ foreach ($rows as $r) {
   $hasDeadlines = !empty($summary['deadlines'] ?? []);
   if ((int)($summary['tasks_open'] ?? 0) <= 0 && (int)($summary['delegations_open'] ?? 0) <= 0 && !$hasDeadlines && (int)($r['confirmation_pending'] ?? 0) !== 1) continue;
   $lang = in_array((string)($r['notification_lang'] ?? 'de'), ['de','en'], true) ? (string)$r['notification_lang'] : 'de';
-  $subject = ((int)($r['confirmation_pending'] ?? 0) === 1)
+  $summaryHash = hash('sha256', json_encode($summary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . '|' . $lang);
+  $lastHash = (string)($r['last_summary_hash'] ?? '');
+  $lastSentAt = trim((string)($r['last_email_sent_at'] ?? ''));
+  $isConfirm = ((int)($r['confirmation_pending'] ?? 0) === 1);
+  if (!$isConfirm && $lastHash !== '' && hash_equals($lastHash, $summaryHash) && $lastSentAt !== '') {
+    try {
+      $lastDt = new DateTimeImmutable($lastSentAt);
+      $nextAllowed = $lastDt->modify('+7 days');
+      if ($nextAllowed > new DateTimeImmutable('now')) continue;
+    } catch (Throwable $e) {
+      // ignore parse errors and continue sending
+    }
+  }
+  $subject = $isConfirm
     ? ($lang === 'en' ? 'Confirmation: email notifications enabled' : 'Bestätigung: E-Mail-Benachrichtigungen aktiviert')
     : ($lang === 'en' ? 'LEB Tool: new hints and open tasks' : 'LEB-Tool: Neue Hinweise und offene Aufgaben');
   $body = build_teacher_notification_email((string)($r['display_name'] ?? 'Lehrkraft'), $summary, $lang);
   if (send_email($email, $subject, $body)) {
-    $upd = $pdo->prepare("UPDATE teacher_notification_preferences SET confirmation_pending=0, last_email_sent_at=NOW() WHERE user_id=?");
-    $upd->execute([$userId]);
+    $upd = $pdo->prepare("UPDATE teacher_notification_preferences SET confirmation_pending=0, last_summary_hash=?, last_email_sent_at=NOW() WHERE user_id=?");
+    $upd->execute([$summaryHash, $userId]);
     $sent++;
   }
 }

--- a/cron/teacher_notifications.php
+++ b/cron/teacher_notifications.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../bootstrap.php';
+$pdo = db();
+if (!db_has_table($pdo, 'teacher_notification_preferences')) {
+  fwrite(STDOUT, "preferences table missing\n");
+  exit(0);
+}
+$st = $pdo->query("SELECT p.user_id, p.confirmation_pending, u.email, u.display_name FROM teacher_notification_preferences p JOIN users u ON u.id=p.user_id WHERE p.wants_email=1 AND u.is_active=1 AND u.deleted_at IS NULL");
+$rows = $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
+$sent = 0;
+foreach ($rows as $r) {
+  $userId = (int)$r['user_id'];
+  $email = trim((string)($r['email'] ?? ''));
+  if (!filter_var($email, FILTER_VALIDATE_EMAIL)) continue;
+  $summary = teacher_notification_summary($pdo, $userId);
+  if ((int)($summary['tasks_open'] ?? 0) <= 0 && (int)($r['confirmation_pending'] ?? 0) !== 1) continue;
+  $subject = ((int)($r['confirmation_pending'] ?? 0) === 1)
+    ? 'Bestätigung: E-Mail-Benachrichtigungen aktiviert'
+    : 'LEB-Tool: Neue Hinweise und offene Aufgaben';
+  $body = build_teacher_notification_email((string)($r['display_name'] ?? 'Lehrkraft'), $summary);
+  if (send_email($email, $subject, $body)) {
+    $upd = $pdo->prepare("UPDATE teacher_notification_preferences SET confirmation_pending=0, last_email_sent_at=NOW() WHERE user_id=?");
+    $upd->execute([$userId]);
+    $sent++;
+  }
+}
+fwrite(STDOUT, "sent={$sent}\n");

--- a/cron/teacher_notifications.php
+++ b/cron/teacher_notifications.php
@@ -2,8 +2,17 @@
 declare(strict_types=1);
 require __DIR__ . '/../bootstrap.php';
 $pdo = db();
+
+function cron_log_line(string $msg): void {
+  if (PHP_SAPI === 'cli' && defined('STDOUT')) {
+    fwrite(STDOUT, $msg . "\n");
+    return;
+  }
+  echo $msg . "\n";
+}
+
 if (!db_has_table($pdo, 'teacher_notification_preferences')) {
-  fwrite(STDOUT, "preferences table missing\n");
+  cron_log_line('preferences table missing');
   exit(0);
 }
 $st = $pdo->query("SELECT p.user_id, p.confirmation_pending, u.email, u.display_name FROM teacher_notification_preferences p JOIN users u ON u.id=p.user_id WHERE p.wants_email=1 AND u.is_active=1 AND u.deleted_at IS NULL");
@@ -25,4 +34,4 @@ foreach ($rows as $r) {
     $sent++;
   }
 }
-fwrite(STDOUT, "sent={$sent}\n");
+cron_log_line("sent={$sent}");

--- a/cron/teacher_notifications.php
+++ b/cron/teacher_notifications.php
@@ -15,7 +15,7 @@ if (!db_has_table($pdo, 'teacher_notification_preferences')) {
   cron_log_line('preferences table missing');
   exit(0);
 }
-$st = $pdo->query("SELECT p.user_id, p.confirmation_pending, u.email, u.display_name FROM teacher_notification_preferences p JOIN users u ON u.id=p.user_id WHERE p.wants_email=1 AND u.is_active=1 AND u.deleted_at IS NULL");
+$st = $pdo->query("SELECT p.user_id, p.confirmation_pending, p.notification_lang, u.email, u.display_name FROM teacher_notification_preferences p JOIN users u ON u.id=p.user_id WHERE p.wants_email=1 AND u.is_active=1 AND u.deleted_at IS NULL");
 $rows = $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
 $sent = 0;
 foreach ($rows as $r) {
@@ -25,10 +25,11 @@ foreach ($rows as $r) {
   $summary = teacher_notification_summary($pdo, $userId);
   $hasDeadlines = !empty($summary['deadlines'] ?? []);
   if ((int)($summary['tasks_open'] ?? 0) <= 0 && (int)($summary['delegations_open'] ?? 0) <= 0 && !$hasDeadlines && (int)($r['confirmation_pending'] ?? 0) !== 1) continue;
+  $lang = in_array((string)($r['notification_lang'] ?? 'de'), ['de','en'], true) ? (string)$r['notification_lang'] : 'de';
   $subject = ((int)($r['confirmation_pending'] ?? 0) === 1)
-    ? 'Bestätigung: E-Mail-Benachrichtigungen aktiviert'
-    : 'LEB-Tool: Neue Hinweise und offene Aufgaben';
-  $body = build_teacher_notification_email((string)($r['display_name'] ?? 'Lehrkraft'), $summary);
+    ? ($lang === 'en' ? 'Confirmation: email notifications enabled' : 'Bestätigung: E-Mail-Benachrichtigungen aktiviert')
+    : ($lang === 'en' ? 'LEB Tool: new hints and open tasks' : 'LEB-Tool: Neue Hinweise und offene Aufgaben');
+  $body = build_teacher_notification_email((string)($r['display_name'] ?? 'Lehrkraft'), $summary, $lang);
   if (send_email($email, $subject, $body)) {
     $upd = $pdo->prepare("UPDATE teacher_notification_preferences SET confirmation_pending=0, last_email_sent_at=NOW() WHERE user_id=?");
     $upd->execute([$userId]);

--- a/cron/teacher_notifications.php
+++ b/cron/teacher_notifications.php
@@ -23,7 +23,8 @@ foreach ($rows as $r) {
   $email = trim((string)($r['email'] ?? ''));
   if (!filter_var($email, FILTER_VALIDATE_EMAIL)) continue;
   $summary = teacher_notification_summary($pdo, $userId);
-  if ((int)($summary['tasks_open'] ?? 0) <= 0 && (int)($r['confirmation_pending'] ?? 0) !== 1) continue;
+  $hasDeadlines = !empty($summary['deadlines'] ?? []);
+  if ((int)($summary['tasks_open'] ?? 0) <= 0 && (int)($summary['delegations_open'] ?? 0) <= 0 && !$hasDeadlines && (int)($r['confirmation_pending'] ?? 0) !== 1) continue;
   $subject = ((int)($r['confirmation_pending'] ?? 0) === 1)
     ? 'Bestätigung: E-Mail-Benachrichtigungen aktiviert'
     : 'LEB-Tool: Neue Hinweise und offene Aufgaben';

--- a/teacher/ajax/notification_settings_api.php
+++ b/teacher/ajax/notification_settings_api.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../../bootstrap.php';
+require_teacher();
+header('Content-Type: application/json; charset=utf-8');
+$pdo = db();
+$u = current_user();
+$userId = (int)($u['id'] ?? 0);
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  echo json_encode(['ok'=>false]);
+  exit;
+}
+$raw = json_decode(file_get_contents('php://input') ?: '{}', true);
+$enabled = !empty($raw['enabled']) ? 1 : 0;
+$st = $pdo->prepare("INSERT INTO teacher_notification_preferences (user_id,wants_email,confirmation_pending,last_email_sent_at) VALUES (?,?,?,NULL)
+ON DUPLICATE KEY UPDATE wants_email=VALUES(wants_email), confirmation_pending=VALUES(confirmation_pending)");
+$st->execute([$userId, $enabled, $enabled]);
+audit('teacher_notification_pref_update', $userId, ['wants_email'=>$enabled]);
+echo json_encode(['ok'=>true,'enabled'=>(bool)$enabled]);

--- a/teacher/ajax/notification_settings_api.php
+++ b/teacher/ajax/notification_settings_api.php
@@ -12,6 +12,10 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   exit;
 }
 $raw = json_decode(file_get_contents('php://input') ?: '{}', true);
+if (!is_array($raw)) $raw = [];
+if (!isset($_POST['csrf_token']) && isset($raw['csrf_token'])) $_POST['csrf_token'] = (string)$raw['csrf_token'];
+if (!isset($_POST['csrf_token']) && isset($_SERVER['HTTP_X_CSRF_TOKEN'])) $_POST['csrf_token'] = (string)$_SERVER['HTTP_X_CSRF_TOKEN'];
+csrf_verify();
 $enabled = !empty($raw['enabled']) ? 1 : 0;
 $st = $pdo->prepare("INSERT INTO teacher_notification_preferences (user_id,wants_email,confirmation_pending,last_email_sent_at) VALUES (?,?,?,NULL)
 ON DUPLICATE KEY UPDATE wants_email=VALUES(wants_email), confirmation_pending=VALUES(confirmation_pending)");

--- a/teacher/ajax/notification_settings_api.php
+++ b/teacher/ajax/notification_settings_api.php
@@ -17,8 +17,10 @@ if (!isset($_POST['csrf_token']) && isset($raw['csrf_token'])) $_POST['csrf_toke
 if (!isset($_POST['csrf_token']) && isset($_SERVER['HTTP_X_CSRF_TOKEN'])) $_POST['csrf_token'] = (string)$_SERVER['HTTP_X_CSRF_TOKEN'];
 csrf_verify();
 $enabled = !empty($raw['enabled']) ? 1 : 0;
-$st = $pdo->prepare("INSERT INTO teacher_notification_preferences (user_id,wants_email,confirmation_pending,last_email_sent_at) VALUES (?,?,?,NULL)
-ON DUPLICATE KEY UPDATE wants_email=VALUES(wants_email), confirmation_pending=VALUES(confirmation_pending)");
-$st->execute([$userId, $enabled, $enabled]);
-audit('teacher_notification_pref_update', $userId, ['wants_email'=>$enabled]);
-echo json_encode(['ok'=>true,'enabled'=>(bool)$enabled]);
+$lang = strtolower(trim((string)($raw['lang'] ?? 'de')));
+if (!in_array($lang, ['de','en'], true)) $lang = 'de';
+$st = $pdo->prepare("INSERT INTO teacher_notification_preferences (user_id,wants_email,notification_lang,confirmation_pending,last_email_sent_at) VALUES (?,?,?,?,NULL)
+ON DUPLICATE KEY UPDATE wants_email=VALUES(wants_email), notification_lang=VALUES(notification_lang), confirmation_pending=VALUES(confirmation_pending)");
+$st->execute([$userId, $enabled, $lang, $enabled]);
+audit('teacher_notification_pref_update', $userId, ['wants_email'=>$enabled, 'notification_lang'=>$lang]);
+echo json_encode(['ok'=>true,'enabled'=>(bool)$enabled,'lang'=>$lang]);

--- a/teacher/index.php
+++ b/teacher/index.php
@@ -7,6 +7,7 @@ require_teacher();
 $pdo = db();
 $u = current_user();
 $userId = (int)($u['id'] ?? 0);
+$notifyPrefEnabled = false;
 
 function meta_read(?string $json): array {
   if (!$json) return [];
@@ -61,6 +62,15 @@ function period_label_display(?string $raw): string {
     ? t('admin.classes.period.h2', '2. Halbjahr')
     : t('admin.classes.period.h1', '1. Halbjahr');
 }
+
+// Mail notification preference
+if (db_has_table($pdo, 'teacher_notification_preferences')) {
+  $pst = $pdo->prepare("SELECT wants_email FROM teacher_notification_preferences WHERE user_id=? LIMIT 1");
+  $pst->execute([$userId]);
+  $notifyPrefEnabled = ((int)($pst->fetchColumn() ?: 0) === 1);
+}
+
+$dashboardSummary = teacher_notification_summary($pdo, $userId);
 
 // Delegations inbox count (groups delegated to this teacher)
 $delegationCount = 0;
@@ -840,6 +850,19 @@ render_teacher_header(t('teacher.title'));
   <?php endif; ?>
 </div>
 
+
+<?php if (($dashboardSummary['delegations_open'] ?? 0) > 0 || ($dashboardSummary['deadlines_soon'] ?? 0) > 0): ?>
+  <div class="card">
+    <h2>Benachrichtigungen</h2>
+    <p class="muted">Es gibt neue Hinweise auf deinem Dashboard.</p>
+    <ul>
+      <li>Offene Delegationen: <strong><?=h((string)($dashboardSummary['delegations_open'] ?? 0))?></strong></li>
+      <li>Fristen in den nächsten 48h: <strong><?=h((string)($dashboardSummary['deadlines_soon'] ?? 0))?></strong></li>
+      <li>Offene Aufgaben gesamt: <strong><?=h((string)($dashboardSummary['tasks_open'] ?? 0))?> von <?=h((string)($dashboardSummary['tasks_total'] ?? 0))?></strong></li>
+    </ul>
+  </div>
+<?php endif; ?>
+
 <div class="card">
   <h2><?=h(t('teacher.management'))?></h2>
   <p class="muted"><?=h(t('teacher.management_hint'))?></p>
@@ -912,6 +935,41 @@ render_teacher_header(t('teacher.title'));
     <?php endif; ?>
   </div>
 <?php endif; ?>
+
+
+<div class="card" id="mail-pref-card">
+  <h2>E-Mail-Benachrichtigungen</h2>
+  <p class="muted">Wenn aktiviert, versendet der Cronjob Benachrichtigungen zu Delegationen und nahenden Fristen.</p>
+  <label style="display:flex;gap:10px;align-items:center;">
+    <input type="checkbox" id="mail_pref_toggle" <?= $notifyPrefEnabled ? 'checked' : '' ?>>
+    E-Mails erhalten
+  </label>
+  <p class="small muted" id="mail_pref_status"></p>
+</div>
+<script>
+(function(){
+  const el = document.getElementById('mail_pref_toggle');
+  const status = document.getElementById('mail_pref_status');
+  if (!el) return;
+  el.addEventListener('change', async () => {
+    status.textContent = 'Speichere …';
+    try {
+      const res = await fetch('ajax/notification_settings_api.php', {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({enabled: el.checked})
+      });
+      const data = await res.json();
+      if (!data.ok) throw new Error('save_failed');
+      status.textContent = el.checked
+        ? 'Aktiviert. Eine Bestätigungs-E-Mail wird über den Cronjob versendet.'
+        : 'Deaktiviert. Es werden keine E-Mails mehr versendet.';
+    } catch (e) {
+      status.textContent = 'Speichern fehlgeschlagen.';
+    }
+  });
+})();
+</script>
 
 <?php
 render_teacher_footer();

--- a/teacher/index.php
+++ b/teacher/index.php
@@ -851,15 +851,31 @@ render_teacher_header(t('teacher.title'));
 </div>
 
 
-<?php if (($dashboardSummary['delegations_open'] ?? 0) > 0 || ($dashboardSummary['deadlines_soon'] ?? 0) > 0): ?>
+<?php if (($dashboardSummary['delegations_open'] ?? 0) > 0 || ($dashboardSummary['tasks_open'] ?? 0) > 0 || !empty($dashboardSummary['deadlines'])): ?>
   <div class="card">
     <h2>Benachrichtigungen</h2>
     <p class="muted">Es gibt neue Hinweise auf deinem Dashboard.</p>
     <ul>
       <li>Offene Delegationen: <strong><?=h((string)($dashboardSummary['delegations_open'] ?? 0))?></strong></li>
-      <li>Fristen in den nächsten 48h: <strong><?=h((string)($dashboardSummary['deadlines_soon'] ?? 0))?></strong></li>
-      <li>Offene Aufgaben gesamt: <strong><?=h((string)($dashboardSummary['tasks_open'] ?? 0))?> von <?=h((string)($dashboardSummary['tasks_total'] ?? 0))?></strong></li>
+      <li>Offene Lehrkrafteingaben gesamt: <strong><?=h((string)($dashboardSummary['tasks_open'] ?? 0))?> von <?=h((string)($dashboardSummary['tasks_total'] ?? 0))?></strong></li>
+      <li>Fristen gesamt: <strong><?=h((string)count((array)($dashboardSummary['deadlines'] ?? [])))?></strong></li>
     </ul>
+    <?php if (!empty($dashboardSummary['classes'])): ?>
+      <div class="table-wrap" style="margin-top:10px;">
+        <table>
+          <thead><tr><th>Klasse</th><th>Delegationen offen</th><th>Lehrkrafteingaben offen</th></tr></thead>
+          <tbody>
+            <?php foreach ((array)$dashboardSummary['classes'] as $row): ?>
+              <tr>
+                <td><?=h((string)($row['class_label'] ?? ''))?></td>
+                <td><?=h((string)($row['delegations_open'] ?? 0))?></td>
+                <td><?=h((string)($row['tasks_open'] ?? 0))?> / <?=h((string)($row['tasks_total'] ?? 0))?></td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php endif; ?>
   </div>
 <?php endif; ?>
 

--- a/teacher/index.php
+++ b/teacher/index.php
@@ -8,6 +8,7 @@ $pdo = db();
 $u = current_user();
 $userId = (int)($u['id'] ?? 0);
 $notifyPrefEnabled = false;
+$notifyPrefLang = 'de';
 
 function meta_read(?string $json): array {
   if (!$json) return [];
@@ -65,9 +66,11 @@ function period_label_display(?string $raw): string {
 
 // Mail notification preference
 if (db_has_table($pdo, 'teacher_notification_preferences')) {
-  $pst = $pdo->prepare("SELECT wants_email FROM teacher_notification_preferences WHERE user_id=? LIMIT 1");
+  $pst = $pdo->prepare("SELECT wants_email, notification_lang FROM teacher_notification_preferences WHERE user_id=? LIMIT 1");
   $pst->execute([$userId]);
-  $notifyPrefEnabled = ((int)($pst->fetchColumn() ?: 0) === 1);
+  $pr = $pst->fetch(PDO::FETCH_ASSOC) ?: [];
+  $notifyPrefEnabled = ((int)($pr['wants_email'] ?? 0) === 1);
+  $notifyPrefLang = in_array((string)($pr['notification_lang'] ?? 'de'), ['de','en'], true) ? (string)$pr['notification_lang'] : 'de';
 }
 
 $dashboardSummary = teacher_notification_summary($pdo, $userId);
@@ -959,11 +962,19 @@ render_teacher_header(t('teacher.title'));
     <input type="checkbox" id="mail_pref_toggle" <?= $notifyPrefEnabled ? 'checked' : '' ?>>
     E-Mails erhalten
   </label>
+  <div style="margin-top:8px;">
+    <label for="mail_pref_lang">Sprache der E-Mail</label>
+    <select id="mail_pref_lang">
+      <option value="de" <?= $notifyPrefLang === 'de' ? 'selected' : '' ?>>Deutsch</option>
+      <option value="en" <?= $notifyPrefLang === 'en' ? 'selected' : '' ?>>English</option>
+    </select>
+  </div>
   <p class="small muted" id="mail_pref_status"></p>
 </div>
 <script>
 (function(){
   const el = document.getElementById('mail_pref_toggle');
+  const langEl = document.getElementById('mail_pref_lang');
   const status = document.getElementById('mail_pref_status');
   const csrf = <?=json_encode(csrf_token())?>;
   if (!el) return;
@@ -973,7 +984,7 @@ render_teacher_header(t('teacher.title'));
       const res = await fetch('ajax/notification_settings_api.php', {
         method: 'POST',
         headers: {'Content-Type':'application/json', 'X-CSRF-Token': csrf},
-        body: JSON.stringify({enabled: el.checked, csrf_token: csrf})
+        body: JSON.stringify({enabled: el.checked, lang: (langEl ? langEl.value : 'de'), csrf_token: csrf})
       });
       const data = await res.json();
       if (!data.ok) throw new Error('save_failed');
@@ -984,6 +995,9 @@ render_teacher_header(t('teacher.title'));
       status.textContent = 'Speichern fehlgeschlagen.';
     }
   });
+  if (langEl) {
+    langEl.addEventListener('change', () => el.dispatchEvent(new Event('change')));
+  }
 })();
 </script>
 

--- a/teacher/index.php
+++ b/teacher/index.php
@@ -75,7 +75,7 @@ $dashboardSummary = teacher_notification_summary($pdo, $userId);
 // Delegations inbox count (groups delegated to this teacher)
 $delegationCount = 0;
 try {
-  $st = $pdo->prepare("SELECT COUNT(*) FROM class_group_delegations WHERE user_id=?");
+  $st = $pdo->prepare("SELECT COUNT(*) FROM class_group_delegations WHERE user_id=? AND status='open'");
   $st->execute([$userId]);
   $delegationCount = (int)($st->fetchColumn() ?: 0);
 } catch (Throwable $e) {
@@ -852,13 +852,12 @@ render_teacher_header(t('teacher.title'));
 
 
 <?php if (($dashboardSummary['delegations_open'] ?? 0) > 0 || ($dashboardSummary['tasks_open'] ?? 0) > 0 || !empty($dashboardSummary['deadlines'])): ?>
-  <div class="card">
+  <div class="card" style="background:#fff8db;border-color:#f2cc60;">
     <h2>Benachrichtigungen</h2>
     <p class="muted">Es gibt neue Hinweise auf deinem Dashboard.</p>
     <ul>
       <li>Offene Delegationen: <strong><?=h((string)($dashboardSummary['delegations_open'] ?? 0))?></strong></li>
       <li>Offene Lehrkrafteingaben gesamt: <strong><?=h((string)($dashboardSummary['tasks_open'] ?? 0))?> von <?=h((string)($dashboardSummary['tasks_total'] ?? 0))?></strong></li>
-      <li>Fristen gesamt: <strong><?=h((string)count((array)($dashboardSummary['deadlines'] ?? [])))?></strong></li>
     </ul>
     <?php if (!empty($dashboardSummary['classes'])): ?>
       <div class="table-wrap" style="margin-top:10px;">

--- a/teacher/index.php
+++ b/teacher/index.php
@@ -950,14 +950,15 @@ render_teacher_header(t('teacher.title'));
 (function(){
   const el = document.getElementById('mail_pref_toggle');
   const status = document.getElementById('mail_pref_status');
+  const csrf = <?=json_encode(csrf_token())?>;
   if (!el) return;
   el.addEventListener('change', async () => {
     status.textContent = 'Speichere …';
     try {
       const res = await fetch('ajax/notification_settings_api.php', {
         method: 'POST',
-        headers: {'Content-Type':'application/json'},
-        body: JSON.stringify({enabled: el.checked})
+        headers: {'Content-Type':'application/json', 'X-CSRF-Token': csrf},
+        body: JSON.stringify({enabled: el.checked, csrf_token: csrf})
       });
       const data = await res.json();
       if (!data.ok) throw new Error('save_failed');


### PR DESCRIPTION
### Motivation
- Provide teachers with timely notifications for delegated tasks and upcoming submission deadlines and allow optional email delivery even when not on the site. 
- Ensure the opt-in setting is saved without reloading the page and that activation triggers a one-time confirmation email (via the cron path) to validate delivery.

### Description
- Add persistent preference storage and bootstrap schema `teacher_notification_preferences` to record `wants_email`, `confirmation_pending` and `last_email_sent_at` in `ensure_schema` in `bootstrap.php`.
- Add backend helpers `teacher_notification_summary(PDO,int)` and `build_teacher_notification_email(string,array)` in `bootstrap.php` to compute dashboard summaries and render the notification email body.
- Add an AJAX endpoint `teacher/ajax/notification_settings_api.php` that stores the opt-in toggle and sets `confirmation_pending` on enable, allowing saving without a page reload.
- Add a cron script `cron/teacher_notifications.php` that sends one-time confirmation mails and recurring summary emails and clears `confirmation_pending` / updates `last_email_sent_at` on success.
- Add a dashboard notification card and a mail opt-in checkbox (with client-side `fetch` POST to the API) to `teacher/index.php` to show the short overview and allow toggling email notifications.

### Testing
- Ran PHP syntax checks with `php -l bootstrap.php`, `php -l teacher/index.php`, `php -l teacher/ajax/notification_settings_api.php`, and `php -l cron/teacher_notifications.php`, all of which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f05c19860832ea7a8a5bbbd54fbac)