### PR TITLE
Add DB-backed competency catalog and LaTeX PDF builder with admin/teacher UIs

### DIFF
--- a/admin/build.php
+++ b/admin/build.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+require_admin();
+
+require __DIR__ . '/../shared/build.php';

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -306,18 +306,14 @@ modal.addEventListener('cancel',(e)=>{e.preventDefault(); document.getElementByI
 
 let dragEl=null;
 function initDnd(){
-  console.debug('[competencies dnd] bind draggables',
-    Array.from(document.querySelectorAll('.draggable')).map(el => ({ type: el.dataset.type, id: el.dataset.id, itemType: el.dataset.itemType, itemId: el.dataset.itemId }))
-  );
   document.querySelectorAll('.draggable').forEach(el=>{el.ondragstart=(e)=>{ 
     e.stopPropagation();
     const type = el.dataset.type;
-    const id = Number(el.dataset.id || 0);
     if(type!=='category' && type!=='subcategory') return;
     dragEl=el;
     document.body.classList.remove('is-dragging-category','is-dragging-subcategory');
     document.body.classList.add(type==='category'?'is-dragging-category':'is-dragging-subcategory');
-    console.debug('[competencies dnd] start', { type, id });
+    if(type==='category') console.debug('[competencies dnd category] start', Number(el.dataset.id));
     if(type==='subcategory') console.debug('[competencies dnd subcategory] start', Number(el.dataset.id), Number(el.dataset.parent||0));
   }; el.ondragend=(e)=>{e.stopPropagation(); dragEl=null; document.body.classList.remove('is-dragging-category','is-dragging-subcategory'); document.querySelectorAll('.dnd-placeholder-category,.dnd-placeholder-subcategory').forEach(d=>d.classList.remove('active'));};});
   document.querySelectorAll('.dnd-placeholder-category').forEach(d=>{
@@ -333,7 +329,7 @@ function initDnd(){
       if(beforeId===itemId) return;
       let orderedIds=stateTree.map(c=>Number(c.id)).filter(x=>x!==itemId);
       if(beforeId>0){ const i=orderedIds.indexOf(beforeId); if(i>=0) orderedIds.splice(i,0,itemId); else orderedIds.push(itemId);} else { orderedIds.push(itemId); }
-      if(itemId===beforeId || orderedIds.join(',')===currentIds.join(',')) return;
+      if(orderedIds.join(',')===currentIds.join(',')) return;
       console.debug('[competencies dnd category] drop', {itemId,beforeId:beforeIdRaw,orderedIds});
       try{ const res=await api({action:'reorder',type:'category',id:String(itemId),ordered_ids:JSON.stringify(orderedIds)}); stateTree=res.tree; render(); }
       catch(err){ showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render(); }

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -162,8 +162,13 @@ if($_SERVER['REQUEST_METHOD']==='POST' && isset($_SERVER['HTTP_X_REQUESTED_WITH'
         foreach($ordered as $pos=>$x){$pdo->prepare("UPDATE competency_categories SET sort_order=? WHERE id=?")->execute([$pos+1,$x]);}
       } elseif($type==='subcategory'){
         if($newParent<=0) bad('Kategorie als Parent erforderlich');
+        $st=$pdo->prepare("SELECT category_id FROM competency_subcategories WHERE id=?"); $st->execute([$id]); $oldParent=(int)($st->fetchColumn()?:0);
+        $st=$pdo->query("SELECT id FROM competency_subcategories"); $validSub=array_map('intval',$st->fetchAll(PDO::FETCH_COLUMN)?:[]);
+        foreach($ordered as $x){ if(!in_array((int)$x,$validSub,true)) bad('Ungültige Unterkategorie-ID in ordered_ids'); }
         $pdo->prepare("UPDATE competency_subcategories SET category_id=? WHERE id=?")->execute([$newParent,$id]);
-        foreach($ordered as $x){$pdo->prepare("UPDATE competency_subcategories SET category_id=?, sort_order=? WHERE id=?")->execute([$newParent,array_search($x,$ordered,true)+1,$x]);}
+        foreach($ordered as $pos=>$x){$pdo->prepare("UPDATE competency_subcategories SET category_id=?, sort_order=? WHERE id=?")->execute([$newParent,$pos+1,$x]);}
+        if($oldParent>0 && $oldParent!==$newParent){ normalize_order($pdo,'competency_subcategories','category_id=?',[$oldParent]); }
+        normalize_order($pdo,'competency_subcategories','category_id=?',[$newParent]);
       } elseif($type==='competency'){
         if($newParent<=0) bad('Unterkategorie als Parent erforderlich');
         $st=$pdo->prepare("SELECT category_id FROM competency_subcategories WHERE id=?");$st->execute([$newParent]);$cat=(int)($st->fetchColumn()?:0); if($cat<=0) bad('Ziel-Unterkategorie nicht gefunden');
@@ -239,8 +244,17 @@ function renderCategory(c){
   const wrap=document.createElement('div'); wrap.dataset.itemType='category'; wrap.dataset.itemId=String(c.id); wrap.className='tree-node category-node draggable'; wrap.draggable=true; wrap.dataset.type='category'; wrap.dataset.id=String(c.id);
   wrap.innerHTML=`<div class="node-head"><span class="node-title">${hasChildren?`<button data-act="toggle" data-node="${nodeKey}" style="border:0;background:none;cursor:pointer">${isCollapsed?'▸':'▾'}</button>`:''}${escapeHtml(c.name_de)} <small>${escapeHtml(c.name_en)}</small></span><span class="node-actions"><button data-act="addSub" data-id="${c.id}">＋</button><button data-act="edit" data-type="category" data-id="${c.id}">✏️</button><button data-act="del" data-type="category" data-id="${c.id}">🗑️</button></span></div>`;
   const subList=document.createElement('div'); subList.className='children'; subList.dataset.dndList='subcategories'; subList.dataset.categoryId=String(c.id); subList.style.display=isCollapsed?'none':'';
-  subList.appendChild(mkDrop('subcategory','0',{parent:c.id}));
-  (c.children||[]).forEach(s=>{ subList.appendChild(renderSub(s,c.id)); subList.appendChild(mkDrop('subcategory','0',{parent:c.id})); });
+  const realSubs=(c.children||[]).filter(x=>!x.is_virtual);
+  const virtualSubs=(c.children||[]).filter(x=>!!x.is_virtual);
+  const firstReal=realSubs[0] ? String(realSubs[0].id) : '';
+  subList.appendChild(mkDrop('subcategory', firstReal || '0', {dropType:'subcategory', parent:c.id, beforeId:firstReal}));
+  realSubs.forEach((s,idx)=>{ 
+    subList.appendChild(renderSub(s,c.id)); 
+    const nextId = realSubs[idx+1] ? String(realSubs[idx+1].id) : '';
+    subList.appendChild(mkDrop('subcategory', nextId || '0', {dropType:'subcategory', parent:c.id, beforeId:nextId}));
+  });
+  console.debug('[competencies dnd subcategory] render subcategory dropzones', c.id, realSubs.map(s=>s.id));
+  virtualSubs.forEach(s=>subList.appendChild(renderSub(s,c.id)));
   wrap.appendChild(subList);
   return wrap;
 }
@@ -281,7 +295,12 @@ modal.addEventListener('cancel',(e)=>{e.preventDefault(); document.getElementByI
 
 let dragEl=null;
 function initDnd(){
-  document.querySelectorAll('.draggable').forEach(el=>{el.ondragstart=()=>{ if(el.dataset.type!=='category') return; dragEl=el; console.debug('[competencies dnd category] start', Number(el.dataset.id));}; el.ondragend=()=>{dragEl=null; document.querySelectorAll('.dnd-placeholder-category').forEach(d=>d.classList.remove('active'));};});
+  document.querySelectorAll('.draggable').forEach(el=>{el.ondragstart=()=>{ 
+    if(el.dataset.type!=='category' && el.dataset.type!=='subcategory') return;
+    dragEl=el; 
+    if(el.dataset.type==='category') console.debug('[competencies dnd category] start', Number(el.dataset.id));
+    if(el.dataset.type==='subcategory') console.debug('[competencies dnd subcategory] start', Number(el.dataset.id), Number(el.dataset.parent||0));
+  }; el.ondragend=()=>{dragEl=null; document.querySelectorAll('.dnd-placeholder-category,.dnd-placeholder-subcategory').forEach(d=>d.classList.remove('active'));};});
   document.querySelectorAll('.dnd-placeholder-category').forEach(d=>{
     d.ondragover=(e)=>{ if(!dragEl || dragEl.dataset.type!=='category') return; if(d.dataset.dropType!=='category') return; e.preventDefault(); d.classList.add('active'); };
     d.ondragleave=()=>d.classList.remove('active');
@@ -295,6 +314,26 @@ function initDnd(){
       if(beforeId>0){ const i=orderedIds.indexOf(beforeId); if(i>=0) orderedIds.splice(i,0,itemId); else orderedIds.push(itemId);} else { orderedIds.push(itemId); }
       console.debug('[competencies dnd category] drop', {itemId,beforeId:beforeIdRaw,orderedIds});
       try{ const res=await api({action:'reorder',type:'category',id:String(itemId),ordered_ids:JSON.stringify(orderedIds)}); stateTree=res.tree; render(); }
+      catch(err){ showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render(); }
+    };
+  });
+  document.querySelectorAll('.dnd-placeholder-subcategory').forEach(d=>{
+    d.ondragover=(e)=>{ if(!dragEl || dragEl.dataset.type!=='subcategory') return; if(d.dataset.dropType!=='subcategory') return; e.preventDefault(); d.classList.add('active'); };
+    d.ondragleave=()=>d.classList.remove('active');
+    d.ondrop=async (e)=>{
+      e.preventDefault(); d.classList.remove('active');
+      if(!dragEl || dragEl.dataset.type!=='subcategory') return;
+      const itemId=Number(dragEl.dataset.id);
+      const sourceCategoryId=Number(dragEl.dataset.parent||0);
+      const targetCategoryId=Number(d.dataset.parent||0);
+      const beforeIdRaw=(d.dataset.beforeId||'').trim();
+      const beforeId=beforeIdRaw===''?0:Number(beforeIdRaw);
+      const targetCat = stateTree.find(c=>Number(c.id)===targetCategoryId);
+      const targetRealSubs = ((targetCat?.children)||[]).filter(s=>!s.is_virtual).map(s=>Number(s.id));
+      let orderedIds=targetRealSubs.filter(x=>x!==itemId);
+      if(beforeId>0){ const i=orderedIds.indexOf(beforeId); if(i>=0) orderedIds.splice(i,0,itemId); else orderedIds.push(itemId);} else { orderedIds.push(itemId); }
+      console.debug('[competencies dnd subcategory] drop', {itemId,sourceCategoryId,targetCategoryId,beforeId:beforeIdRaw,orderedIds});
+      try{ const res=await api({action:'reorder',type:'subcategory',id:String(itemId),new_parent_id:String(targetCategoryId),ordered_ids:JSON.stringify(orderedIds)}); stateTree=res.tree; render(); }
       catch(err){ showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render(); }
     };
   });

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -207,6 +207,8 @@ render_admin_header('Kompetenzen verwalten'); ?>
 .dnd-placeholder-subcategory.active{border-color:#7a3cff;background:#f5f0ff}
 body.is-dragging-category .dnd-placeholder-category{height:32px;min-height:32px;border-color:#0b57d0;background:#eef5ff}
 body.is-dragging-subcategory .dnd-placeholder-subcategory{height:30px;min-height:30px;border-color:#7a3cff;background:#f5f0ff}
+body.is-dragging-category .dnd-placeholder-subcategory{display:none !important}
+body.is-dragging-subcategory .dnd-placeholder-category{display:none !important}
 .draggable{cursor:move}
 .comp-main{font-weight:600}
 .comp-sub{font-size:12px;color:#666}
@@ -304,16 +306,24 @@ modal.addEventListener('cancel',(e)=>{e.preventDefault(); document.getElementByI
 
 let dragEl=null;
 function initDnd(){
+  console.debug('[competencies dnd] bind draggables',
+    Array.from(document.querySelectorAll('.draggable')).map(el => ({
+      type: el.dataset.type,
+      id: el.dataset.id,
+      itemType: el.dataset.itemType,
+      itemId: el.dataset.itemId
+    }))
+  );
   document.querySelectorAll('.draggable').forEach(el=>{el.ondragstart=(e)=>{ 
     e.stopPropagation();
-    const nested = e.target.closest('.tree-node.draggable');
-    if(nested && nested!==el) return;
-    if(el.dataset.type!=='category' && el.dataset.type!=='subcategory') return;
-    dragEl=el; 
+    const type = el.dataset.type;
+    const id = Number(el.dataset.id || 0);
+    if(type!=='category' && type!=='subcategory'){ e.preventDefault(); return; }
+    dragEl=el;
     document.body.classList.remove('is-dragging-category','is-dragging-subcategory');
-    document.body.classList.add(el.dataset.type==='category'?'is-dragging-category':'is-dragging-subcategory');
-    if(el.dataset.type==='category') console.debug('[competencies dnd category] start', Number(el.dataset.id));
-    if(el.dataset.type==='subcategory') console.debug('[competencies dnd subcategory] start', Number(el.dataset.id), Number(el.dataset.parent||0));
+    document.body.classList.add(type==='category'?'is-dragging-category':'is-dragging-subcategory');
+    console.debug('[competencies dnd] start', { type, id });
+    if(type==='subcategory') console.debug('[competencies dnd subcategory] start', Number(el.dataset.id), Number(el.dataset.parent||0));
   }; el.ondragend=(e)=>{e.stopPropagation(); dragEl=null; document.body.classList.remove('is-dragging-category','is-dragging-subcategory'); document.querySelectorAll('.dnd-placeholder-category,.dnd-placeholder-subcategory').forEach(d=>d.classList.remove('active'));};});
   document.querySelectorAll('.dnd-placeholder-category').forEach(d=>{
     d.ondragover=(e)=>{ if(!dragEl || dragEl.dataset.type!=='category'){ console.debug('[competencies dnd category] dragover ignored for', dragEl?.dataset?.type); return; } if(d.dataset.dropType!=='category') return; e.preventDefault(); d.classList.add('active'); };

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -1,0 +1,218 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/_layout.php';
+require_admin();
+$pdo = db(); $ok=null; $err=null; $gradeOptions=[1,2,3,4];
+
+function json_out(array $d, int $code=200): never { http_response_code($code); header('Content-Type: application/json; charset=utf-8'); echo json_encode($d, JSON_UNESCAPED_UNICODE); exit; }
+function next_comp_code(PDO $pdo, int $categoryId, string $catDe): string { $prefix=strtoupper(preg_replace('/[^A-Za-z0-9]/','',substr($catDe,0,4))?:('CAT'.$categoryId)); $st=$pdo->prepare("SELECT code FROM competencies WHERE category_id=? ORDER BY sort_order DESC,id DESC LIMIT 1"); $st->execute([$categoryId]); $last=(string)($st->fetchColumn()?:''); $n=1; if(preg_match('/-(\d+)$/',$last,$m)) $n=((int)$m[1])+1; return $prefix.'-'.str_pad((string)$n,3,'0',STR_PAD_LEFT);} 
+function resequence_sort(PDO $pdo, string $table, string $whereSql='1=1', array $params=[]): void { $st=$pdo->prepare("SELECT id FROM {$table} WHERE {$whereSql} ORDER BY sort_order,id"); $st->execute($params); $ids=array_map('intval',$st->fetchAll(PDO::FETCH_COLUMN)?:[]); $u=$pdo->prepare("UPDATE {$table} SET sort_order=? WHERE id=?"); foreach($ids as $i=>$id) $u->execute([$i+1,$id]); }
+
+if(isset($_GET['download_csv_template'])){ $csv="category_de;category_en;subcategory_de;subcategory_en;code;text_de;text_en;required;grades\n"; $csv.="Sozialkompetenz;Social skills;Kommunikation;Communication;SOZI-001;Hört anderen aufmerksam zu.;Listens attentively to others.;1;1,2\n"; header('Content-Type:text/csv; charset=utf-8'); header('Content-Disposition: attachment; filename="kompetenzen_vorlage.csv"'); echo $csv; exit; }
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+  try{ csrf_verify(); $a=(string)($_POST['action']??'');
+    if($a==='move_item'){ $type=(string)$_POST['item_type']; $id=(int)$_POST['id']; $before=(int)($_POST['before_id']??0); $targetCategory=(int)($_POST['target_category_id']??0); $targetSub=(int)($_POST['target_subcategory_id']??0);
+      if($type==='category'){resequence_sort($pdo,'competency_categories'); $ids=array_map('intval',$pdo->query("SELECT id FROM competency_categories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_COLUMN)?:[]); $u=$pdo->prepare("UPDATE competency_categories SET sort_order=? WHERE id=?");}
+      elseif($type==='subcategory'){ if($targetCategory>0){$pdo->prepare("UPDATE competency_subcategories SET category_id=? WHERE id=?")->execute([$targetCategory,$id]);} $catId=(int)$pdo->query("SELECT category_id FROM competency_subcategories WHERE id=".$id)->fetchColumn(); resequence_sort($pdo,'competency_subcategories','category_id=?',[$catId]); $st=$pdo->prepare("SELECT id FROM competency_subcategories WHERE category_id=? ORDER BY sort_order,id"); $st->execute([$catId]); $ids=array_map('intval',$st->fetchAll(PDO::FETCH_COLUMN)?:[]); $u=$pdo->prepare("UPDATE competency_subcategories SET sort_order=? WHERE id=?");}
+      else { if($targetCategory>0){ $pdo->prepare("UPDATE competencies SET category_id=?, subcategory_id=? WHERE id=?")->execute([$targetCategory, $targetSub>0?$targetSub:null, $id]); } $st=$pdo->prepare("SELECT COALESCE(category_id,0),COALESCE(subcategory_id,0) FROM competencies WHERE id=?"); $st->execute([$id]); [$catId,$subId]=array_map('intval',$st->fetch(PDO::FETCH_NUM)?:[0,0]); if($subId>0){resequence_sort($pdo,'competencies','subcategory_id=?',[$subId]); $st=$pdo->prepare("SELECT id FROM competencies WHERE subcategory_id=? ORDER BY sort_order,id"); $st->execute([$subId]);} else {resequence_sort($pdo,'competencies','category_id=? AND (subcategory_id IS NULL OR subcategory_id=0)',[$catId]); $st=$pdo->prepare("SELECT id FROM competencies WHERE category_id=? AND (subcategory_id IS NULL OR subcategory_id=0) ORDER BY sort_order,id"); $st->execute([$catId]);} $ids=array_map('intval',$st->fetchAll(PDO::FETCH_COLUMN)?:[]); $u=$pdo->prepare("UPDATE competencies SET sort_order=? WHERE id=?"); }
+      $ids=array_values(array_filter($ids,fn($v)=>$v!==$id)); $pos=array_search($before,$ids,true); if($before>0&&$pos!==false) array_splice($ids,$pos,0,[$id]); else $ids[]=$id; foreach($ids as $i=>$x)$u->execute([$i+1,$x]); json_out(['ok'=>true]);
+    }
+    if($a==='update_category'){ $pdo->prepare("UPDATE competency_categories SET name_de=?, name_en=? WHERE id=?")->execute([trim((string)$_POST['name_de']),trim((string)$_POST['name_en']),(int)$_POST['id']]); json_out(['ok'=>true]); }
+    if($a==='update_subcategory'){ $pdo->prepare("UPDATE competency_subcategories SET name_de=?, name_en=? WHERE id=?")->execute([trim((string)$_POST['name_de']),trim((string)$_POST['name_en']),(int)$_POST['id']]); json_out(['ok'=>true]); }
+    if($a==='update_competency'){ $id=(int)$_POST['id']; $code=trim((string)$_POST['code']); if($code==='') throw new RuntimeException('Code erforderlich'); $pdo->prepare("UPDATE competencies SET code=?, text_de=?, text_en=?, is_required=? WHERE id=?")->execute([$code,trim((string)$_POST['text_de']),trim((string)$_POST['text_en']),isset($_POST['is_required'])?1:0,$id]); $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id=?")->execute([$id]); foreach((array)($_POST['grades']??[]) as $g){$gi=(int)$g;if($gi>=1&&$gi<=4)$pdo->prepare("INSERT INTO competency_grade_levels(competency_id,grade_level) VALUES (?,?)")->execute([$id,$gi]);} json_out(['ok'=>true]); }
+    if($a==='add_category'){ $pdo->prepare("INSERT INTO competency_categories(name_de,name_en,sort_order) VALUES (?,?,9999)")->execute([trim((string)$_POST['name_de']),trim((string)$_POST['name_en'])]); }
+    if($a==='import_csv'){
+      if(!isset($_FILES['csv']) || !is_uploaded_file($_FILES['csv']['tmp_name'])) throw new RuntimeException('CSV-Datei fehlt.');
+      $fh = fopen($_FILES['csv']['tmp_name'], 'r'); if(!$fh) throw new RuntimeException('CSV konnte nicht gelesen werden.');
+      $line=0;
+      while(($row=fgetcsv($fh, 0, ';'))!==false){
+        $line++; if($line===1) continue; if(count($row)<9) continue;
+        [$catDe,$catEn,$subDe,$subEn,$code,$textDe,$textEn,$required,$grades] = $row;
+        $catDe=trim((string)$catDe); $catEn=trim((string)$catEn);
+        $subDe=trim((string)$subDe); $subEn=trim((string)$subEn);
+        $code=trim((string)$code); $textDe=trim((string)$textDe); $textEn=trim((string)$textEn);
+        if($catDe===''||$catEn===''||$textDe===''||$textEn==='') continue;
+
+        $st=$pdo->prepare("SELECT id FROM competency_categories WHERE LOWER(name_de)=LOWER(?) AND LOWER(name_en)=LOWER(?) LIMIT 1");
+        $st->execute([$catDe,$catEn]); $catId=(int)($st->fetchColumn()?:0);
+        if($catId<=0){ $pdo->prepare("INSERT INTO competency_categories(name_de,name_en,sort_order) VALUES (?,?,9999)")->execute([$catDe,$catEn]); $catId=(int)$pdo->lastInsertId(); }
+
+        $subId=0;
+        if($subDe!=='' || $subEn!==''){
+          $st=$pdo->prepare("SELECT id FROM competency_subcategories WHERE category_id=? AND LOWER(name_de)=LOWER(?) AND LOWER(name_en)=LOWER(?) LIMIT 1");
+          $st->execute([$catId,$subDe,$subEn]); $subId=(int)($st->fetchColumn()?:0);
+          if($subId<=0){ $pdo->prepare("INSERT INTO competency_subcategories(category_id,name_de,name_en,sort_order) VALUES (?,?,?,9999)")->execute([$catId,$subDe,$subEn]); $subId=(int)$pdo->lastInsertId(); }
+        }
+
+        $compId=0;
+        if($code!==''){
+          $st=$pdo->prepare("SELECT id FROM competencies WHERE code=? LIMIT 1");
+          $st->execute([$code]); $compId=(int)($st->fetchColumn()?:0);
+        }
+        if($compId<=0){
+          $st=$pdo->prepare("SELECT id FROM competencies WHERE category_id=? AND COALESCE(subcategory_id,0)=? AND LOWER(text_de)=LOWER(?) AND LOWER(text_en)=LOWER(?) LIMIT 1");
+          $st->execute([$catId,$subId,$textDe,$textEn]); $compId=(int)($st->fetchColumn()?:0);
+        }
+        $isReq = (trim(strtolower((string)$required))==='1' || trim(strtolower((string)$required))==='ja') ? 1 : 0;
+        if($compId>0){
+          $pdo->prepare("UPDATE competencies SET category_id=?, subcategory_id=?, code=CASE WHEN code IS NULL OR code='' THEN ? ELSE code END, text_de=?, text_en=?, is_required=? WHERE id=?")
+            ->execute([$catId,$subId>0?$subId:null,$code,$textDe,$textEn,$isReq,$compId]);
+        } else {
+          if($code==='') $code=next_comp_code($pdo,$catId,$catDe);
+          $pdo->prepare("INSERT INTO competencies(category_id,subcategory_id,code,text_de,text_en,is_required,sort_order) VALUES (?,?,?,?,?,?,9999)")
+            ->execute([$catId,$subId>0?$subId:null,$code,$textDe,$textEn,$isReq]);
+          $compId=(int)$pdo->lastInsertId();
+        }
+
+        if($compId>0){
+          $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id=?")->execute([$compId]);
+          foreach(explode(',', (string)$grades) as $g){ $gi=(int)trim($g); if($gi>=1&&$gi<=4){ $pdo->prepare("INSERT IGNORE INTO competency_grade_levels(competency_id,grade_level) VALUES (?,?)")->execute([$compId,$gi]); } }
+        }
+      }
+      fclose($fh);
+      $ok='CSV importiert.';
+    }
+    if($a==='add_subcategory'){ $pdo->prepare("INSERT INTO competency_subcategories(category_id,name_de,name_en,sort_order) VALUES (?,?,?,9999)")->execute([(int)$_POST['category_id'],trim((string)$_POST['name_de']),trim((string)$_POST['name_en'])]); }
+    if($a==='add_competency'){ $sub=(int)($_POST['subcategory_id']??0); $cat=(int)($_POST['category_id']??0); if($sub>0){$st=$pdo->prepare("SELECT category_id FROM competency_subcategories WHERE id=?");$st->execute([$sub]);$cat=(int)($st->fetchColumn()?:0);} $catName=(string)$pdo->query("SELECT name_de FROM competency_categories WHERE id=".$cat)->fetchColumn(); $code=trim((string)($_POST['code']??'')); if($code==='')$code=next_comp_code($pdo,$cat,$catName); $pdo->prepare("INSERT INTO competencies(category_id,subcategory_id,code,text_de,text_en,is_required,sort_order) VALUES (?,?,?,?,?,?,9999)")->execute([$cat,$sub>0?$sub:null,$code,trim((string)$_POST['text_de']),trim((string)$_POST['text_en']),isset($_POST['is_required'])?1:0]); }
+    if($a==='delete_category'){ $id=(int)$_POST['id']; $pdo->prepare("DELETE FROM competencies WHERE category_id=?")->execute([$id]); $pdo->prepare("DELETE FROM competency_subcategories WHERE category_id=?")->execute([$id]); $pdo->prepare("DELETE FROM competency_categories WHERE id=?")->execute([$id]); }
+    if($a==='delete_subcategory'){ $id=(int)$_POST['id']; $pdo->prepare("UPDATE competencies SET subcategory_id=NULL WHERE subcategory_id=?")->execute([$id]); $pdo->prepare("DELETE FROM competency_subcategories WHERE id=?")->execute([$id]); }
+    if($a==='delete_competency'){ $id=(int)$_POST['id']; $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id=?")->execute([$id]); $pdo->prepare("DELETE FROM competencies WHERE id=?")->execute([$id]); }
+    $ok='Gespeichert.';
+  }catch(Throwable $e){ if(isset($_SERVER['HTTP_X_REQUESTED_WITH'])) json_out(['ok'=>false,'error'=>$e->getMessage()],400); $err=$e->getMessage(); }
+}
+
+$cats=$pdo->query("SELECT * FROM competency_categories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_ASSOC);
+$subs=$pdo->query("SELECT * FROM competency_subcategories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_ASSOC);
+$comps=$pdo->query("SELECT c.*, s.name_de AS sub_de, s.name_en AS sub_en FROM competencies c LEFT JOIN competency_subcategories s ON s.id=c.subcategory_id ORDER BY c.sort_order,c.id")->fetchAll(PDO::FETCH_ASSOC);
+$gradesByComp=[]; foreach(($pdo->query("SELECT competency_id,grade_level FROM competency_grade_levels")->fetchAll(PDO::FETCH_ASSOC)?:[]) as $r){$gradesByComp[(int)$r['competency_id']][]=(int)$r['grade_level'];}
+$subsByCat=[]; foreach($subs as $s)$subsByCat[(int)$s['category_id']][]=$s;
+$compsBySub=[]; foreach($comps as $c)$compsBySub[(int)($c['subcategory_id']??0)][]=$c;
+$compCountByCategory=[]; $compCountBySub=[];
+foreach($comps as $c){ $cid=(int)($c['category_id']??0); $sid=(int)($c['subcategory_id']??0); $compCountByCategory[$cid]=($compCountByCategory[$cid]??0)+1; if($sid>0)$compCountBySub[$sid]=($compCountBySub[$sid]??0)+1; }
+
+render_admin_header('Kompetenzen verwalten'); ?>
+<div class="card"><h1>Kompetenzen verwalten</h1><?php if($ok):?><div class="alert success"><?=h($ok)?></div><?php endif;?><?php if($err):?><div class="alert danger"><?=h($err)?></div><?php endif;?> <a class="btn" href="<?=h(url('admin/competencies.php?download_csv_template=1'))?>">CSV-Vorlage herunterladen</a></div>
+<details class="card"><summary><strong>CSV importieren</strong></summary><form method="post" enctype="multipart/form-data"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><input type="hidden" name="action" value="import_csv"><input class="input" type="file" name="csv" accept=".csv,text/csv" required><button class="btn">Import starten</button></form></details>
+<div class="card"><h3>Baumstruktur</h3>
+<?php foreach($cats as $cat): $catId=(int)$cat['id']; ?>
+<details class="drag" draggable="true" data-type="category" data-id="<?=$catId?>"><summary><strong><?=h($cat['name_de'])?></strong> <small><?=h($cat['name_en'])?></small> <button class="icon-edit" type="button" title="Bearbeiten" data-kind="category" data-json='<?=h(json_encode($cat,JSON_UNESCAPED_UNICODE))?>'>✏️</button><button class="icon-del" type="button" title="Löschen" data-action="delete_category" data-id="<?=$catId?>" data-count="<?= (int)($compCountByCategory[$catId] ?? 0) ?>">🗑️</button></summary>
+  <details style="margin-left:16px;" data-category-id="<?=$catId?>" data-subcategory-id="0"><summary>Ohne Unterkategorie</summary><?php foreach(($compsBySub[0]??[]) as $c): if((int)$c['category_id']!==$catId) continue; ?><div class="drag" draggable="true" data-type="competency" data-id="<?=$c['id']?>"><?=h($c['code'])?> — <?=h($c['text_de'])?> <button type="button" class="icon-edit" title="Bearbeiten" data-kind="competency" data-json='<?=h(json_encode($c+['grades'=>$gradesByComp[(int)$c['id']]??[]],JSON_UNESCAPED_UNICODE))?>'>✏️</button><button class="icon-del" type="button" title="Löschen" data-action="delete_competency" data-id="<?=$c['id']?>" data-count="1">🗑️</button></div><?php endforeach;?></details>
+  <?php foreach(($subsByCat[$catId]??[]) as $sub): $subId=(int)$sub['id']; ?>
+    <details class="drag" draggable="true" data-type="subcategory" data-id="<?=$subId?>" style="margin-left:16px;" data-category-id="<?=$catId?>" data-subcategory-id="<?=$subId?>"><summary><?=h($sub['name_de'])?> / <?=h($sub['name_en'])?> <button type="button" class="icon-edit" title="Bearbeiten" data-kind="subcategory" data-json='<?=h(json_encode($sub,JSON_UNESCAPED_UNICODE))?>'>✏️</button><button class="icon-del" type="button" title="Löschen" data-action="delete_subcategory" data-id="<?=$subId?>" data-count="<?= (int)($compCountBySub[$subId] ?? 0) ?>">🗑️</button></summary>
+    <?php foreach(($compsBySub[$subId]??[]) as $c): ?><div class="drag" draggable="true" data-type="competency" data-id="<?=$c['id']?>"><?=h($c['code'])?> — <?=h($c['text_de'])?> <button type="button" class="icon-edit" title="Bearbeiten" data-kind="competency" data-json='<?=h(json_encode($c+['grades'=>$gradesByComp[(int)$c['id']]??[]],JSON_UNESCAPED_UNICODE))?>'>✏️</button><button class="icon-del" type="button" title="Löschen" data-action="delete_competency" data-id="<?=$c['id']?>" data-count="1">🗑️</button></div><?php endforeach; ?>
+    </details>
+  <?php endforeach; ?>
+</details>
+<?php endforeach; ?>
+</div>
+
+<dialog id="editDlg"><form method="dialog" id="editForm"><h3 id="dlgTitle">Bearbeiten</h3><div id="dlgFields"></div><menu><button value="cancel" class="btn">Abbrechen</button><button id="saveBtn" value="default" class="btn">Speichern</button></menu></form></dialog>
+
+<details class="card"><summary><strong>Kategorie hinzufügen</strong></summary><form method="post"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><input type="hidden" name="action" value="add_category"><label>Deutsch</label><input class="input" name="name_de" required><label>English</label><input class="input" name="name_en" required><button class="btn">Speichern</button></form></details>
+<details class="card"><summary><strong>Unterkategorie hinzufügen</strong></summary><form method="post"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><input type="hidden" name="action" value="add_subcategory"><select class="input" name="category_id"><?php foreach($cats as $c):?><option value="<?=$c['id']?>"><?=h($c['name_de'])?></option><?php endforeach;?></select><label>Deutsch</label><input class="input" name="name_de" required><label>English</label><input class="input" name="name_en" required><button class="btn">Speichern</button></form></details>
+<details class="card"><summary><strong>Kompetenz hinzufügen</strong></summary><form method="post"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><input type="hidden" name="action" value="add_competency"><select class="input" name="category_id"><?php foreach($cats as $c):?><option value="<?=$c['id']?>"><?=h($c['name_de'])?></option><?php endforeach;?></select><select class="input" name="subcategory_id"><option value="0">Ohne Unterkategorie</option><?php foreach($subs as $s):?><option value="<?=$s['id']?>"><?=h($s['name_de'])?></option><?php endforeach;?></select><input class="input" name="code" placeholder="Code"><label>Deutsch</label><input class="input" name="text_de" required><label>English</label><input class="input" name="text_en" required><label><input type="checkbox" name="is_required" value="1"> Pflicht</label><div><strong>Klassenstufe:</strong> <?php foreach($gradeOptions as $g):?><label style="display:inline-block;margin-right:10px;"><input type="checkbox" name="grades[]" value="<?=$g?>"> <?=$g?></label><?php endforeach;?></div><button class="btn">Speichern</button></form></details>
+
+<style>
+.icon-edit,.icon-del{background:transparent;border:0;padding:0 4px;cursor:pointer}
+.drop-placeholder{height:10px;border:2px dashed #0b57d0;border-radius:6px;margin:4px 0}
+summary{cursor:pointer}
+.drag{cursor:move;padding:4px 2px}
+.card details{border:1px solid #e7e7e7;border-radius:8px;padding:6px 8px;margin:6px 0;background:#fff}
+.card .input{min-width:220px}
+.drop-zone{height:10px;border:1px dashed transparent;border-radius:4px;margin:3px 0}
+.drop-zone.active{border-color:#0b57d0;background:#eef5ff}
+</style>
+<script>
+const csrf = <?= json_encode(csrf_token()) ?>;
+let drag = null;
+let draggables = [];
+let dropZones = [];
+
+function clearDropZones(){ dropZones.forEach(z=>z.classList.remove('active')); }
+function removeDropZones(){ dropZones.forEach(z=>z.remove()); dropZones = []; }
+function mountDropZone(parent, beforeEl, type, beforeId, targetCategoryId='0', targetSubcategoryId='0'){
+  const dz = document.createElement('div');
+  dz.className = 'drop-zone';
+  dz.dataset.type = type;
+  dz.dataset.beforeId = String(beforeId);
+  dz.dataset.targetCategoryId = String(targetCategoryId);
+  dz.dataset.targetSubcategoryId = String(targetSubcategoryId);
+  parent.insertBefore(dz, beforeEl);
+  dropZones.push(dz);
+  dz.addEventListener('dragover', (e)=>{
+    if(!drag || drag.dataset.type!==dz.dataset.type) return;
+    e.preventDefault(); clearDropZones(); dz.classList.add('active');
+  });
+  dz.addEventListener('drop', async (e)=>{
+    if(!drag || drag.dataset.type!==dz.dataset.type) return;
+    e.preventDefault();
+    const fd = new FormData();
+    fd.append('csrf_token', csrf);
+    fd.append('action','move_item');
+    fd.append('item_type', drag.dataset.type);
+    fd.append('id', drag.dataset.id);
+    fd.append('before_id', dz.dataset.beforeId || '0');
+    fd.append('target_category_id', dz.dataset.targetCategoryId || '0');
+    fd.append('target_subcategory_id', dz.dataset.targetSubcategoryId || '0');
+    const res = await fetch('', {method:'POST', headers:{'X-Requested-With':'XMLHttpRequest'}, body:fd});
+    if(!res.ok) return;
+    // DOM update without reload
+    const targetParent = dz.parentNode;
+    targetParent.insertBefore(drag, dz.nextSibling);
+    if (drag.dataset.type === 'competency') {
+      const targetGroup = targetParent.closest('details[data-category-id]');
+      if (targetGroup) {
+        drag.dataset.categoryId = targetGroup.dataset.categoryId || '0';
+        drag.dataset.subcategoryId = targetGroup.dataset.subcategoryId || '0';
+      }
+    }
+    clearDropZones();
+    initDnD();
+  });
+}
+
+function initDnD(){
+  removeDropZones();
+  draggables = Array.from(document.querySelectorAll('.drag'));
+
+  // category level zones
+  const categoryNodes = Array.from(document.querySelectorAll('.drag[data-type="category"]'));
+  for (const node of categoryNodes) mountDropZone(node.parentNode, node, 'category', node.dataset.id);
+  if (categoryNodes.length) mountDropZone(categoryNodes[0].parentNode, null, 'category', 0);
+
+  // subcategory + competency zones per group
+  const groupDetails = Array.from(document.querySelectorAll('details[data-category-id]'));
+  for (const g of groupDetails) {
+    const cat = g.dataset.categoryId || '0';
+    const sub = g.dataset.subcategoryId || '0';
+    const directChildren = Array.from(g.children);
+    const subs = directChildren.filter(n => n.classList && n.classList.contains('drag') && n.dataset.type === 'subcategory');
+    if (sub === '0') {
+      for (const node of subs) mountDropZone(node.parentNode, node, 'subcategory', node.dataset.id, cat, '0');
+      mountDropZone(g, null, 'subcategory', 0, cat, '0');
+    }
+
+    const comps = directChildren.filter(n => n.classList && n.classList.contains('drag') && n.dataset.type === 'competency');
+    for (const node of comps) mountDropZone(node.parentNode, node, 'competency', node.dataset.id, cat, sub);
+    mountDropZone(g, null, 'competency', 0, cat, sub);
+  }
+
+  draggables.forEach(el => {
+    el.ondragstart = () => { drag = el; el.classList.add('is-dragging'); };
+    el.ondragend = () => { el.classList.remove('is-dragging'); drag = null; clearDropZones(); };
+  });
+}
+initDnD();
+document.querySelectorAll('.icon-del').forEach(btn=>btn.addEventListener('click', async ()=>{const count=Number(btn.dataset.count||0); const action=btn.dataset.action||''; const id=btn.dataset.id||''; const txt=(action==='delete_competency')?'Diese Kompetenz löschen?':`Wirklich löschen? Dabei werden ${count} Kompetenzen entfernt.`; if(!confirm(txt)) return; const fd=new FormData(); fd.append('csrf_token',csrf); fd.append('action',action); fd.append('id',id); const res=await fetch('',{method:'POST',headers:{'X-Requested-With':'XMLHttpRequest'},body:fd}); if(res.ok){ const row=btn.closest('.drag, details'); if(row) row.remove(); }}));
+const dlg=document.getElementById('editDlg'), fields=document.getElementById('dlgFields'), title=document.getElementById('dlgTitle'), save=document.getElementById('saveBtn');
+let current=null;
+function gradeRow(sel=[]){let h='<div><strong>Klassenstufe:</strong> '; for(const g of [1,2,3,4]) h+=`<label style="display:inline-block;margin-right:10px;"><input type="checkbox" name="grades[]" value="${g}" ${sel.includes(g)?'checked':''}> ${g}</label>`; return h+'</div>'}
+document.querySelectorAll('.icon-edit').forEach(b=>b.addEventListener('click',()=>{current={kind:b.dataset.kind,data:JSON.parse(b.dataset.json)}; if(current.kind==='category'){title.textContent='Kategorie bearbeiten'; fields.innerHTML=`<input type="hidden" name="id" value="${current.data.id}"><label>Deutsch</label><input class="input" name="name_de" value="${current.data.name_de||''}"><label>English</label><input class="input" name="name_en" value="${current.data.name_en||''}">`;}
+if(current.kind==='subcategory'){title.textContent='Unterkategorie bearbeiten'; fields.innerHTML=`<input type="hidden" name="id" value="${current.data.id}"><label>Deutsch</label><input class="input" name="name_de" value="${current.data.name_de||''}"><label>English</label><input class="input" name="name_en" value="${current.data.name_en||''}">`;}
+if(current.kind==='competency'){title.textContent='Kompetenz bearbeiten'; fields.innerHTML=`<input type="hidden" name="id" value="${current.data.id}"><label>Code</label><input class="input" name="code" value="${current.data.code||''}"><label>Deutsch</label><input class="input" name="text_de" value="${current.data.text_de||''}"><label>English</label><input class="input" name="text_en" value="${current.data.text_en||''}"><label><input type="checkbox" name="is_required" value="1" ${(current.data.is_required==1)?'checked':''}> Pflicht</label>${gradeRow((current.data.grades||[]).map(Number))}`;}
+ dlg.showModal(); }));
+save.addEventListener('click', async (e)=>{e.preventDefault(); if(!current) return; const fd=new FormData(document.getElementById('editForm')); fd.append('csrf_token',csrf); fd.append('action', current.kind==='category'?'update_category':current.kind==='subcategory'?'update_subcategory':'update_competency'); const res=await fetch('',{method:'POST',headers:{'X-Requested-With':'XMLHttpRequest'},body:fd}); if(res.ok) dlg.close();});
+</script>
+<?php render_admin_footer();

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -160,7 +160,7 @@ render_admin_header('Kompetenzen verwalten'); ?>
   <div id="tree"></div>
 </div>
 
-<dialog id="modal"><form method="dialog" id="modalForm"><h3 id="modalTitle"></h3><div id="modalFields"></div><menu><button class="btn" value="cancel">Abbrechen</button><button id="modalSave" class="btn" value="default">Speichern</button></menu></form></dialog>
+<dialog id="modal"><form id="modalForm"><h3 id="modalTitle"></h3><div id="modalFields"></div><menu><button type="button" id="modalCancel" class="btn">Abbrechen</button><button id="modalSave" type="submit" class="btn">Speichern</button></menu></form></dialog>
 
 <style>
 .tree-node{border:1px solid #e7e7e7;border-radius:8px;padding:8px;margin:6px 0;background:#fff}
@@ -218,9 +218,12 @@ if(b.dataset.type==='competency') openModal({mode:'update',type:'competency',id,
 if(act==='del'){try{const t=b.dataset.type; const prev=await api({action:'delete_preview',type:t,id:String(id)}); let txt=''; if(t==='category') txt=`Diese Kategorie enthält ${prev.counts.subcategories} Unterkategorien und ${prev.counts.competencies} Kompetenzen. Wirklich löschen?`; if(t==='subcategory') txt=`Diese Unterkategorie enthält ${prev.counts.competencies} Kompetenzen. Wirklich löschen?`; if(t==='competency') txt='Diese Kompetenz wirklich löschen?'; if(!confirm(txt)) return; const res=await api({action:'delete',type:t,id:String(id)}); stateTree=res.tree; render(); showMsg('Gelöscht.'); }catch(err){showMsg(err.message,true);} }
 });
 
-modalSave.addEventListener('click', async (e)=>{e.preventDefault(); if(!modalState) return; const fd=new FormData(document.getElementById('modalForm')); const data={action:modalState.mode==='create'?'create':'update',type:modalState.type}; if(modalState.id) data.id=String(modalState.id); if(modalState.parent!==undefined) data.parent_id=String(modalState.parent); if(modalState.targetCategory) data.target_category_id=String(modalState.targetCategory); for(const [k,v] of fd.entries()){ if(k.endsWith('[]')){ const key=k.slice(0,-2); if(!data[key]) data[key]=[]; data[key].push(v);} else data[k]=v; }
+document.getElementById('modalForm').addEventListener('submit', async (e)=>{e.preventDefault(); if(!modalState) return; const fd=new FormData(document.getElementById('modalForm')); const data={action:modalState.mode==='create'?'create':'update',type:modalState.type}; if(modalState.id) data.id=String(modalState.id); if(modalState.parent!==undefined) data.parent_id=String(modalState.parent); if(modalState.targetCategory) data.target_category_id=String(modalState.targetCategory); for(const [k,v] of fd.entries()){ if(k.endsWith('[]')){ const key=k.slice(0,-2); if(!data[key]) data[key]=[]; data[key].push(v);} else data[k]=v; }
   try{ modalSave.disabled=true; const res=await api(data); stateTree=res.tree; render(); modal.close(); showMsg('Gespeichert.'); }catch(err){showMsg(err.message,true);} finally {modalSave.disabled=false;}
 });
+
+document.getElementById('modalCancel').addEventListener('click',()=>{document.getElementById('modalForm').reset(); modal.close();});
+modal.addEventListener('cancel',(e)=>{e.preventDefault(); document.getElementById('modalForm').reset(); modal.close();});
 
 let dragEl=null;
 function initDnd(){
@@ -232,8 +235,8 @@ function initDnd(){
       try{
         let siblings=[];
         if(type==='category') siblings=Array.from(document.querySelectorAll('.draggable[data-type="category"]')).map(x=>Number(x.dataset.id));
-        if(type==='subcategory') siblings=Array.from(document.querySelectorAll(`.draggable[data-type="subcategory"][data-parent="${parent}"]`)).map(x=>Number(x.dataset.id));
-        if(type==='competency') siblings=Array.from(document.querySelectorAll(`.draggable[data-type="competency"][data-parent="${parent}"]`)).map(x=>Number(x.dataset.id));
+        if(type==='subcategory'){ const list=d.closest('.children'); siblings=Array.from((list||document).querySelectorAll(`.draggable[data-type=\"subcategory\"][data-parent=\"${parent}\"]`)).map(x=>Number(x.dataset.id)); }
+        if(type==='competency'){ const list=d.closest('.children'); siblings=Array.from((list||document).querySelectorAll(`.draggable[data-type=\"competency\"][data-parent=\"${parent}\"]`)).map(x=>Number(x.dataset.id)); }
         const id=Number(dragEl.dataset.id); siblings=siblings.filter(x=>x!==id); if(before>0){const idx=siblings.indexOf(before); if(idx>=0) siblings.splice(idx,0,id); else siblings.push(id);} else siblings.push(id);
         const res=await api({action:'reorder',type,id:String(id),new_parent_id:String(parent),target_category_id:String(d.dataset.targetCategory||0),ordered_ids:siblings});
         stateTree=res.tree; render();

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -16,20 +16,33 @@ function normalize_order(PDO $pdo, string $table, string $where='1=1', array $pa
 function fetch_tree(PDO $pdo): array {
   $cats=$pdo->query("SELECT id,name_de,name_en,sort_order FROM competency_categories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_ASSOC)?:[];
   $subs=$pdo->query("SELECT id,category_id,name_de,name_en,sort_order FROM competency_subcategories ORDER BY category_id,sort_order,id")->fetchAll(PDO::FETCH_ASSOC)?:[];
-  $comps=$pdo->query("SELECT id,category_id,subcategory_id,code,text_de,text_en,is_required,sort_order FROM competencies WHERE subcategory_id IS NOT NULL ORDER BY subcategory_id,sort_order,id")->fetchAll(PDO::FETCH_ASSOC)?:[];
+  $comps=$pdo->query("SELECT id,category_id,subcategory_id,code,text_de,text_en,is_required,sort_order FROM competencies ORDER BY category_id, COALESCE(subcategory_id,0), sort_order,id")->fetchAll(PDO::FETCH_ASSOC)?:[];
   $grades=[]; foreach(($pdo->query("SELECT competency_id,grade_level FROM competency_grade_levels ORDER BY grade_level")->fetchAll(PDO::FETCH_ASSOC)?:[]) as $r){$grades[(int)$r['competency_id']][]=(int)$r['grade_level'];}
   $subsByCat=[]; foreach($subs as $s){$subsByCat[(int)$s['category_id']][]=$s;}
-  $compsBySub=[]; foreach($comps as $c){$compsBySub[(int)$c['subcategory_id']][]=$c;}
+  $compsBySub=[]; $compsNoSubByCat=[];
+  foreach($comps as $c){
+    $subId=(int)($c['subcategory_id'] ?? 0);
+    if($subId>0){ $compsBySub[$subId][]=$c; }
+    else { $compsNoSubByCat[(int)($c['category_id']??0)][]=$c; }
+  }
   $tree=[];
   foreach($cats as $c){
     $catId=(int)$c['id'];
     $cn=[];
+    if(!empty($compsNoSubByCat[$catId])){
+      $items=[];
+      foreach(($compsNoSubByCat[$catId]??[]) as $it){
+        $cid=(int)$it['id'];
+        $items[]=['id'=>$cid,'type'=>'competency','title'=>(string)$it['code'].' — '.(string)$it['text_de'],'code'=>(string)$it['code'],'text_de'=>(string)$it['text_de'],'text_en'=>(string)$it['text_en'],'is_required'=>(int)$it['is_required'],'grades'=>$grades[$cid]??[],'category_id'=>(int)$it['category_id'],'sort_order'=>(int)$it['sort_order']];
+      }
+      $cn[]=['id'=>'virtual-no-subcategory-'.$catId,'is_virtual'=>true,'category_id'=>$catId,'type'=>'subcategory','title'=>'Ohne Unterkategorie','name_de'=>'Ohne Unterkategorie','name_en'=>'Without subcategory','sort_order'=>0,'children'=>$items];
+    }
     foreach(($subsByCat[$catId]??[]) as $s){
       $subId=(int)$s['id'];
       $items=[];
       foreach(($compsBySub[$subId]??[]) as $it){
         $cid=(int)$it['id'];
-        $items[]=['id'=>$cid,'type'=>'competency','title'=>(string)$it['code'].' — '.(string)$it['text_de'],'code'=>(string)$it['code'],'text_de'=>(string)$it['text_de'],'text_en'=>(string)$it['text_en'],'is_required'=>(int)$it['is_required'],'grades'=>$grades[$cid]??[],'sort_order'=>(int)$it['sort_order']];
+        $items[]=['id'=>$cid,'type'=>'competency','title'=>(string)$it['code'].' — '.(string)$it['text_de'],'code'=>(string)$it['code'],'text_de'=>(string)$it['text_de'],'text_en'=>(string)$it['text_en'],'is_required'=>(int)$it['is_required'],'grades'=>$grades[$cid]??[],'category_id'=>(int)$it['category_id'],'sort_order'=>(int)$it['sort_order']];
       }
       $cn[]=['id'=>$subId,'type'=>'subcategory','title'=>(string)$s['name_de'],'name_de'=>(string)$s['name_de'],'name_en'=>(string)$s['name_en'],'sort_order'=>(int)$s['sort_order'],'children'=>$items];
     }
@@ -69,9 +82,9 @@ if($_SERVER['REQUEST_METHOD']==='POST' && isset($_SERVER['HTTP_X_REQUESTED_WITH'
         $de=trim((string)($_POST['name_de']??'')); $en=trim((string)($_POST['name_en']??'')); if($de===''||$en==='') bad('Name DE/EN erforderlich');
         $so=max_sort($pdo,'competency_subcategories','category_id=?',[$cat])+1; $pdo->prepare("INSERT INTO competency_subcategories(category_id,name_de,name_en,sort_order) VALUES (?,?,?,?)")->execute([$cat,$de,$en,$so]);
       } elseif($type==='competency'){
-        $sub=(int)($_POST['parent_id']??0); if($sub<=0) bad('Unterkategorie erforderlich');
-        $st=$pdo->prepare("SELECT category_id,name_de FROM competency_subcategories WHERE id=?");$st->execute([$sub]);$sr=$st->fetch(PDO::FETCH_ASSOC); if(!$sr) bad('Unterkategorie nicht gefunden');
-        $cat=(int)$sr['category_id'];
+        $subRaw=(string)($_POST['parent_id']??''); $sub=(int)$subRaw; $cat=(int)($_POST['target_category_id']??0); $catName='';
+        if($sub>0){ $st=$pdo->prepare("SELECT category_id,name_de FROM competency_subcategories WHERE id=?");$st->execute([$sub]);$sr=$st->fetch(PDO::FETCH_ASSOC); if(!$sr) bad('Unterkategorie nicht gefunden'); $cat=(int)$sr['category_id']; $catName=(string)$sr['name_de']; }
+        else { if($cat<=0) bad('Kategorie erforderlich'); $st=$pdo->prepare("SELECT name_de FROM competency_categories WHERE id=?");$st->execute([$cat]); $catName=(string)($st->fetchColumn()?:'CAT'); }
         $de=trim((string)($_POST['text_de']??'')); $en=trim((string)($_POST['text_en']??'')); if($de===''||$en==='') bad('Kompetenztext DE/EN erforderlich');
         $code=trim((string)($_POST['code']??'')); if($code==='') $code=next_comp_code($pdo,$cat,(string)$sr['name_de']);
         $so=max_sort($pdo,'competencies','subcategory_id=?',[$sub])+1;
@@ -158,6 +171,11 @@ render_admin_header('Kompetenzen verwalten'); ?>
 .drop-target{height:12px;border:2px dashed transparent;border-radius:6px;margin:4px 0}
 .drop-target.active{border-color:#0b57d0;background:#eef5ff}
 .draggable{cursor:move}
+.comp-main{font-weight:600}
+.comp-sub{font-size:12px;color:#666}
+.chip{display:inline-block;border-radius:999px;padding:1px 8px;font-size:11px;background:#eef5ff;margin-right:4px}
+#modal{width:min(900px,95vw)}
+#modal textarea{width:100%;min-height:80px}
 </style>
 <script>
 const csrf = <?=json_encode(csrf_token())?>;
@@ -167,23 +185,23 @@ const modal=document.getElementById('modal');
 const modalTitle=document.getElementById('modalTitle');
 const modalFields=document.getElementById('modalFields');
 const modalSave=document.getElementById('modalSave');
-let stateTree=[]; let busy=false; let modalState=null;
+let stateTree=[]; let busy=false; let modalState=null; const collapsed = new Set();
 function showMsg(text,err=false){msg.style.display='block';msg.textContent=text;msg.className='card '+(err?'alert danger':'alert success');}
-async function api(data){if(busy) throw new Error('Bitte warten…'); busy=true; try{const fd=new FormData(); Object.entries(data).forEach(([k,v])=>fd.append(k, typeof v==='string'?v:JSON.stringify(v))); fd.append('csrf_token',csrf); const r=await fetch('',{method:'POST',headers:{'X-Requested-With':'XMLHttpRequest'},body:fd}); const j=await r.json(); if(!r.ok||!j.ok) throw new Error(j.error||'Fehler'); return j;} finally {busy=false;}}
+async function api(data){if(busy) throw new Error('Bitte warten…'); busy=true; try{const fd=new FormData(); Object.entries(data).forEach(([k,v])=>{ if(Array.isArray(v)){ v.forEach(x=>fd.append(k+'[]',String(x))); } else fd.append(k,String(v)); }); fd.append('csrf_token',csrf); const r=await fetch('',{method:'POST',headers:{'X-Requested-With':'XMLHttpRequest'},body:fd}); const j=await r.json(); if(!r.ok||!j.ok) throw new Error(j.error||'Fehler'); return j;} finally {busy=false;}}
 function gradeChecks(sel=[]){return `<div><strong>Klassenstufe</strong> ${[1,2,3,4].map(g=>`<label><input type="checkbox" name="grades[]" value="${g}" ${sel.includes(g)?'checked':''}> ${g}</label>`).join(' ')}</div>`}
 function render(){treeEl.innerHTML=''; if(!stateTree.length){treeEl.innerHTML='<div>Keine Kategorien vorhanden.</div>'; return;} stateTree.forEach(c=>treeEl.appendChild(renderCategory(c))); initDnd();}
-function renderCategory(c){const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='category'; el.dataset.id=c.id; el.innerHTML=`<div class="drop-target" data-type="category" data-parent="0" data-before="${c.id}"></div><div class="node-head"><span class="node-title">${escapeHtml(c.name_de)} <small>${escapeHtml(c.name_en)}</small></span><span class="node-actions"><button data-act="addSub" data-id="${c.id}">＋</button><button data-act="edit" data-type="category" data-id="${c.id}">✏️</button><button data-act="del" data-type="category" data-id="${c.id}">🗑️</button></span></div><div class="children"></div>`;
+function renderCategory(c){const nodeKey=`category-${c.id}`;const hasChildren=(c.children||[]).length>0;const isCollapsed=collapsed.has(nodeKey);const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='category'; el.dataset.id=c.id; el.innerHTML=`<div class="drop-target" data-type="category" data-parent="0" data-before="${c.id}"></div><div class="node-head"><span class="node-title">${hasChildren?`<button data-act="toggle" data-node="${nodeKey}" style="border:0;background:none;cursor:pointer">${isCollapsed?'▸':'▾'}</button>`:''}${escapeHtml(c.name_de)} <small>${escapeHtml(c.name_en)}</small></span><span class="node-actions"><button data-act="addSub" data-id="${c.id}">＋</button><button data-act="edit" data-type="category" data-id="${c.id}">✏️</button><button data-act="del" data-type="category" data-id="${c.id}">🗑️</button></span></div><div class="children" style="${isCollapsed?'display:none':''}"></div>`;
 const ch=el.querySelector('.children');
 if(!c.children.length){ch.innerHTML='<div>Keine Unterkategorien.</div>';} else c.children.forEach(s=>ch.appendChild(renderSub(s,c.id)));
 const tail=document.createElement('div'); tail.className='drop-target'; tail.dataset.type='category'; tail.dataset.parent='0'; tail.dataset.before='0'; ch.parentNode.appendChild(tail);
 return el;}
-function renderSub(s,catId){const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='subcategory'; el.dataset.id=s.id; el.dataset.parent=catId; el.innerHTML=`<div class="drop-target" data-type="subcategory" data-parent="${catId}" data-before="${s.id}"></div><div class="node-head"><span>${escapeHtml(s.name_de)} <small>${escapeHtml(s.name_en)}</small></span><span class="node-actions"><button data-act="addComp" data-id="${s.id}">＋</button><button data-act="edit" data-type="subcategory" data-id="${s.id}">✏️</button><button data-act="del" data-type="subcategory" data-id="${s.id}">🗑️</button></span></div><div class="children"></div>`;
+function renderSub(s,catId){const virtual=!!s.is_virtual;const sid=String(s.id);const nodeKey=`subcategory-${sid}`;const hasChildren=(s.children||[]).length>0;const isCollapsed=collapsed.has(nodeKey);const el=document.createElement('div'); el.className='tree-node'+(virtual?'':' draggable'); if(!virtual){el.draggable=true; el.dataset.type='subcategory'; el.dataset.id=sid; el.dataset.parent=catId;} el.innerHTML=`${virtual?'':'<div class="drop-target" data-type="subcategory" data-parent="'+catId+'" data-before="'+sid+'"></div>'}<div class="node-head"><span>${hasChildren?`<button data-act="toggle" data-node="${nodeKey}" style="border:0;background:none;cursor:pointer">${isCollapsed?'▸':'▾'}</button>`:''}${escapeHtml(s.name_de)} <small>${escapeHtml(s.name_en||'')}</small></span><span class="node-actions"><button data-act="addComp" data-id="${sid}" data-virtual="${virtual?1:0}" data-category="${catId}">＋</button>${virtual?'':'<button data-act="edit" data-type="subcategory" data-id="'+sid+'">✏️</button><button data-act="del" data-type="subcategory" data-id="'+sid+'">🗑️</button>'}</span></div><div class="children" style="${isCollapsed?'display:none':''}"></div>`;
 const ch=el.querySelector('.children'); if(!s.children.length){ch.innerHTML='<div>Keine Kompetenzen.</div>';} else s.children.forEach(k=>ch.appendChild(renderComp(k,s.id)));
 const tail=document.createElement('div'); tail.className='drop-target'; tail.dataset.type='subcategory'; tail.dataset.parent=catId; tail.dataset.before='0';
-const ct=document.createElement('div'); ct.className='drop-target'; ct.dataset.type='competency'; ct.dataset.parent=s.id; ct.dataset.before='0';
+const ct=document.createElement('div'); ct.className='drop-target'; ct.dataset.type='competency'; ct.dataset.parent=virtual?'0':sid; ct.dataset.targetCategory=String(catId); ct.dataset.before='0';
 el.appendChild(ct); el.appendChild(tail);
 return el;}
-function renderComp(k,subId){const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='competency'; el.dataset.id=k.id; el.dataset.parent=subId; el.innerHTML=`<div class="drop-target" data-type="competency" data-parent="${subId}" data-before="${k.id}"></div><div class="node-head"><span>${escapeHtml(k.code)} — ${escapeHtml(k.text_de)}</span><span class="node-actions"><button data-act="edit" data-type="competency" data-id="${k.id}">✏️</button><button data-act="del" data-type="competency" data-id="${k.id}">🗑️</button></span></div>`; return el;}
+function renderComp(k,subId){const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='competency'; el.dataset.id=k.id; el.dataset.parent=subId;const grade=(k.grades||[]).map(g=>`<span class="chip">${g}</span>`).join('');const req=k.is_required?'<span class="chip">Pflicht</span>':'<span class="chip">Optional</span>'; el.innerHTML=`<div class="drop-target" data-type="competency" data-parent="${subId}" data-before="${k.id}" data-target-category="${k.category_id||0}"></div><div class="node-head"><span><div class="comp-main">${escapeHtml(k.code)} — ${escapeHtml(k.text_de)}</div>${k.text_en?`<div class="comp-sub">${escapeHtml(k.text_en)}</div>`:''}<div>${req}${grade}</div></span><span class="node-actions"><button data-act="edit" data-type="competency" data-id="${k.id}">✏️</button><button data-act="del" data-type="competency" data-id="${k.id}">🗑️</button></span></div>`; return el;}
 function escapeHtml(s){return (s??'').toString().replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[m]));}
 
 function findNode(type,id){for(const c of stateTree){if(type==='category'&&c.id==id) return c; for(const s of c.children||[]){if(type==='subcategory'&&s.id==id)return s; for(const k of s.children||[]){if(type==='competency'&&k.id==id)return k;}}} return null;}
@@ -192,14 +210,15 @@ function openModal(cfg){modalState=cfg; modalTitle.textContent=cfg.title; modalF
 document.getElementById('addCategory').addEventListener('click',()=>openModal({mode:'create',type:'category',title:'Kategorie hinzufügen',html:'<label>Deutsch</label><input class="input" name="name_de" required><label>English</label><input class="input" name="name_en" required>'}));
 treeEl.addEventListener('click', async (e)=>{const b=e.target.closest('button[data-act]'); if(!b) return; const act=b.dataset.act; const id=Number(b.dataset.id);
 if(act==='addSub'){openModal({mode:'create',type:'subcategory',parent:id,title:'Unterkategorie hinzufügen',html:'<label>Deutsch</label><input class="input" name="name_de" required><label>English</label><input class="input" name="name_en" required>'});}
-if(act==='addComp'){openModal({mode:'create',type:'competency',parent:id,title:'Kompetenz hinzufügen',html:'<label>Code (optional)</label><input class="input" name="code"><label>Deutsch</label><input class="input" name="text_de" required><label>English</label><input class="input" name="text_en" required><label><input type="checkbox" name="is_required" value="1"> Pflicht</label>'+gradeChecks([])});}
+if(act==='toggle'){const key=b.dataset.node; if(collapsed.has(key)) collapsed.delete(key); else collapsed.add(key); render(); return;}
+if(act==='addComp'){const virt=b.dataset.virtual==='1';openModal({mode:'create',type:'competency',parent:virt?0:id,targetCategory:virt?Number(b.dataset.category):0,title:'Kompetenz hinzufügen',html:'<label>Code (optional)</label><input class="input" name="code"><label>Deutsch</label><textarea name="text_de" required></textarea><label>English</label><textarea name="text_en"></textarea><label><input type="checkbox" name="is_required" value="1"> Pflicht</label>'+gradeChecks([])});}
 if(act==='edit'){const n=findNode(b.dataset.type,id); if(!n) return; if(b.dataset.type==='category') openModal({mode:'update',type:'category',id,title:'Kategorie bearbeiten',html:`<label>Deutsch</label><input class="input" name="name_de" value="${escapeHtml(n.name_de)}" required><label>English</label><input class="input" name="name_en" value="${escapeHtml(n.name_en)}" required>`});
 if(b.dataset.type==='subcategory') openModal({mode:'update',type:'subcategory',id,title:'Unterkategorie bearbeiten',html:`<label>Deutsch</label><input class="input" name="name_de" value="${escapeHtml(n.name_de)}" required><label>English</label><input class="input" name="name_en" value="${escapeHtml(n.name_en)}" required>`});
-if(b.dataset.type==='competency') openModal({mode:'update',type:'competency',id,title:'Kompetenz bearbeiten',html:`<label>Code</label><input class="input" name="code" value="${escapeHtml(n.code)}" required><label>Deutsch</label><input class="input" name="text_de" value="${escapeHtml(n.text_de)}" required><label>English</label><input class="input" name="text_en" value="${escapeHtml(n.text_en)}" required><label><input type="checkbox" name="is_required" value="1" ${n.is_required? 'checked':''}> Pflicht</label>${gradeChecks((n.grades||[]).map(Number))}`});}
+if(b.dataset.type==='competency') openModal({mode:'update',type:'competency',id,title:'Kompetenz bearbeiten',html:`<label>Code</label><input class="input" name="code" value="${escapeHtml(n.code)}" required><label>Deutsch</label><textarea name="text_de" required>${escapeHtml(n.text_de)}</textarea><label>English</label><textarea name="text_en">${escapeHtml(n.text_en||'')}</textarea><label><input type="checkbox" name="is_required" value="1" ${n.is_required? 'checked':''}> Pflicht</label>${gradeChecks((n.grades||[]).map(Number))}`});}
 if(act==='del'){try{const t=b.dataset.type; const prev=await api({action:'delete_preview',type:t,id:String(id)}); let txt=''; if(t==='category') txt=`Diese Kategorie enthält ${prev.counts.subcategories} Unterkategorien und ${prev.counts.competencies} Kompetenzen. Wirklich löschen?`; if(t==='subcategory') txt=`Diese Unterkategorie enthält ${prev.counts.competencies} Kompetenzen. Wirklich löschen?`; if(t==='competency') txt='Diese Kompetenz wirklich löschen?'; if(!confirm(txt)) return; const res=await api({action:'delete',type:t,id:String(id)}); stateTree=res.tree; render(); showMsg('Gelöscht.'); }catch(err){showMsg(err.message,true);} }
 });
 
-modalSave.addEventListener('click', async (e)=>{e.preventDefault(); if(!modalState) return; const fd=new FormData(document.getElementById('modalForm')); const data={action:modalState.mode==='create'?'create':'update',type:modalState.type}; if(modalState.id) data.id=String(modalState.id); if(modalState.parent) data.parent_id=String(modalState.parent); for(const [k,v] of fd.entries()){ if(k.endsWith('[]')){ if(!data[k]) data[k]=[]; data[k].push(v);} else data[k]=v; }
+modalSave.addEventListener('click', async (e)=>{e.preventDefault(); if(!modalState) return; const fd=new FormData(document.getElementById('modalForm')); const data={action:modalState.mode==='create'?'create':'update',type:modalState.type}; if(modalState.id) data.id=String(modalState.id); if(modalState.parent!==undefined) data.parent_id=String(modalState.parent); if(modalState.targetCategory) data.target_category_id=String(modalState.targetCategory); for(const [k,v] of fd.entries()){ if(k.endsWith('[]')){ const key=k.slice(0,-2); if(!data[key]) data[key]=[]; data[key].push(v);} else data[k]=v; }
   try{ modalSave.disabled=true; const res=await api(data); stateTree=res.tree; render(); modal.close(); showMsg('Gespeichert.'); }catch(err){showMsg(err.message,true);} finally {modalSave.disabled=false;}
 });
 
@@ -216,7 +235,7 @@ function initDnd(){
         if(type==='subcategory') siblings=Array.from(document.querySelectorAll(`.draggable[data-type="subcategory"][data-parent="${parent}"]`)).map(x=>Number(x.dataset.id));
         if(type==='competency') siblings=Array.from(document.querySelectorAll(`.draggable[data-type="competency"][data-parent="${parent}"]`)).map(x=>Number(x.dataset.id));
         const id=Number(dragEl.dataset.id); siblings=siblings.filter(x=>x!==id); if(before>0){const idx=siblings.indexOf(before); if(idx>=0) siblings.splice(idx,0,id); else siblings.push(id);} else siblings.push(id);
-        const res=await api({action:'reorder',type,id:String(id),new_parent_id:String(parent),ordered_ids:siblings});
+        const res=await api({action:'reorder',type,id:String(id),new_parent_id:String(parent),target_category_id:String(d.dataset.targetCategory||0),ordered_ids:siblings});
         stateTree=res.tree; render();
       }catch(err){showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render();}
     });

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -201,14 +201,12 @@ render_admin_header('Kompetenzen verwalten'); ?>
 .node-title{font-weight:600}
 .node-actions button{background:transparent;border:0;cursor:pointer}
 .children{margin-left:18px}
-.drop-target{min-height:10px;height:10px;border:2px dashed transparent;border-radius:8px;margin:4px 0;display:flex;align-items:center;padding:0 10px;font-size:12px;color:#7a7a7a}
+.drop-target{height:12px;min-height:12px;border:2px dashed transparent;border-radius:8px;margin:4px 0;display:flex;align-items:center;padding:0;font-size:0;color:transparent}
 .drop-target.active{border-color:#0b57d0;background:#eef5ff}
 .dnd-placeholder-subcategory{min-height:10px;height:10px;border-width:1px;margin:3px 0 3px 12px}
 .dnd-placeholder-subcategory.active{border-color:#7a3cff;background:#f5f0ff}
-body.is-dragging-category .dnd-placeholder-category{height:44px;min-height:44px;border-color:#0b57d0;background:#eef5ff;display:flex;align-items:center}
-body.is-dragging-subcategory .dnd-placeholder-subcategory{height:40px;min-height:40px;border-color:#7a3cff;background:#f5f0ff;display:flex;align-items:center}
-body.is-dragging-category .dnd-placeholder-subcategory{display:none}
-body.is-dragging-subcategory .dnd-placeholder-category{display:none}
+body.is-dragging-category .dnd-placeholder-category{height:32px;min-height:32px;border-color:#0b57d0;background:#eef5ff}
+body.is-dragging-subcategory .dnd-placeholder-subcategory{height:30px;min-height:30px;border-color:#7a3cff;background:#f5f0ff}
 .draggable{cursor:move}
 .comp-main{font-weight:600}
 .comp-sub{font-size:12px;color:#666}
@@ -244,7 +242,7 @@ function render(){
   treeEl.appendChild(catList);
   initDnd();
 }
-function mkDrop(type,before='0',extra={}){ const d=document.createElement('div'); d.className=`drop-target dnd-placeholder-${type}`; d.dataset.type=type; d.dataset.before=String(before); Object.entries(extra).forEach(([k,v])=>d.dataset[k]=String(v)); d.textContent=type==='category'?'Kategorie hier ablegen':'Unterkategorie hier ablegen'; return d; }
+function mkDrop(type,before='0',extra={}){ const d=document.createElement('div'); d.className=`drop-target dnd-placeholder-${type}`; d.dataset.type=type; d.dataset.before=String(before); Object.entries(extra).forEach(([k,v])=>d.dataset[k]=String(v)); return d; }
 function renderCategory(c){
   const nodeKey=`category-${c.id}`; const isCollapsed=collapsed.has(nodeKey); const hasChildren=(c.children||[]).length>0;
   const wrap=document.createElement('div'); wrap.dataset.itemType='category'; wrap.dataset.itemId=String(c.id); wrap.className='tree-node category-node draggable'; wrap.draggable=true; wrap.dataset.type='category'; wrap.dataset.id=String(c.id);
@@ -327,12 +325,7 @@ function initDnd(){
       const beforeIdRaw=(d.dataset.beforeId||'').trim();
       const beforeId=beforeIdRaw===''?0:Number(beforeIdRaw);
       const currentIds=stateTree.map(c=>Number(c.id));
-      const oldIndex=currentIds.indexOf(itemId);
-      const beforeIndex=beforeId>0?currentIds.indexOf(beforeId):currentIds.length;
-      if(beforeId===itemId || beforeIndex===oldIndex || beforeIndex===oldIndex+1){
-        console.debug('[competencies dnd] noop same position', { type:'category', itemId, beforeId, oldIndex, beforeIndex });
-        return;
-      }
+      if(beforeId===itemId) return;
       let orderedIds=stateTree.map(c=>Number(c.id)).filter(x=>x!==itemId);
       if(beforeId>0){ const i=orderedIds.indexOf(beforeId); if(i>=0) orderedIds.splice(i,0,itemId); else orderedIds.push(itemId);} else { orderedIds.push(itemId); }
       if(itemId===beforeId || orderedIds.join(',')===currentIds.join(',')) return;
@@ -352,15 +345,7 @@ function initDnd(){
       const targetCategoryId=Number(d.dataset.parent||0);
       const beforeIdRaw=(d.dataset.beforeId||'').trim();
       const beforeId=beforeIdRaw===''?0:Number(beforeIdRaw);
-      if(sourceCategoryId===targetCategoryId){
-        const sameIds=((stateTree.find(c=>Number(c.id)===sourceCategoryId)?.children)||[]).filter(s=>!s.is_virtual).map(s=>Number(s.id));
-        const oldIndex=sameIds.indexOf(itemId);
-        const beforeIndex=beforeId>0?sameIds.indexOf(beforeId):sameIds.length;
-        if(beforeId===itemId || beforeIndex===oldIndex || beforeIndex===oldIndex+1){
-          console.debug('[competencies dnd] noop same position', { type:'subcategory', itemId, beforeId, oldIndex, beforeIndex });
-          return;
-        }
-      }
+      if(sourceCategoryId===targetCategoryId && beforeId===itemId) return;
       const targetCat = stateTree.find(c=>Number(c.id)===targetCategoryId);
       const targetRealSubs = ((targetCat?.children)||[]).filter(s=>!s.is_virtual).map(s=>Number(s.id));
       let orderedIds=targetRealSubs.filter(x=>x!==itemId);
@@ -368,7 +353,7 @@ function initDnd(){
       const currentIds = sourceCategoryId===targetCategoryId
         ? ((stateTree.find(c=>Number(c.id)===sourceCategoryId)?.children)||[]).filter(s=>!s.is_virtual).map(s=>Number(s.id))
         : targetRealSubs;
-      if(itemId===beforeId || orderedIds.join(',')===currentIds.join(',')) return;
+      if(sourceCategoryId===targetCategoryId && orderedIds.join(',')===currentIds.join(',')) return;
       console.debug('[competencies dnd subcategory] drop', {itemId,sourceCategoryId,targetCategoryId,beforeId:beforeIdRaw,orderedIds});
       try{ const res=await api({action:'reorder',type:'subcategory',id:String(itemId),new_parent_id:String(targetCategoryId),ordered_ids:JSON.stringify(orderedIds)}); stateTree=res.tree; render(); }
       catch(err){ showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render(); }

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -66,6 +66,30 @@ function delete_preview(PDO $pdo, string $type, int $id): array {
 
 if(isset($_GET['download_csv_template'])){ $csv="category_de;category_en;subcategory_de;subcategory_en;code;text_de;text_en;required;grades\n"; $csv.="Sozialkompetenz;Social skills;Kommunikation;Communication;SOZI-001;Hört anderen aufmerksam zu.;Listens attentively to others.;1;1,2\n"; header('Content-Type:text/csv; charset=utf-8'); header('Content-Disposition: attachment; filename="kompetenzen_vorlage.csv"'); echo $csv; exit; }
 
+
+if($_SERVER['REQUEST_METHOD']==='POST' && !isset($_SERVER['HTTP_X_REQUESTED_WITH']) && (string)($_POST['action']??'')==='import_csv'){
+  try{ csrf_verify();
+    if(!isset($_FILES['csv']) || !is_uploaded_file($_FILES['csv']['tmp_name'])) throw new RuntimeException('CSV-Datei fehlt.');
+    $fh=fopen($_FILES['csv']['tmp_name'],'r'); if(!$fh) throw new RuntimeException('CSV konnte nicht gelesen werden.');
+    $line=0; while(($row=fgetcsv($fh,0,';'))!==false){ $line++; if($line===1) continue; if(count($row)<9) continue;
+      [$catDe,$catEn,$subDe,$subEn,$code,$textDe,$textEn,$required,$grades]=$row;
+      $catDe=trim((string)$catDe); $catEn=trim((string)$catEn); $subDe=trim((string)$subDe); $subEn=trim((string)$subEn); $code=trim((string)$code); $textDe=trim((string)$textDe); $textEn=trim((string)$textEn);
+      if($catDe===''||$catEn===''||$textDe==='') continue;
+      $st=$pdo->prepare("SELECT id FROM competency_categories WHERE LOWER(name_de)=LOWER(?) AND LOWER(name_en)=LOWER(?) LIMIT 1"); $st->execute([$catDe,$catEn]); $catId=(int)($st->fetchColumn()?:0);
+      if($catId<=0){ $pdo->prepare("INSERT INTO competency_categories(name_de,name_en,sort_order) VALUES (?,?,?)")->execute([$catDe,$catEn,max_sort($pdo,'competency_categories')+1]); $catId=(int)$pdo->lastInsertId(); }
+      $subId=0; if($subDe!==''||$subEn!==''){ $st=$pdo->prepare("SELECT id FROM competency_subcategories WHERE category_id=? AND LOWER(name_de)=LOWER(?) AND LOWER(name_en)=LOWER(?) LIMIT 1"); $st->execute([$catId,$subDe,$subEn]); $subId=(int)($st->fetchColumn()?:0); if($subId<=0){ $pdo->prepare("INSERT INTO competency_subcategories(category_id,name_de,name_en,sort_order) VALUES (?,?,?,?)")->execute([$catId,$subDe,$subEn,max_sort($pdo,'competency_subcategories','category_id=?',[$catId])+1]); $subId=(int)$pdo->lastInsertId(); } }
+      if($code==='') $code=next_comp_code($pdo,$catId,$catDe);
+      $st=$pdo->prepare("SELECT id FROM competencies WHERE code=? LIMIT 1"); $st->execute([$code]); $compId=(int)($st->fetchColumn()?:0);
+      $isReq=(trim(strtolower((string)$required))==='1'||trim(strtolower((string)$required))==='ja')?1:0;
+      if($compId>0){ $pdo->prepare("UPDATE competencies SET category_id=?,subcategory_id=?,text_de=?,text_en=?,is_required=? WHERE id=?")->execute([$catId,$subId>0?$subId:null,$textDe,$textEn,$isReq,$compId]); }
+      else { $so=$subId>0?max_sort($pdo,'competencies','subcategory_id=?',[$subId])+1:max_sort($pdo,'competencies','category_id=? AND subcategory_id IS NULL',[$catId])+1; $pdo->prepare("INSERT INTO competencies(category_id,subcategory_id,code,text_de,text_en,is_required,sort_order) VALUES (?,?,?,?,?,?,?)")->execute([$catId,$subId>0?$subId:null,$code,$textDe,$textEn,$isReq,$so]); $compId=(int)$pdo->lastInsertId(); }
+      $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id=?")->execute([$compId]);
+      foreach(explode(',',(string)$grades) as $g){ $gi=(int)trim($g); if($gi>=1&&$gi<=4){ $pdo->prepare("INSERT INTO competency_grade_levels(competency_id,grade_level) VALUES (?,?)")->execute([$compId,$gi]); } }
+    }
+    fclose($fh);
+    header('Location: '.url('admin/competencies.php')); exit;
+  } catch(Throwable $e){ header('Location: '.url('admin/competencies.php')); exit; }
+}
 if($_SERVER['REQUEST_METHOD']==='POST' && isset($_SERVER['HTTP_X_REQUESTED_WITH'])){
   try{
     csrf_verify();
@@ -155,6 +179,8 @@ if($_SERVER['REQUEST_METHOD']==='POST' && isset($_SERVER['HTTP_X_REQUESTED_WITH'
 render_admin_header('Kompetenzen verwalten'); ?>
 <div class="card"><h1>Kompetenzen verwalten</h1><a class="btn" href="<?=h(url('admin/competencies.php?download_csv_template=1'))?>">CSV-Vorlage herunterladen</a></div>
 <div id="msg" class="card" style="display:none;"></div>
+<div class="card"><details><summary><strong>CSV importieren</strong></summary><form method="post" enctype="multipart/form-data" style="margin-top:8px;"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><input type="hidden" name="action" value="import_csv"><input type="file" name="csv" accept=".csv,text/csv" required><button class="btn" type="submit">Import starten</button></form></details></div>
+
 <div class="card">
   <div style="display:flex;justify-content:space-between;align-items:center"><h3>Baumstruktur</h3><button id="addCategory" class="btn" type="button">+ Kategorie</button></div>
   <div id="tree"></div>
@@ -189,19 +215,37 @@ let stateTree=[]; let busy=false; let modalState=null; const collapsed = new Set
 function showMsg(text,err=false){msg.style.display='block';msg.textContent=text;msg.className='card '+(err?'alert danger':'alert success');}
 async function api(data){if(busy) throw new Error('Bitte warten…'); busy=true; try{const fd=new FormData(); Object.entries(data).forEach(([k,v])=>{ if(Array.isArray(v)){ v.forEach(x=>fd.append(k+'[]',String(x))); } else fd.append(k,String(v)); }); fd.append('csrf_token',csrf); const r=await fetch('',{method:'POST',headers:{'X-Requested-With':'XMLHttpRequest'},body:fd}); const j=await r.json(); if(!r.ok||!j.ok) throw new Error(j.error||'Fehler'); return j;} finally {busy=false;}}
 function gradeChecks(sel=[]){return `<div><strong>Klassenstufe</strong> ${[1,2,3,4].map(g=>`<label><input type="checkbox" name="grades[]" value="${g}" ${sel.includes(g)?'checked':''}> ${g}</label>`).join(' ')}</div>`}
-function render(){treeEl.innerHTML=''; if(!stateTree.length){treeEl.innerHTML='<div>Keine Kategorien vorhanden.</div>'; return;} stateTree.forEach(c=>treeEl.appendChild(renderCategory(c))); initDnd();}
-function renderCategory(c){const nodeKey=`category-${c.id}`;const hasChildren=(c.children||[]).length>0;const isCollapsed=collapsed.has(nodeKey);const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='category'; el.dataset.id=c.id; el.innerHTML=`<div class="drop-target" data-type="category" data-parent="0" data-before="${c.id}"></div><div class="node-head"><span class="node-title">${hasChildren?`<button data-act="toggle" data-node="${nodeKey}" style="border:0;background:none;cursor:pointer">${isCollapsed?'▸':'▾'}</button>`:''}${escapeHtml(c.name_de)} <small>${escapeHtml(c.name_en)}</small></span><span class="node-actions"><button data-act="addSub" data-id="${c.id}">＋</button><button data-act="edit" data-type="category" data-id="${c.id}">✏️</button><button data-act="del" data-type="category" data-id="${c.id}">🗑️</button></span></div><div class="children" style="${isCollapsed?'display:none':''}"></div>`;
-const ch=el.querySelector('.children');
-if(!c.children.length){ch.innerHTML='<div>Keine Unterkategorien.</div>';} else c.children.forEach(s=>ch.appendChild(renderSub(s,c.id)));
-const tail=document.createElement('div'); tail.className='drop-target'; tail.dataset.type='category'; tail.dataset.parent='0'; tail.dataset.before='0'; ch.parentNode.appendChild(tail);
-return el;}
-function renderSub(s,catId){const virtual=!!s.is_virtual;const sid=String(s.id);const nodeKey=`subcategory-${sid}`;const hasChildren=(s.children||[]).length>0;const isCollapsed=collapsed.has(nodeKey);const el=document.createElement('div'); el.className='tree-node'+(virtual?'':' draggable'); if(!virtual){el.draggable=true; el.dataset.type='subcategory'; el.dataset.id=sid; el.dataset.parent=catId;} el.innerHTML=`${virtual?'':'<div class="drop-target" data-type="subcategory" data-parent="'+catId+'" data-before="'+sid+'"></div>'}<div class="node-head"><span>${hasChildren?`<button data-act="toggle" data-node="${nodeKey}" style="border:0;background:none;cursor:pointer">${isCollapsed?'▸':'▾'}</button>`:''}${escapeHtml(s.name_de)} <small>${escapeHtml(s.name_en||'')}</small></span><span class="node-actions"><button data-act="addComp" data-id="${sid}" data-virtual="${virtual?1:0}" data-category="${catId}">＋</button>${virtual?'':'<button data-act="edit" data-type="subcategory" data-id="'+sid+'">✏️</button><button data-act="del" data-type="subcategory" data-id="'+sid+'">🗑️</button>'}</span></div><div class="children" style="${isCollapsed?'display:none':''}"></div>`;
-const ch=el.querySelector('.children'); if(!s.children.length){ch.innerHTML='<div>Keine Kompetenzen.</div>';} else s.children.forEach(k=>ch.appendChild(renderComp(k,s.id)));
-const tail=document.createElement('div'); tail.className='drop-target'; tail.dataset.type='subcategory'; tail.dataset.parent=catId; tail.dataset.before='0';
-const ct=document.createElement('div'); ct.className='drop-target'; ct.dataset.type='competency'; ct.dataset.parent=virtual?'0':sid; ct.dataset.targetCategory=String(catId); ct.dataset.before='0';
-el.appendChild(ct); el.appendChild(tail);
-return el;}
-function renderComp(k,subId){const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='competency'; el.dataset.id=k.id; el.dataset.parent=subId;const grade=(k.grades||[]).map(g=>`<span class="chip">${g}</span>`).join('');const req=k.is_required?'<span class="chip">Pflicht</span>':'<span class="chip">Optional</span>'; el.innerHTML=`<div class="drop-target" data-type="competency" data-parent="${subId}" data-before="${k.id}" data-target-category="${k.category_id||0}"></div><div class="node-head"><span><div class="comp-main">${escapeHtml(k.code)} — ${escapeHtml(k.text_de)}</div>${k.text_en?`<div class="comp-sub">${escapeHtml(k.text_en)}</div>`:''}<div>${req}${grade}</div></span><span class="node-actions"><button data-act="edit" data-type="competency" data-id="${k.id}">✏️</button><button data-act="del" data-type="competency" data-id="${k.id}">🗑️</button></span></div>`; return el;}
+function render(){
+  treeEl.innerHTML='';
+  if(!stateTree.length){treeEl.innerHTML='<div>Keine Kategorien vorhanden.</div>'; return;}
+  const catList=document.createElement('div'); catList.dataset.dndList='categories';
+  stateTree.forEach(c=>{ catList.appendChild(renderCategory(c)); });
+  treeEl.appendChild(catList);
+  initDnd();
+}
+function mkDrop(type,before='0',extra={}){ const d=document.createElement('div'); d.className=`drop-target dnd-placeholder-${type}`; d.dataset.type=type; d.dataset.before=String(before); Object.entries(extra).forEach(([k,v])=>d.dataset[k]=String(v)); return d; }
+function renderCategory(c){
+  const nodeKey=`category-${c.id}`; const isCollapsed=collapsed.has(nodeKey); const hasChildren=(c.children||[]).length>0;
+  const wrap=document.createElement('div'); wrap.dataset.itemType='category'; wrap.dataset.itemId=String(c.id); wrap.className='tree-node draggable'; wrap.draggable=true; wrap.dataset.type='category'; wrap.dataset.id=String(c.id);
+  wrap.innerHTML=`<div class="node-head"><span class="node-title"><span class="drag-handle category-drag-handle">↕</span>${hasChildren?`<button data-act="toggle" data-node="${nodeKey}" style="border:0;background:none;cursor:pointer">${isCollapsed?'▸':'▾'}</button>`:''}${escapeHtml(c.name_de)} <small>${escapeHtml(c.name_en)}</small></span><span class="node-actions"><button data-act="addSub" data-id="${c.id}">＋</button><button data-act="edit" data-type="category" data-id="${c.id}">✏️</button><button data-act="del" data-type="category" data-id="${c.id}">🗑️</button></span></div>`;
+  const subList=document.createElement('div'); subList.className='children'; subList.dataset.dndList='subcategories'; subList.dataset.categoryId=String(c.id); subList.style.display=isCollapsed?'none':'';
+  subList.appendChild(mkDrop('subcategory','0',{parent:c.id}));
+  (c.children||[]).forEach(s=>{ subList.appendChild(renderSub(s,c.id)); subList.appendChild(mkDrop('subcategory','0',{parent:c.id})); });
+  wrap.appendChild(subList);
+  return wrap;
+}
+function renderSub(s,catId){
+  const virtual=!!s.is_virtual; const sid=String(s.id); const nodeKey=`subcategory-${sid}`; const isCollapsed=collapsed.has(nodeKey); const hasChildren=(s.children||[]).length>0;
+  const wrap=document.createElement('div'); wrap.className='tree-node'+(virtual?'':' draggable');
+  if(!virtual){ wrap.draggable=true; wrap.dataset.type='subcategory'; wrap.dataset.id=sid; wrap.dataset.parent=String(catId); wrap.dataset.itemType='subcategory'; wrap.dataset.itemId=sid; }
+  wrap.innerHTML=`<div class="node-head"><span>${virtual?'':`<span class="drag-handle subcategory-drag-handle">↕</span>`}${hasChildren?`<button data-act="toggle" data-node="${nodeKey}" style="border:0;background:none;cursor:pointer">${isCollapsed?'▸':'▾'}</button>`:''}${escapeHtml(s.name_de)} <small>${escapeHtml(s.name_en||'')}</small></span><span class="node-actions"><button data-act="addComp" data-id="${sid}" data-virtual="${virtual?1:0}" data-category="${catId}">＋</button>${virtual?'':'<button data-act="edit" data-type="subcategory" data-id="'+sid+'">✏️</button><button data-act="del" data-type="subcategory" data-id="'+sid+'">🗑️</button>'}</span></div>`;
+  const compList=document.createElement('div'); compList.className='children'; compList.dataset.dndList='competencies'; compList.dataset.categoryId=String(catId); compList.dataset.subcategoryId=virtual?'':sid; if(virtual) compList.dataset.virtualNoSubcategory='1'; compList.style.display=isCollapsed?'none':'';
+  compList.appendChild(mkDrop('competency','0',{parent:virtual?0:sid,targetCategory:catId}));
+  (s.children||[]).forEach(k=>{ compList.appendChild(renderComp(k,sid)); compList.appendChild(mkDrop('competency','0',{parent:virtual?0:sid,targetCategory:catId})); });
+  wrap.appendChild(compList);
+  return wrap;
+}
+function renderComp(k,subId){const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='competency'; el.dataset.itemType='competency'; el.dataset.itemId=String(k.id); el.dataset.id=String(k.id); el.dataset.parent=String(subId);const grade=(k.grades||[]).map(g=>`<span class="chip">${g}</span>`).join('');const req=k.is_required?'<span class="chip">Pflicht</span>':'<span class="chip">Optional</span>'; el.innerHTML=`<div class="node-head"><span><span class="drag-handle competency-drag-handle">↕</span><div class="comp-main">${escapeHtml(k.code)} — ${escapeHtml(k.text_de)}</div>${k.text_en?`<div class="comp-sub">${escapeHtml(k.text_en)}</div>`:''}<div>${req}${grade}</div></span><span class="node-actions"><button data-act="edit" data-type="competency" data-id="${k.id}">✏️</button><button data-act="del" data-type="competency" data-id="${k.id}">🗑️</button></span></div>`; return el;}
 function escapeHtml(s){return (s??'').toString().replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[m]));}
 
 function findNode(type,id){for(const c of stateTree){if(type==='category'&&c.id==id) return c; for(const s of c.children||[]){if(type==='subcategory'&&s.id==id)return s; for(const k of s.children||[]){if(type==='competency'&&k.id==id)return k;}}} return null;}
@@ -227,21 +271,24 @@ modal.addEventListener('cancel',(e)=>{e.preventDefault(); document.getElementByI
 
 let dragEl=null;
 function initDnd(){
-  document.querySelectorAll('.draggable').forEach(el=>{el.addEventListener('dragstart',()=>{dragEl=el;}); el.addEventListener('dragend',()=>{dragEl=null; document.querySelectorAll('.drop-target').forEach(d=>d.classList.remove('active'));});});
+  console.debug('[competencies dnd] init categories', document.querySelectorAll('[data-dnd-list="categories"]').length);
+  document.querySelectorAll('[data-dnd-list="subcategories"]').forEach(l=>console.debug('[competencies dnd] init subcategories', l.dataset.categoryId));
+  document.querySelectorAll('[data-dnd-list="competencies"]').forEach(l=>console.debug('[competencies dnd] init competencies', l.dataset.categoryId, l.dataset.subcategoryId||''));
+  document.querySelectorAll('.draggable').forEach(el=>{el.ondragstart=()=>{dragEl=el; console.debug('[competencies dnd] start', el.dataset.type, el.dataset.id);}; el.ondragend=()=>{dragEl=null; document.querySelectorAll('.drop-target').forEach(d=>d.classList.remove('active'));};});
   document.querySelectorAll('.drop-target').forEach(d=>{
-    d.addEventListener('dragover',(e)=>{if(!dragEl) return; if(d.dataset.type!==dragEl.dataset.type) return; e.preventDefault(); d.classList.add('active');});
-    d.addEventListener('dragleave',()=>d.classList.remove('active'));
-    d.addEventListener('drop', async (e)=>{e.preventDefault(); d.classList.remove('active'); if(!dragEl) return; const type=dragEl.dataset.type; if(d.dataset.type!==type) return; const parent=Number(d.dataset.parent||0); const before=Number(d.dataset.before||0);
-      try{
-        let siblings=[];
-        if(type==='category') siblings=Array.from(document.querySelectorAll('.draggable[data-type="category"]')).map(x=>Number(x.dataset.id));
-        if(type==='subcategory'){ const list=d.closest('.children'); siblings=Array.from((list||document).querySelectorAll(`.draggable[data-type=\"subcategory\"][data-parent=\"${parent}\"]`)).map(x=>Number(x.dataset.id)); }
-        if(type==='competency'){ const list=d.closest('.children'); siblings=Array.from((list||document).querySelectorAll(`.draggable[data-type=\"competency\"][data-parent=\"${parent}\"]`)).map(x=>Number(x.dataset.id)); }
-        const id=Number(dragEl.dataset.id); siblings=siblings.filter(x=>x!==id); if(before>0){const idx=siblings.indexOf(before); if(idx>=0) siblings.splice(idx,0,id); else siblings.push(id);} else siblings.push(id);
-        const res=await api({action:'reorder',type,id:String(id),new_parent_id:String(parent),target_category_id:String(d.dataset.targetCategory||0),ordered_ids:siblings});
-        stateTree=res.tree; render();
-      }catch(err){showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render();}
-    });
+    d.ondragover=(e)=>{if(!dragEl) return; const item=dragEl.dataset.type; const to=d.closest('[data-dnd-list]')?.dataset.dndList||''; const allow=(item==='category'&&to==='categories')||(item==='subcategory'&&to==='subcategories')||(item==='competency'&&to==='competencies'); if(!allow) return false; e.preventDefault(); d.classList.add('active'); console.debug('[competencies dnd] move', item, 'from', dragEl.closest('[data-dnd-list]')?.dataset.dndList, 'to', to);};
+    d.ondragleave=()=>d.classList.remove('active');
+    d.ondrop=async (e)=>{e.preventDefault(); d.classList.remove('active'); if(!dragEl) return; const itemType=dragEl.dataset.type; const targetList=d.closest('[data-dnd-list]'); const toListType=targetList?.dataset.dndList||''; if((itemType==='category'&&toListType!=='categories')||(itemType==='subcategory'&&toListType!=='subcategories')||(itemType==='competency'&&toListType!=='competencies')) return;
+      const before=Number(d.dataset.before||0); const id=Number(dragEl.dataset.id);
+      let orderedIds=Array.from((targetList?.children||[])).filter(x=>x.dataset&&x.dataset.itemType===itemType).map(x=>Number(x.dataset.itemId));
+      orderedIds=orderedIds.filter(x=>x!==id); if(before>0){const i=orderedIds.indexOf(before); if(i>=0) orderedIds.splice(i,0,id); else orderedIds.push(id);} else orderedIds.push(id);
+      const targetCategoryId = Number(targetList?.dataset.categoryId||d.dataset.targetCategory||0);
+      const subRaw = (targetList?.dataset.subcategoryId ?? '');
+      const targetSubcategoryId = itemType==='competency' ? (subRaw===''?0:Number(subRaw||0)) : Number(d.dataset.parent||0);
+      console.debug('[competencies dnd] end', {itemType,itemId:id,fromListType:dragEl.closest('[data-dnd-list]')?.dataset.dndList,toListType,targetCategoryId,targetSubcategoryId,orderedIds});
+      try{ const res=await api({action:'reorder',type:itemType,id:String(id),new_parent_id:String(targetSubcategoryId||0),target_category_id:String(targetCategoryId||0),ordered_ids:orderedIds}); stateTree=res.tree; render(); }
+      catch(err){ showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render(); }
+    };
   });
 }
 

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -157,7 +157,9 @@ if($_SERVER['REQUEST_METHOD']==='POST' && isset($_SERVER['HTTP_X_REQUESTED_WITH'
       $ordered=json_decode((string)($_POST['ordered_ids']??'[]'), true); if(!is_array($ordered)) bad('ordered_ids ungültig'); $ordered=array_values(array_map('intval',$ordered));
       if(!in_array($id,$ordered,true)) bad('ID nicht in ordered_ids');
       if($type==='category'){
-        foreach($ordered as $x){$pdo->prepare("UPDATE competency_categories SET sort_order=? WHERE id=?")->execute([array_search($x,$ordered,true)+1,$x]);}
+        $st=$pdo->query("SELECT id FROM competency_categories"); $valid=array_map('intval',$st->fetchAll(PDO::FETCH_COLUMN)?:[]);
+        foreach($ordered as $x){ if(!in_array((int)$x,$valid,true)) bad('Ungültige Kategorie-ID in ordered_ids'); }
+        foreach($ordered as $pos=>$x){$pdo->prepare("UPDATE competency_categories SET sort_order=? WHERE id=?")->execute([$pos+1,$x]);}
       } elseif($type==='subcategory'){
         if($newParent<=0) bad('Kategorie als Parent erforderlich');
         $pdo->prepare("UPDATE competency_subcategories SET category_id=? WHERE id=?")->execute([$newParent,$id]);
@@ -219,15 +221,23 @@ function render(){
   treeEl.innerHTML='';
   if(!stateTree.length){treeEl.innerHTML='<div>Keine Kategorien vorhanden.</div>'; return;}
   const catList=document.createElement('div'); catList.dataset.dndList='categories';
-  stateTree.forEach(c=>{ catList.appendChild(renderCategory(c)); });
+  if(stateTree.length){
+    catList.appendChild(mkDrop('category', String(stateTree[0].id), {dropType:'category', beforeId:String(stateTree[0].id)}));
+  }
+  stateTree.forEach((c,idx)=>{
+    catList.appendChild(renderCategory(c));
+    const nextId = stateTree[idx+1] ? String(stateTree[idx+1].id) : '';
+    catList.appendChild(mkDrop('category', nextId || '0', {dropType:'category', beforeId:nextId}));
+  });
+  console.debug('[competencies dnd category] render category dropzones', stateTree.map(c=>c.id));
   treeEl.appendChild(catList);
   initDnd();
 }
 function mkDrop(type,before='0',extra={}){ const d=document.createElement('div'); d.className=`drop-target dnd-placeholder-${type}`; d.dataset.type=type; d.dataset.before=String(before); Object.entries(extra).forEach(([k,v])=>d.dataset[k]=String(v)); return d; }
 function renderCategory(c){
   const nodeKey=`category-${c.id}`; const isCollapsed=collapsed.has(nodeKey); const hasChildren=(c.children||[]).length>0;
-  const wrap=document.createElement('div'); wrap.dataset.itemType='category'; wrap.dataset.itemId=String(c.id); wrap.className='tree-node draggable'; wrap.draggable=true; wrap.dataset.type='category'; wrap.dataset.id=String(c.id);
-  wrap.innerHTML=`<div class="node-head"><span class="node-title"><span class="drag-handle category-drag-handle">↕</span>${hasChildren?`<button data-act="toggle" data-node="${nodeKey}" style="border:0;background:none;cursor:pointer">${isCollapsed?'▸':'▾'}</button>`:''}${escapeHtml(c.name_de)} <small>${escapeHtml(c.name_en)}</small></span><span class="node-actions"><button data-act="addSub" data-id="${c.id}">＋</button><button data-act="edit" data-type="category" data-id="${c.id}">✏️</button><button data-act="del" data-type="category" data-id="${c.id}">🗑️</button></span></div>`;
+  const wrap=document.createElement('div'); wrap.dataset.itemType='category'; wrap.dataset.itemId=String(c.id); wrap.className='tree-node category-node draggable'; wrap.draggable=true; wrap.dataset.type='category'; wrap.dataset.id=String(c.id);
+  wrap.innerHTML=`<div class="node-head"><span class="node-title">${hasChildren?`<button data-act="toggle" data-node="${nodeKey}" style="border:0;background:none;cursor:pointer">${isCollapsed?'▸':'▾'}</button>`:''}${escapeHtml(c.name_de)} <small>${escapeHtml(c.name_en)}</small></span><span class="node-actions"><button data-act="addSub" data-id="${c.id}">＋</button><button data-act="edit" data-type="category" data-id="${c.id}">✏️</button><button data-act="del" data-type="category" data-id="${c.id}">🗑️</button></span></div>`;
   const subList=document.createElement('div'); subList.className='children'; subList.dataset.dndList='subcategories'; subList.dataset.categoryId=String(c.id); subList.style.display=isCollapsed?'none':'';
   subList.appendChild(mkDrop('subcategory','0',{parent:c.id}));
   (c.children||[]).forEach(s=>{ subList.appendChild(renderSub(s,c.id)); subList.appendChild(mkDrop('subcategory','0',{parent:c.id})); });
@@ -238,14 +248,14 @@ function renderSub(s,catId){
   const virtual=!!s.is_virtual; const sid=String(s.id); const nodeKey=`subcategory-${sid}`; const isCollapsed=collapsed.has(nodeKey); const hasChildren=(s.children||[]).length>0;
   const wrap=document.createElement('div'); wrap.className='tree-node'+(virtual?'':' draggable');
   if(!virtual){ wrap.draggable=true; wrap.dataset.type='subcategory'; wrap.dataset.id=sid; wrap.dataset.parent=String(catId); wrap.dataset.itemType='subcategory'; wrap.dataset.itemId=sid; }
-  wrap.innerHTML=`<div class="node-head"><span>${virtual?'':`<span class="drag-handle subcategory-drag-handle">↕</span>`}${hasChildren?`<button data-act="toggle" data-node="${nodeKey}" style="border:0;background:none;cursor:pointer">${isCollapsed?'▸':'▾'}</button>`:''}${escapeHtml(s.name_de)} <small>${escapeHtml(s.name_en||'')}</small></span><span class="node-actions"><button data-act="addComp" data-id="${sid}" data-virtual="${virtual?1:0}" data-category="${catId}">＋</button>${virtual?'':'<button data-act="edit" data-type="subcategory" data-id="'+sid+'">✏️</button><button data-act="del" data-type="subcategory" data-id="'+sid+'">🗑️</button>'}</span></div>`;
+  wrap.innerHTML=`<div class="node-head"><span>${virtual?'':''}${hasChildren?`<button data-act="toggle" data-node="${nodeKey}" style="border:0;background:none;cursor:pointer">${isCollapsed?'▸':'▾'}</button>`:''}${escapeHtml(s.name_de)} <small>${escapeHtml(s.name_en||'')}</small></span><span class="node-actions"><button data-act="addComp" data-id="${sid}" data-virtual="${virtual?1:0}" data-category="${catId}">＋</button>${virtual?'':'<button data-act="edit" data-type="subcategory" data-id="'+sid+'">✏️</button><button data-act="del" data-type="subcategory" data-id="'+sid+'">🗑️</button>'}</span></div>`;
   const compList=document.createElement('div'); compList.className='children'; compList.dataset.dndList='competencies'; compList.dataset.categoryId=String(catId); compList.dataset.subcategoryId=virtual?'':sid; if(virtual) compList.dataset.virtualNoSubcategory='1'; compList.style.display=isCollapsed?'none':'';
   compList.appendChild(mkDrop('competency','0',{parent:virtual?0:sid,targetCategory:catId}));
   (s.children||[]).forEach(k=>{ compList.appendChild(renderComp(k,sid)); compList.appendChild(mkDrop('competency','0',{parent:virtual?0:sid,targetCategory:catId})); });
   wrap.appendChild(compList);
   return wrap;
 }
-function renderComp(k,subId){const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='competency'; el.dataset.itemType='competency'; el.dataset.itemId=String(k.id); el.dataset.id=String(k.id); el.dataset.parent=String(subId);const grade=(k.grades||[]).map(g=>`<span class="chip">${g}</span>`).join('');const req=k.is_required?'<span class="chip">Pflicht</span>':'<span class="chip">Optional</span>'; el.innerHTML=`<div class="node-head"><span><span class="drag-handle competency-drag-handle">↕</span><div class="comp-main">${escapeHtml(k.code)} — ${escapeHtml(k.text_de)}</div>${k.text_en?`<div class="comp-sub">${escapeHtml(k.text_en)}</div>`:''}<div>${req}${grade}</div></span><span class="node-actions"><button data-act="edit" data-type="competency" data-id="${k.id}">✏️</button><button data-act="del" data-type="competency" data-id="${k.id}">🗑️</button></span></div>`; return el;}
+function renderComp(k,subId){const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='competency'; el.dataset.itemType='competency'; el.dataset.itemId=String(k.id); el.dataset.id=String(k.id); el.dataset.parent=String(subId);const grade=(k.grades||[]).map(g=>`<span class="chip">${g}</span>`).join('');const req=k.is_required?'<span class="chip">Pflicht</span>':'<span class="chip">Optional</span>'; el.innerHTML=`<div class="node-head"><span><div class="comp-main">${escapeHtml(k.code)} — ${escapeHtml(k.text_de)}</div>${k.text_en?`<div class="comp-sub">${escapeHtml(k.text_en)}</div>`:''}<div>${req}${grade}</div></span><span class="node-actions"><button data-act="edit" data-type="competency" data-id="${k.id}">✏️</button><button data-act="del" data-type="competency" data-id="${k.id}">🗑️</button></span></div>`; return el;}
 function escapeHtml(s){return (s??'').toString().replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[m]));}
 
 function findNode(type,id){for(const c of stateTree){if(type==='category'&&c.id==id) return c; for(const s of c.children||[]){if(type==='subcategory'&&s.id==id)return s; for(const k of s.children||[]){if(type==='competency'&&k.id==id)return k;}}} return null;}
@@ -271,22 +281,20 @@ modal.addEventListener('cancel',(e)=>{e.preventDefault(); document.getElementByI
 
 let dragEl=null;
 function initDnd(){
-  console.debug('[competencies dnd] init categories', document.querySelectorAll('[data-dnd-list="categories"]').length);
-  document.querySelectorAll('[data-dnd-list="subcategories"]').forEach(l=>console.debug('[competencies dnd] init subcategories', l.dataset.categoryId));
-  document.querySelectorAll('[data-dnd-list="competencies"]').forEach(l=>console.debug('[competencies dnd] init competencies', l.dataset.categoryId, l.dataset.subcategoryId||''));
-  document.querySelectorAll('.draggable').forEach(el=>{el.ondragstart=()=>{dragEl=el; console.debug('[competencies dnd] start', el.dataset.type, el.dataset.id);}; el.ondragend=()=>{dragEl=null; document.querySelectorAll('.drop-target').forEach(d=>d.classList.remove('active'));};});
-  document.querySelectorAll('.drop-target').forEach(d=>{
-    d.ondragover=(e)=>{if(!dragEl) return; const item=dragEl.dataset.type; const to=d.closest('[data-dnd-list]')?.dataset.dndList||''; const allow=(item==='category'&&to==='categories')||(item==='subcategory'&&to==='subcategories')||(item==='competency'&&to==='competencies'); if(!allow) return false; e.preventDefault(); d.classList.add('active'); console.debug('[competencies dnd] move', item, 'from', dragEl.closest('[data-dnd-list]')?.dataset.dndList, 'to', to);};
+  document.querySelectorAll('.draggable').forEach(el=>{el.ondragstart=()=>{ if(el.dataset.type!=='category') return; dragEl=el; console.debug('[competencies dnd category] start', Number(el.dataset.id));}; el.ondragend=()=>{dragEl=null; document.querySelectorAll('.dnd-placeholder-category').forEach(d=>d.classList.remove('active'));};});
+  document.querySelectorAll('.dnd-placeholder-category').forEach(d=>{
+    d.ondragover=(e)=>{ if(!dragEl || dragEl.dataset.type!=='category') return; if(d.dataset.dropType!=='category') return; e.preventDefault(); d.classList.add('active'); };
     d.ondragleave=()=>d.classList.remove('active');
-    d.ondrop=async (e)=>{e.preventDefault(); d.classList.remove('active'); if(!dragEl) return; const itemType=dragEl.dataset.type; const targetList=d.closest('[data-dnd-list]'); const toListType=targetList?.dataset.dndList||''; if((itemType==='category'&&toListType!=='categories')||(itemType==='subcategory'&&toListType!=='subcategories')||(itemType==='competency'&&toListType!=='competencies')) return;
-      const before=Number(d.dataset.before||0); const id=Number(dragEl.dataset.id);
-      let orderedIds=Array.from((targetList?.children||[])).filter(x=>x.dataset&&x.dataset.itemType===itemType).map(x=>Number(x.dataset.itemId));
-      orderedIds=orderedIds.filter(x=>x!==id); if(before>0){const i=orderedIds.indexOf(before); if(i>=0) orderedIds.splice(i,0,id); else orderedIds.push(id);} else orderedIds.push(id);
-      const targetCategoryId = Number(targetList?.dataset.categoryId||d.dataset.targetCategory||0);
-      const subRaw = (targetList?.dataset.subcategoryId ?? '');
-      const targetSubcategoryId = itemType==='competency' ? (subRaw===''?0:Number(subRaw||0)) : Number(d.dataset.parent||0);
-      console.debug('[competencies dnd] end', {itemType,itemId:id,fromListType:dragEl.closest('[data-dnd-list]')?.dataset.dndList,toListType,targetCategoryId,targetSubcategoryId,orderedIds});
-      try{ const res=await api({action:'reorder',type:itemType,id:String(id),new_parent_id:String(targetSubcategoryId||0),target_category_id:String(targetCategoryId||0),ordered_ids:orderedIds}); stateTree=res.tree; render(); }
+    d.ondrop=async (e)=>{
+      e.preventDefault(); d.classList.remove('active');
+      if(!dragEl || dragEl.dataset.type!=='category') return;
+      const itemId=Number(dragEl.dataset.id);
+      const beforeIdRaw=(d.dataset.beforeId||'').trim();
+      const beforeId=beforeIdRaw===''?0:Number(beforeIdRaw);
+      let orderedIds=stateTree.map(c=>Number(c.id)).filter(x=>x!==itemId);
+      if(beforeId>0){ const i=orderedIds.indexOf(beforeId); if(i>=0) orderedIds.splice(i,0,itemId); else orderedIds.push(itemId);} else { orderedIds.push(itemId); }
+      console.debug('[competencies dnd category] drop', {itemId,beforeId:beforeIdRaw,orderedIds});
+      try{ const res=await api({action:'reorder',type:'category',id:String(itemId),ordered_ids:orderedIds}); stateTree=res.tree; render(); }
       catch(err){ showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render(); }
     };
   });

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -294,7 +294,7 @@ function initDnd(){
       let orderedIds=stateTree.map(c=>Number(c.id)).filter(x=>x!==itemId);
       if(beforeId>0){ const i=orderedIds.indexOf(beforeId); if(i>=0) orderedIds.splice(i,0,itemId); else orderedIds.push(itemId);} else { orderedIds.push(itemId); }
       console.debug('[competencies dnd category] drop', {itemId,beforeId:beforeIdRaw,orderedIds});
-      try{ const res=await api({action:'reorder',type:'category',id:String(itemId),ordered_ids:orderedIds}); stateTree=res.tree; render(); }
+      try{ const res=await api({action:'reorder',type:'category',id:String(itemId),ordered_ids:JSON.stringify(orderedIds)}); stateTree=res.tree; render(); }
       catch(err){ showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render(); }
     };
   });

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -201,9 +201,9 @@ render_admin_header('Kompetenzen verwalten'); ?>
 .node-title{font-weight:600}
 .node-actions button{background:transparent;border:0;cursor:pointer}
 .children{margin-left:18px}
-.drop-target{height:12px;min-height:12px;border:2px dashed transparent;border-radius:8px;margin:4px 0;display:flex;align-items:center;padding:0;font-size:0;color:transparent}
+.drop-target{height:12px;min-height:12px;border:2px dashed transparent;border-radius:8px;margin:4px 0;padding:0;font-size:0;color:transparent}
 .drop-target.active{border-color:#0b57d0;background:#eef5ff}
-.dnd-placeholder-subcategory{min-height:10px;height:10px;border-width:1px;margin:3px 0 3px 12px}
+.dnd-placeholder-subcategory{height:12px;min-height:12px;border-width:1px;margin:3px 0 3px 12px}
 .dnd-placeholder-subcategory.active{border-color:#7a3cff;background:#f5f0ff}
 body.is-dragging-category .dnd-placeholder-category{height:32px;min-height:32px;border-color:#0b57d0;background:#eef5ff}
 body.is-dragging-subcategory .dnd-placeholder-subcategory{height:30px;min-height:30px;border-color:#7a3cff;background:#f5f0ff}
@@ -307,18 +307,13 @@ modal.addEventListener('cancel',(e)=>{e.preventDefault(); document.getElementByI
 let dragEl=null;
 function initDnd(){
   console.debug('[competencies dnd] bind draggables',
-    Array.from(document.querySelectorAll('.draggable')).map(el => ({
-      type: el.dataset.type,
-      id: el.dataset.id,
-      itemType: el.dataset.itemType,
-      itemId: el.dataset.itemId
-    }))
+    Array.from(document.querySelectorAll('.draggable')).map(el => ({ type: el.dataset.type, id: el.dataset.id, itemType: el.dataset.itemType, itemId: el.dataset.itemId }))
   );
   document.querySelectorAll('.draggable').forEach(el=>{el.ondragstart=(e)=>{ 
     e.stopPropagation();
     const type = el.dataset.type;
     const id = Number(el.dataset.id || 0);
-    if(type!=='category' && type!=='subcategory'){ e.preventDefault(); return; }
+    if(type!=='category' && type!=='subcategory') return;
     dragEl=el;
     document.body.classList.remove('is-dragging-category','is-dragging-subcategory');
     document.body.classList.add(type==='category'?'is-dragging-category':'is-dragging-subcategory');
@@ -360,10 +355,10 @@ function initDnd(){
       const targetRealSubs = ((targetCat?.children)||[]).filter(s=>!s.is_virtual).map(s=>Number(s.id));
       let orderedIds=targetRealSubs.filter(x=>x!==itemId);
       if(beforeId>0){ const i=orderedIds.indexOf(beforeId); if(i>=0) orderedIds.splice(i,0,itemId); else orderedIds.push(itemId);} else { orderedIds.push(itemId); }
-      const currentIds = sourceCategoryId===targetCategoryId
-        ? ((stateTree.find(c=>Number(c.id)===sourceCategoryId)?.children)||[]).filter(s=>!s.is_virtual).map(s=>Number(s.id))
-        : targetRealSubs;
-      if(sourceCategoryId===targetCategoryId && orderedIds.join(',')===currentIds.join(',')) return;
+      if(sourceCategoryId===targetCategoryId){
+        const currentIds=((stateTree.find(c=>Number(c.id)===sourceCategoryId)?.children)||[]).filter(s=>!s.is_virtual).map(s=>Number(s.id));
+        if(orderedIds.join(',')===currentIds.join(',')) return;
+      }
       console.debug('[competencies dnd subcategory] drop', {itemId,sourceCategoryId,targetCategoryId,beforeId:beforeIdRaw,orderedIds});
       try{ const res=await api({action:'reorder',type:'subcategory',id:String(itemId),new_parent_id:String(targetCategoryId),ordered_ids:JSON.stringify(orderedIds)}); stateTree=res.tree; render(); }
       catch(err){ showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render(); }

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -201,10 +201,14 @@ render_admin_header('Kompetenzen verwalten'); ?>
 .node-title{font-weight:600}
 .node-actions button{background:transparent;border:0;cursor:pointer}
 .children{margin-left:18px}
-.drop-target{height:12px;border:2px dashed transparent;border-radius:6px;margin:4px 0}
+.drop-target{min-height:10px;border:2px dashed transparent;border-radius:8px;margin:4px 0;display:flex;align-items:center;padding:0 10px;font-size:12px;color:#7a7a7a}
 .drop-target.active{border-color:#0b57d0;background:#eef5ff}
-.dnd-placeholder-subcategory{height:8px;border-width:1px;margin:3px 0 3px 12px}
+.dnd-placeholder-subcategory{min-height:10px;border-width:1px;margin:3px 0 3px 12px}
 .dnd-placeholder-subcategory.active{border-color:#7a3cff;background:#f5f0ff}
+body.is-dragging-category .dnd-placeholder-category{min-height:40px}
+body.is-dragging-subcategory .dnd-placeholder-subcategory{min-height:38px}
+body.is-dragging-category .dnd-placeholder-subcategory{display:none}
+body.is-dragging-subcategory .dnd-placeholder-category{display:none}
 .draggable{cursor:move}
 .comp-main{font-weight:600}
 .comp-sub{font-size:12px;color:#666}
@@ -240,7 +244,7 @@ function render(){
   treeEl.appendChild(catList);
   initDnd();
 }
-function mkDrop(type,before='0',extra={}){ const d=document.createElement('div'); d.className=`drop-target dnd-placeholder-${type}`; d.dataset.type=type; d.dataset.before=String(before); Object.entries(extra).forEach(([k,v])=>d.dataset[k]=String(v)); return d; }
+function mkDrop(type,before='0',extra={}){ const d=document.createElement('div'); d.className=`drop-target dnd-placeholder-${type}`; d.dataset.type=type; d.dataset.before=String(before); Object.entries(extra).forEach(([k,v])=>d.dataset[k]=String(v)); d.textContent=type==='category'?'Kategorie hier ablegen':'Unterkategorie hier ablegen'; return d; }
 function renderCategory(c){
   const nodeKey=`category-${c.id}`; const isCollapsed=collapsed.has(nodeKey); const hasChildren=(c.children||[]).length>0;
   const wrap=document.createElement('div'); wrap.dataset.itemType='category'; wrap.dataset.itemId=String(c.id); wrap.className='tree-node category-node draggable'; wrap.draggable=true; wrap.dataset.type='category'; wrap.dataset.id=String(c.id);
@@ -303,9 +307,11 @@ function initDnd(){
     if(nested && nested!==el) return;
     if(el.dataset.type!=='category' && el.dataset.type!=='subcategory') return;
     dragEl=el; 
+    document.body.classList.remove('is-dragging-category','is-dragging-subcategory');
+    document.body.classList.add(el.dataset.type==='category'?'is-dragging-category':'is-dragging-subcategory');
     if(el.dataset.type==='category') console.debug('[competencies dnd category] start', Number(el.dataset.id));
     if(el.dataset.type==='subcategory') console.debug('[competencies dnd subcategory] start', Number(el.dataset.id), Number(el.dataset.parent||0));
-  }; el.ondragend=(e)=>{e.stopPropagation(); dragEl=null; document.querySelectorAll('.dnd-placeholder-category,.dnd-placeholder-subcategory').forEach(d=>d.classList.remove('active'));};});
+  }; el.ondragend=(e)=>{e.stopPropagation(); dragEl=null; document.body.classList.remove('is-dragging-category','is-dragging-subcategory'); document.querySelectorAll('.dnd-placeholder-category,.dnd-placeholder-subcategory').forEach(d=>d.classList.remove('active'));};});
   document.querySelectorAll('.dnd-placeholder-category').forEach(d=>{
     d.ondragover=(e)=>{ if(!dragEl || dragEl.dataset.type!=='category'){ console.debug('[competencies dnd category] dragover ignored for', dragEl?.dataset?.type); return; } if(d.dataset.dropType!=='category') return; e.preventDefault(); d.classList.add('active'); };
     d.ondragleave=()=>d.classList.remove('active');
@@ -317,6 +323,8 @@ function initDnd(){
       const beforeId=beforeIdRaw===''?0:Number(beforeIdRaw);
       let orderedIds=stateTree.map(c=>Number(c.id)).filter(x=>x!==itemId);
       if(beforeId>0){ const i=orderedIds.indexOf(beforeId); if(i>=0) orderedIds.splice(i,0,itemId); else orderedIds.push(itemId);} else { orderedIds.push(itemId); }
+      const currentIds=stateTree.map(c=>Number(c.id));
+      if(itemId===beforeId || orderedIds.join(',')===currentIds.join(',')) return;
       console.debug('[competencies dnd category] drop', {itemId,beforeId:beforeIdRaw,orderedIds});
       try{ const res=await api({action:'reorder',type:'category',id:String(itemId),ordered_ids:JSON.stringify(orderedIds)}); stateTree=res.tree; render(); }
       catch(err){ showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render(); }
@@ -337,6 +345,10 @@ function initDnd(){
       const targetRealSubs = ((targetCat?.children)||[]).filter(s=>!s.is_virtual).map(s=>Number(s.id));
       let orderedIds=targetRealSubs.filter(x=>x!==itemId);
       if(beforeId>0){ const i=orderedIds.indexOf(beforeId); if(i>=0) orderedIds.splice(i,0,itemId); else orderedIds.push(itemId);} else { orderedIds.push(itemId); }
+      const currentIds = sourceCategoryId===targetCategoryId
+        ? ((stateTree.find(c=>Number(c.id)===sourceCategoryId)?.children)||[]).filter(s=>!s.is_virtual).map(s=>Number(s.id))
+        : targetRealSubs;
+      if(itemId===beforeId || orderedIds.join(',')===currentIds.join(',')) return;
       console.debug('[competencies dnd subcategory] drop', {itemId,sourceCategoryId,targetCategoryId,beforeId:beforeIdRaw,orderedIds});
       try{ const res=await api({action:'reorder',type:'subcategory',id:String(itemId),new_parent_id:String(targetCategoryId),ordered_ids:JSON.stringify(orderedIds)}); stateTree=res.tree; render(); }
       catch(err){ showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render(); }

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -203,6 +203,8 @@ render_admin_header('Kompetenzen verwalten'); ?>
 .children{margin-left:18px}
 .drop-target{height:12px;border:2px dashed transparent;border-radius:6px;margin:4px 0}
 .drop-target.active{border-color:#0b57d0;background:#eef5ff}
+.dnd-placeholder-subcategory{height:8px;border-width:1px;margin:3px 0 3px 12px}
+.dnd-placeholder-subcategory.active{border-color:#7a3cff;background:#f5f0ff}
 .draggable{cursor:move}
 .comp-main{font-weight:600}
 .comp-sub{font-size:12px;color:#666}
@@ -295,14 +297,17 @@ modal.addEventListener('cancel',(e)=>{e.preventDefault(); document.getElementByI
 
 let dragEl=null;
 function initDnd(){
-  document.querySelectorAll('.draggable').forEach(el=>{el.ondragstart=()=>{ 
+  document.querySelectorAll('.draggable').forEach(el=>{el.ondragstart=(e)=>{ 
+    e.stopPropagation();
+    const nested = e.target.closest('.tree-node.draggable');
+    if(nested && nested!==el) return;
     if(el.dataset.type!=='category' && el.dataset.type!=='subcategory') return;
     dragEl=el; 
     if(el.dataset.type==='category') console.debug('[competencies dnd category] start', Number(el.dataset.id));
     if(el.dataset.type==='subcategory') console.debug('[competencies dnd subcategory] start', Number(el.dataset.id), Number(el.dataset.parent||0));
-  }; el.ondragend=()=>{dragEl=null; document.querySelectorAll('.dnd-placeholder-category,.dnd-placeholder-subcategory').forEach(d=>d.classList.remove('active'));};});
+  }; el.ondragend=(e)=>{e.stopPropagation(); dragEl=null; document.querySelectorAll('.dnd-placeholder-category,.dnd-placeholder-subcategory').forEach(d=>d.classList.remove('active'));};});
   document.querySelectorAll('.dnd-placeholder-category').forEach(d=>{
-    d.ondragover=(e)=>{ if(!dragEl || dragEl.dataset.type!=='category') return; if(d.dataset.dropType!=='category') return; e.preventDefault(); d.classList.add('active'); };
+    d.ondragover=(e)=>{ if(!dragEl || dragEl.dataset.type!=='category'){ console.debug('[competencies dnd category] dragover ignored for', dragEl?.dataset?.type); return; } if(d.dataset.dropType!=='category') return; e.preventDefault(); d.classList.add('active'); };
     d.ondragleave=()=>d.classList.remove('active');
     d.ondrop=async (e)=>{
       e.preventDefault(); d.classList.remove('active');
@@ -318,7 +323,7 @@ function initDnd(){
     };
   });
   document.querySelectorAll('.dnd-placeholder-subcategory').forEach(d=>{
-    d.ondragover=(e)=>{ if(!dragEl || dragEl.dataset.type!=='subcategory') return; if(d.dataset.dropType!=='subcategory') return; e.preventDefault(); d.classList.add('active'); };
+    d.ondragover=(e)=>{ if(!dragEl || dragEl.dataset.type!=='subcategory') return; if(d.dataset.dropType!=='subcategory') return; e.preventDefault(); d.classList.add('active'); console.debug('[competencies dnd subcategory] dragover allowed', Number(d.dataset.parent||0)); };
     d.ondragleave=()=>d.classList.remove('active');
     d.ondrop=async (e)=>{
       e.preventDefault(); d.classList.remove('active');

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -201,12 +201,12 @@ render_admin_header('Kompetenzen verwalten'); ?>
 .node-title{font-weight:600}
 .node-actions button{background:transparent;border:0;cursor:pointer}
 .children{margin-left:18px}
-.drop-target{min-height:10px;border:2px dashed transparent;border-radius:8px;margin:4px 0;display:flex;align-items:center;padding:0 10px;font-size:12px;color:#7a7a7a}
+.drop-target{min-height:10px;height:10px;border:2px dashed transparent;border-radius:8px;margin:4px 0;display:flex;align-items:center;padding:0 10px;font-size:12px;color:#7a7a7a}
 .drop-target.active{border-color:#0b57d0;background:#eef5ff}
-.dnd-placeholder-subcategory{min-height:10px;border-width:1px;margin:3px 0 3px 12px}
+.dnd-placeholder-subcategory{min-height:10px;height:10px;border-width:1px;margin:3px 0 3px 12px}
 .dnd-placeholder-subcategory.active{border-color:#7a3cff;background:#f5f0ff}
-body.is-dragging-category .dnd-placeholder-category{min-height:40px}
-body.is-dragging-subcategory .dnd-placeholder-subcategory{min-height:38px}
+body.is-dragging-category .dnd-placeholder-category{height:44px;min-height:44px;border-color:#0b57d0;background:#eef5ff;display:flex;align-items:center}
+body.is-dragging-subcategory .dnd-placeholder-subcategory{height:40px;min-height:40px;border-color:#7a3cff;background:#f5f0ff;display:flex;align-items:center}
 body.is-dragging-category .dnd-placeholder-subcategory{display:none}
 body.is-dragging-subcategory .dnd-placeholder-category{display:none}
 .draggable{cursor:move}
@@ -252,15 +252,20 @@ function renderCategory(c){
   const subList=document.createElement('div'); subList.className='children'; subList.dataset.dndList='subcategories'; subList.dataset.categoryId=String(c.id); subList.style.display=isCollapsed?'none':'';
   const realSubs=(c.children||[]).filter(x=>!x.is_virtual);
   const virtualSubs=(c.children||[]).filter(x=>!!x.is_virtual);
-  const firstReal=realSubs[0] ? String(realSubs[0].id) : '';
-  subList.appendChild(mkDrop('subcategory', firstReal || '0', {dropType:'subcategory', parent:c.id, beforeId:firstReal}));
-  realSubs.forEach((s,idx)=>{ 
-    subList.appendChild(renderSub(s,c.id)); 
-    const nextId = realSubs[idx+1] ? String(realSubs[idx+1].id) : '';
-    subList.appendChild(mkDrop('subcategory', nextId || '0', {dropType:'subcategory', parent:c.id, beforeId:nextId}));
-  });
+  if(realSubs.length>0){
+    const firstReal=String(realSubs[0].id);
+    subList.appendChild(mkDrop('subcategory', firstReal, {dropType:'subcategory', parent:c.id, beforeId:firstReal}));
+    realSubs.forEach((s,idx)=>{ 
+      subList.appendChild(renderSub(s,c.id)); 
+      const nextId = realSubs[idx+1] ? String(realSubs[idx+1].id) : '';
+      subList.appendChild(mkDrop('subcategory', nextId || '0', {dropType:'subcategory', parent:c.id, beforeId:nextId}));
+    });
+    virtualSubs.forEach(s=>subList.appendChild(renderSub(s,c.id)));
+  } else {
+    virtualSubs.forEach(s=>subList.appendChild(renderSub(s,c.id)));
+    subList.appendChild(mkDrop('subcategory', '0', {dropType:'subcategory', parent:c.id, beforeId:''}));
+  }
   console.debug('[competencies dnd subcategory] render subcategory dropzones', c.id, realSubs.map(s=>s.id));
-  virtualSubs.forEach(s=>subList.appendChild(renderSub(s,c.id)));
   wrap.appendChild(subList);
   return wrap;
 }
@@ -321,9 +326,15 @@ function initDnd(){
       const itemId=Number(dragEl.dataset.id);
       const beforeIdRaw=(d.dataset.beforeId||'').trim();
       const beforeId=beforeIdRaw===''?0:Number(beforeIdRaw);
+      const currentIds=stateTree.map(c=>Number(c.id));
+      const oldIndex=currentIds.indexOf(itemId);
+      const beforeIndex=beforeId>0?currentIds.indexOf(beforeId):currentIds.length;
+      if(beforeId===itemId || beforeIndex===oldIndex || beforeIndex===oldIndex+1){
+        console.debug('[competencies dnd] noop same position', { type:'category', itemId, beforeId, oldIndex, beforeIndex });
+        return;
+      }
       let orderedIds=stateTree.map(c=>Number(c.id)).filter(x=>x!==itemId);
       if(beforeId>0){ const i=orderedIds.indexOf(beforeId); if(i>=0) orderedIds.splice(i,0,itemId); else orderedIds.push(itemId);} else { orderedIds.push(itemId); }
-      const currentIds=stateTree.map(c=>Number(c.id));
       if(itemId===beforeId || orderedIds.join(',')===currentIds.join(',')) return;
       console.debug('[competencies dnd category] drop', {itemId,beforeId:beforeIdRaw,orderedIds});
       try{ const res=await api({action:'reorder',type:'category',id:String(itemId),ordered_ids:JSON.stringify(orderedIds)}); stateTree=res.tree; render(); }
@@ -341,6 +352,15 @@ function initDnd(){
       const targetCategoryId=Number(d.dataset.parent||0);
       const beforeIdRaw=(d.dataset.beforeId||'').trim();
       const beforeId=beforeIdRaw===''?0:Number(beforeIdRaw);
+      if(sourceCategoryId===targetCategoryId){
+        const sameIds=((stateTree.find(c=>Number(c.id)===sourceCategoryId)?.children)||[]).filter(s=>!s.is_virtual).map(s=>Number(s.id));
+        const oldIndex=sameIds.indexOf(itemId);
+        const beforeIndex=beforeId>0?sameIds.indexOf(beforeId):sameIds.length;
+        if(beforeId===itemId || beforeIndex===oldIndex || beforeIndex===oldIndex+1){
+          console.debug('[competencies dnd] noop same position', { type:'subcategory', itemId, beforeId, oldIndex, beforeIndex });
+          return;
+        }
+      }
       const targetCat = stateTree.find(c=>Number(c.id)===targetCategoryId);
       const targetRealSubs = ((targetCat?.children)||[]).filter(s=>!s.is_virtual).map(s=>Number(s.id));
       let orderedIds=targetRealSubs.filter(x=>x!==itemId);

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -3,216 +3,226 @@ declare(strict_types=1);
 require __DIR__ . '/../bootstrap.php';
 require __DIR__ . '/_layout.php';
 require_admin();
-$pdo = db(); $ok=null; $err=null; $gradeOptions=[1,2,3,4];
+$pdo = db();
+$gradeOptions = [1,2,3,4];
 
 function json_out(array $d, int $code=200): never { http_response_code($code); header('Content-Type: application/json; charset=utf-8'); echo json_encode($d, JSON_UNESCAPED_UNICODE); exit; }
+function bad(string $m, int $c=400): never { json_out(['ok'=>false,'error'=>$m],$c); }
 function next_comp_code(PDO $pdo, int $categoryId, string $catDe): string { $prefix=strtoupper(preg_replace('/[^A-Za-z0-9]/','',substr($catDe,0,4))?:('CAT'.$categoryId)); $st=$pdo->prepare("SELECT code FROM competencies WHERE category_id=? ORDER BY sort_order DESC,id DESC LIMIT 1"); $st->execute([$categoryId]); $last=(string)($st->fetchColumn()?:''); $n=1; if(preg_match('/-(\d+)$/',$last,$m)) $n=((int)$m[1])+1; return $prefix.'-'.str_pad((string)$n,3,'0',STR_PAD_LEFT);} 
-function resequence_sort(PDO $pdo, string $table, string $whereSql='1=1', array $params=[]): void { $st=$pdo->prepare("SELECT id FROM {$table} WHERE {$whereSql} ORDER BY sort_order,id"); $st->execute($params); $ids=array_map('intval',$st->fetchAll(PDO::FETCH_COLUMN)?:[]); $u=$pdo->prepare("UPDATE {$table} SET sort_order=? WHERE id=?"); foreach($ids as $i=>$id) $u->execute([$i+1,$id]); }
+
+function max_sort(PDO $pdo, string $table, string $where='1=1', array $params=[]): int { $st=$pdo->prepare("SELECT COALESCE(MAX(sort_order),0) FROM {$table} WHERE {$where}"); $st->execute($params); return (int)$st->fetchColumn(); }
+function normalize_order(PDO $pdo, string $table, string $where='1=1', array $params=[]): void { $st=$pdo->prepare("SELECT id FROM {$table} WHERE {$where} ORDER BY sort_order,id"); $st->execute($params); $ids=$st->fetchAll(PDO::FETCH_COLUMN)?:[]; $u=$pdo->prepare("UPDATE {$table} SET sort_order=? WHERE id=?"); foreach($ids as $i=>$id){$u->execute([$i+1,(int)$id]);}}
+
+function fetch_tree(PDO $pdo): array {
+  $cats=$pdo->query("SELECT id,name_de,name_en,sort_order FROM competency_categories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_ASSOC)?:[];
+  $subs=$pdo->query("SELECT id,category_id,name_de,name_en,sort_order FROM competency_subcategories ORDER BY category_id,sort_order,id")->fetchAll(PDO::FETCH_ASSOC)?:[];
+  $comps=$pdo->query("SELECT id,category_id,subcategory_id,code,text_de,text_en,is_required,sort_order FROM competencies WHERE subcategory_id IS NOT NULL ORDER BY subcategory_id,sort_order,id")->fetchAll(PDO::FETCH_ASSOC)?:[];
+  $grades=[]; foreach(($pdo->query("SELECT competency_id,grade_level FROM competency_grade_levels ORDER BY grade_level")->fetchAll(PDO::FETCH_ASSOC)?:[]) as $r){$grades[(int)$r['competency_id']][]=(int)$r['grade_level'];}
+  $subsByCat=[]; foreach($subs as $s){$subsByCat[(int)$s['category_id']][]=$s;}
+  $compsBySub=[]; foreach($comps as $c){$compsBySub[(int)$c['subcategory_id']][]=$c;}
+  $tree=[];
+  foreach($cats as $c){
+    $catId=(int)$c['id'];
+    $cn=[];
+    foreach(($subsByCat[$catId]??[]) as $s){
+      $subId=(int)$s['id'];
+      $items=[];
+      foreach(($compsBySub[$subId]??[]) as $it){
+        $cid=(int)$it['id'];
+        $items[]=['id'=>$cid,'type'=>'competency','title'=>(string)$it['code'].' — '.(string)$it['text_de'],'code'=>(string)$it['code'],'text_de'=>(string)$it['text_de'],'text_en'=>(string)$it['text_en'],'is_required'=>(int)$it['is_required'],'grades'=>$grades[$cid]??[],'sort_order'=>(int)$it['sort_order']];
+      }
+      $cn[]=['id'=>$subId,'type'=>'subcategory','title'=>(string)$s['name_de'],'name_de'=>(string)$s['name_de'],'name_en'=>(string)$s['name_en'],'sort_order'=>(int)$s['sort_order'],'children'=>$items];
+    }
+    $tree[]=['id'=>$catId,'type'=>'category','title'=>(string)$c['name_de'],'name_de'=>(string)$c['name_de'],'name_en'=>(string)$c['name_en'],'sort_order'=>(int)$c['sort_order'],'children'=>$cn];
+  }
+  return $tree;
+}
+
+function delete_preview(PDO $pdo, string $type, int $id): array {
+  if($type==='category'){
+    $st=$pdo->prepare("SELECT COUNT(*) FROM competency_subcategories WHERE category_id=?");$st->execute([$id]);$subs=(int)$st->fetchColumn();
+    $st=$pdo->prepare("SELECT COUNT(*) FROM competencies c INNER JOIN competency_subcategories s ON s.id=c.subcategory_id WHERE s.category_id=?");$st->execute([$id]);$comps=(int)$st->fetchColumn();
+    return ['subcategories'=>$subs,'competencies'=>$comps];
+  }
+  if($type==='subcategory'){
+    $st=$pdo->prepare("SELECT COUNT(*) FROM competencies WHERE subcategory_id=?");$st->execute([$id]);
+    return ['subcategories'=>0,'competencies'=>(int)$st->fetchColumn()];
+  }
+  return ['subcategories'=>0,'competencies'=>1];
+}
 
 if(isset($_GET['download_csv_template'])){ $csv="category_de;category_en;subcategory_de;subcategory_en;code;text_de;text_en;required;grades\n"; $csv.="Sozialkompetenz;Social skills;Kommunikation;Communication;SOZI-001;Hört anderen aufmerksam zu.;Listens attentively to others.;1;1,2\n"; header('Content-Type:text/csv; charset=utf-8'); header('Content-Disposition: attachment; filename="kompetenzen_vorlage.csv"'); echo $csv; exit; }
 
-if($_SERVER['REQUEST_METHOD']==='POST'){
-  try{ csrf_verify(); $a=(string)($_POST['action']??'');
-    if($a==='move_item'){ $type=(string)$_POST['item_type']; $id=(int)$_POST['id']; $before=(int)($_POST['before_id']??0); $targetCategory=(int)($_POST['target_category_id']??0); $targetSub=(int)($_POST['target_subcategory_id']??0);
-      if($type==='category'){resequence_sort($pdo,'competency_categories'); $ids=array_map('intval',$pdo->query("SELECT id FROM competency_categories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_COLUMN)?:[]); $u=$pdo->prepare("UPDATE competency_categories SET sort_order=? WHERE id=?");}
-      elseif($type==='subcategory'){ if($targetCategory>0){$pdo->prepare("UPDATE competency_subcategories SET category_id=? WHERE id=?")->execute([$targetCategory,$id]);} $catId=(int)$pdo->query("SELECT category_id FROM competency_subcategories WHERE id=".$id)->fetchColumn(); resequence_sort($pdo,'competency_subcategories','category_id=?',[$catId]); $st=$pdo->prepare("SELECT id FROM competency_subcategories WHERE category_id=? ORDER BY sort_order,id"); $st->execute([$catId]); $ids=array_map('intval',$st->fetchAll(PDO::FETCH_COLUMN)?:[]); $u=$pdo->prepare("UPDATE competency_subcategories SET sort_order=? WHERE id=?");}
-      else { if($targetCategory>0){ $pdo->prepare("UPDATE competencies SET category_id=?, subcategory_id=? WHERE id=?")->execute([$targetCategory, $targetSub>0?$targetSub:null, $id]); } $st=$pdo->prepare("SELECT COALESCE(category_id,0),COALESCE(subcategory_id,0) FROM competencies WHERE id=?"); $st->execute([$id]); [$catId,$subId]=array_map('intval',$st->fetch(PDO::FETCH_NUM)?:[0,0]); if($subId>0){resequence_sort($pdo,'competencies','subcategory_id=?',[$subId]); $st=$pdo->prepare("SELECT id FROM competencies WHERE subcategory_id=? ORDER BY sort_order,id"); $st->execute([$subId]);} else {resequence_sort($pdo,'competencies','category_id=? AND (subcategory_id IS NULL OR subcategory_id=0)',[$catId]); $st=$pdo->prepare("SELECT id FROM competencies WHERE category_id=? AND (subcategory_id IS NULL OR subcategory_id=0) ORDER BY sort_order,id"); $st->execute([$catId]);} $ids=array_map('intval',$st->fetchAll(PDO::FETCH_COLUMN)?:[]); $u=$pdo->prepare("UPDATE competencies SET sort_order=? WHERE id=?"); }
-      $ids=array_values(array_filter($ids,fn($v)=>$v!==$id)); $pos=array_search($before,$ids,true); if($before>0&&$pos!==false) array_splice($ids,$pos,0,[$id]); else $ids[]=$id; foreach($ids as $i=>$x)$u->execute([$i+1,$x]); json_out(['ok'=>true]);
+if($_SERVER['REQUEST_METHOD']==='POST' && isset($_SERVER['HTTP_X_REQUESTED_WITH'])){
+  try{
+    csrf_verify();
+    $a=(string)($_POST['action']??'');
+    if($a==='list_tree') json_out(['ok'=>true,'tree'=>fetch_tree($pdo)]);
+
+    if($a==='create'){
+      $type=(string)($_POST['type']??'');
+      if($type==='category'){
+        $de=trim((string)($_POST['name_de']??'')); $en=trim((string)($_POST['name_en']??'')); if($de===''||$en==='') bad('Name DE/EN erforderlich');
+        $so=max_sort($pdo,'competency_categories')+1; $pdo->prepare("INSERT INTO competency_categories(name_de,name_en,sort_order) VALUES (?,?,?)")->execute([$de,$en,$so]);
+      } elseif($type==='subcategory'){
+        $cat=(int)($_POST['parent_id']??0); if($cat<=0) bad('Kategorie erforderlich');
+        $de=trim((string)($_POST['name_de']??'')); $en=trim((string)($_POST['name_en']??'')); if($de===''||$en==='') bad('Name DE/EN erforderlich');
+        $so=max_sort($pdo,'competency_subcategories','category_id=?',[$cat])+1; $pdo->prepare("INSERT INTO competency_subcategories(category_id,name_de,name_en,sort_order) VALUES (?,?,?,?)")->execute([$cat,$de,$en,$so]);
+      } elseif($type==='competency'){
+        $sub=(int)($_POST['parent_id']??0); if($sub<=0) bad('Unterkategorie erforderlich');
+        $st=$pdo->prepare("SELECT category_id,name_de FROM competency_subcategories WHERE id=?");$st->execute([$sub]);$sr=$st->fetch(PDO::FETCH_ASSOC); if(!$sr) bad('Unterkategorie nicht gefunden');
+        $cat=(int)$sr['category_id'];
+        $de=trim((string)($_POST['text_de']??'')); $en=trim((string)($_POST['text_en']??'')); if($de===''||$en==='') bad('Kompetenztext DE/EN erforderlich');
+        $code=trim((string)($_POST['code']??'')); if($code==='') $code=next_comp_code($pdo,$cat,(string)$sr['name_de']);
+        $so=max_sort($pdo,'competencies','subcategory_id=?',[$sub])+1;
+        $pdo->prepare("INSERT INTO competencies(category_id,subcategory_id,code,text_de,text_en,is_required,sort_order) VALUES (?,?,?,?,?,?,?)")->execute([$cat,$sub,$code,$de,$en,isset($_POST['is_required'])?1:0,$so]);
+        $id=(int)$pdo->lastInsertId();
+        $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id=?")->execute([$id]);
+        foreach((array)($_POST['grades']??[]) as $g){$gi=(int)$g;if($gi>=1&&$gi<=4)$pdo->prepare("INSERT INTO competency_grade_levels(competency_id,grade_level) VALUES (?,?)")->execute([$id,$gi]);}
+      } else bad('Ungültiger Typ');
+      json_out(['ok'=>true,'tree'=>fetch_tree($pdo)]);
     }
-    if($a==='update_category'){ $pdo->prepare("UPDATE competency_categories SET name_de=?, name_en=? WHERE id=?")->execute([trim((string)$_POST['name_de']),trim((string)$_POST['name_en']),(int)$_POST['id']]); json_out(['ok'=>true]); }
-    if($a==='update_subcategory'){ $pdo->prepare("UPDATE competency_subcategories SET name_de=?, name_en=? WHERE id=?")->execute([trim((string)$_POST['name_de']),trim((string)$_POST['name_en']),(int)$_POST['id']]); json_out(['ok'=>true]); }
-    if($a==='update_competency'){ $id=(int)$_POST['id']; $code=trim((string)$_POST['code']); if($code==='') throw new RuntimeException('Code erforderlich'); $pdo->prepare("UPDATE competencies SET code=?, text_de=?, text_en=?, is_required=? WHERE id=?")->execute([$code,trim((string)$_POST['text_de']),trim((string)$_POST['text_en']),isset($_POST['is_required'])?1:0,$id]); $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id=?")->execute([$id]); foreach((array)($_POST['grades']??[]) as $g){$gi=(int)$g;if($gi>=1&&$gi<=4)$pdo->prepare("INSERT INTO competency_grade_levels(competency_id,grade_level) VALUES (?,?)")->execute([$id,$gi]);} json_out(['ok'=>true]); }
-    if($a==='add_category'){ $pdo->prepare("INSERT INTO competency_categories(name_de,name_en,sort_order) VALUES (?,?,9999)")->execute([trim((string)$_POST['name_de']),trim((string)$_POST['name_en'])]); }
-    if($a==='import_csv'){
-      if(!isset($_FILES['csv']) || !is_uploaded_file($_FILES['csv']['tmp_name'])) throw new RuntimeException('CSV-Datei fehlt.');
-      $fh = fopen($_FILES['csv']['tmp_name'], 'r'); if(!$fh) throw new RuntimeException('CSV konnte nicht gelesen werden.');
-      $line=0;
-      while(($row=fgetcsv($fh, 0, ';'))!==false){
-        $line++; if($line===1) continue; if(count($row)<9) continue;
-        [$catDe,$catEn,$subDe,$subEn,$code,$textDe,$textEn,$required,$grades] = $row;
-        $catDe=trim((string)$catDe); $catEn=trim((string)$catEn);
-        $subDe=trim((string)$subDe); $subEn=trim((string)$subEn);
-        $code=trim((string)$code); $textDe=trim((string)$textDe); $textEn=trim((string)$textEn);
-        if($catDe===''||$catEn===''||$textDe===''||$textEn==='') continue;
 
-        $st=$pdo->prepare("SELECT id FROM competency_categories WHERE LOWER(name_de)=LOWER(?) AND LOWER(name_en)=LOWER(?) LIMIT 1");
-        $st->execute([$catDe,$catEn]); $catId=(int)($st->fetchColumn()?:0);
-        if($catId<=0){ $pdo->prepare("INSERT INTO competency_categories(name_de,name_en,sort_order) VALUES (?,?,9999)")->execute([$catDe,$catEn]); $catId=(int)$pdo->lastInsertId(); }
-
-        $subId=0;
-        if($subDe!=='' || $subEn!==''){
-          $st=$pdo->prepare("SELECT id FROM competency_subcategories WHERE category_id=? AND LOWER(name_de)=LOWER(?) AND LOWER(name_en)=LOWER(?) LIMIT 1");
-          $st->execute([$catId,$subDe,$subEn]); $subId=(int)($st->fetchColumn()?:0);
-          if($subId<=0){ $pdo->prepare("INSERT INTO competency_subcategories(category_id,name_de,name_en,sort_order) VALUES (?,?,?,9999)")->execute([$catId,$subDe,$subEn]); $subId=(int)$pdo->lastInsertId(); }
-        }
-
-        $compId=0;
-        if($code!==''){
-          $st=$pdo->prepare("SELECT id FROM competencies WHERE code=? LIMIT 1");
-          $st->execute([$code]); $compId=(int)($st->fetchColumn()?:0);
-        }
-        if($compId<=0){
-          $st=$pdo->prepare("SELECT id FROM competencies WHERE category_id=? AND COALESCE(subcategory_id,0)=? AND LOWER(text_de)=LOWER(?) AND LOWER(text_en)=LOWER(?) LIMIT 1");
-          $st->execute([$catId,$subId,$textDe,$textEn]); $compId=(int)($st->fetchColumn()?:0);
-        }
-        $isReq = (trim(strtolower((string)$required))==='1' || trim(strtolower((string)$required))==='ja') ? 1 : 0;
-        if($compId>0){
-          $pdo->prepare("UPDATE competencies SET category_id=?, subcategory_id=?, code=CASE WHEN code IS NULL OR code='' THEN ? ELSE code END, text_de=?, text_en=?, is_required=? WHERE id=?")
-            ->execute([$catId,$subId>0?$subId:null,$code,$textDe,$textEn,$isReq,$compId]);
-        } else {
-          if($code==='') $code=next_comp_code($pdo,$catId,$catDe);
-          $pdo->prepare("INSERT INTO competencies(category_id,subcategory_id,code,text_de,text_en,is_required,sort_order) VALUES (?,?,?,?,?,?,9999)")
-            ->execute([$catId,$subId>0?$subId:null,$code,$textDe,$textEn,$isReq]);
-          $compId=(int)$pdo->lastInsertId();
-        }
-
-        if($compId>0){
-          $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id=?")->execute([$compId]);
-          foreach(explode(',', (string)$grades) as $g){ $gi=(int)trim($g); if($gi>=1&&$gi<=4){ $pdo->prepare("INSERT IGNORE INTO competency_grade_levels(competency_id,grade_level) VALUES (?,?)")->execute([$compId,$gi]); } }
-        }
-      }
-      fclose($fh);
-      $ok='CSV importiert.';
+    if($a==='update'){
+      $type=(string)($_POST['type']??''); $id=(int)($_POST['id']??0); if($id<=0) bad('Ungültige ID');
+      if($type==='category'){ $de=trim((string)($_POST['name_de']??'')); $en=trim((string)($_POST['name_en']??'')); if($de===''||$en==='') bad('Name DE/EN erforderlich'); $pdo->prepare("UPDATE competency_categories SET name_de=?,name_en=? WHERE id=?")->execute([$de,$en,$id]); }
+      elseif($type==='subcategory'){ $de=trim((string)($_POST['name_de']??'')); $en=trim((string)($_POST['name_en']??'')); if($de===''||$en==='') bad('Name DE/EN erforderlich'); $pdo->prepare("UPDATE competency_subcategories SET name_de=?,name_en=? WHERE id=?")->execute([$de,$en,$id]); }
+      elseif($type==='competency'){ $code=trim((string)($_POST['code']??'')); $de=trim((string)($_POST['text_de']??'')); $en=trim((string)($_POST['text_en']??'')); if($code===''||$de===''||$en==='') bad('Code und Texte erforderlich'); $pdo->prepare("UPDATE competencies SET code=?,text_de=?,text_en=?,is_required=? WHERE id=?")->execute([$code,$de,$en,isset($_POST['is_required'])?1:0,$id]); $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id=?")->execute([$id]); foreach((array)($_POST['grades']??[]) as $g){$gi=(int)$g;if($gi>=1&&$gi<=4)$pdo->prepare("INSERT INTO competency_grade_levels(competency_id,grade_level) VALUES (?,?)")->execute([$id,$gi]);} }
+      else bad('Ungültiger Typ');
+      json_out(['ok'=>true,'tree'=>fetch_tree($pdo)]);
     }
-    if($a==='add_subcategory'){ $pdo->prepare("INSERT INTO competency_subcategories(category_id,name_de,name_en,sort_order) VALUES (?,?,?,9999)")->execute([(int)$_POST['category_id'],trim((string)$_POST['name_de']),trim((string)$_POST['name_en'])]); }
-    if($a==='add_competency'){ $sub=(int)($_POST['subcategory_id']??0); $cat=(int)($_POST['category_id']??0); if($sub>0){$st=$pdo->prepare("SELECT category_id FROM competency_subcategories WHERE id=?");$st->execute([$sub]);$cat=(int)($st->fetchColumn()?:0);} $catName=(string)$pdo->query("SELECT name_de FROM competency_categories WHERE id=".$cat)->fetchColumn(); $code=trim((string)($_POST['code']??'')); if($code==='')$code=next_comp_code($pdo,$cat,$catName); $pdo->prepare("INSERT INTO competencies(category_id,subcategory_id,code,text_de,text_en,is_required,sort_order) VALUES (?,?,?,?,?,?,9999)")->execute([$cat,$sub>0?$sub:null,$code,trim((string)$_POST['text_de']),trim((string)$_POST['text_en']),isset($_POST['is_required'])?1:0]); }
-    if($a==='delete_category'){ $id=(int)$_POST['id']; $pdo->prepare("DELETE FROM competencies WHERE category_id=?")->execute([$id]); $pdo->prepare("DELETE FROM competency_subcategories WHERE category_id=?")->execute([$id]); $pdo->prepare("DELETE FROM competency_categories WHERE id=?")->execute([$id]); }
-    if($a==='delete_subcategory'){ $id=(int)$_POST['id']; $pdo->prepare("UPDATE competencies SET subcategory_id=NULL WHERE subcategory_id=?")->execute([$id]); $pdo->prepare("DELETE FROM competency_subcategories WHERE id=?")->execute([$id]); }
-    if($a==='delete_competency'){ $id=(int)$_POST['id']; $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id=?")->execute([$id]); $pdo->prepare("DELETE FROM competencies WHERE id=?")->execute([$id]); }
-    $ok='Gespeichert.';
-  }catch(Throwable $e){ if(isset($_SERVER['HTTP_X_REQUESTED_WITH'])) json_out(['ok'=>false,'error'=>$e->getMessage()],400); $err=$e->getMessage(); }
+
+    if($a==='delete_preview'){
+      $type=(string)($_POST['type']??''); $id=(int)($_POST['id']??0); if($id<=0) bad('Ungültige ID');
+      json_out(['ok'=>true,'counts'=>delete_preview($pdo,$type,$id)]);
+    }
+
+    if($a==='delete'){
+      $type=(string)($_POST['type']??''); $id=(int)($_POST['id']??0); if($id<=0) bad('Ungültige ID');
+      $pdo->beginTransaction();
+      if($type==='category'){
+        $subIds=[]; $st=$pdo->prepare("SELECT id FROM competency_subcategories WHERE category_id=?");$st->execute([$id]);$subIds=array_map('intval',$st->fetchAll(PDO::FETCH_COLUMN)?:[]);
+        if($subIds){ $in=implode(',',array_fill(0,count($subIds),'?')); $st=$pdo->prepare("SELECT id FROM competencies WHERE subcategory_id IN ($in)"); $st->execute($subIds); $compIds=array_map('intval',$st->fetchAll(PDO::FETCH_COLUMN)?:[]); if($compIds){$in2=implode(',',array_fill(0,count($compIds),'?')); $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id IN ($in2)")->execute($compIds); $pdo->prepare("DELETE FROM competencies WHERE id IN ($in2)")->execute($compIds);} $pdo->prepare("DELETE FROM competency_subcategories WHERE id IN ($in)")->execute($subIds);} 
+        $pdo->prepare("DELETE FROM competency_categories WHERE id=?")->execute([$id]);
+      } elseif($type==='subcategory'){
+        $st=$pdo->prepare("SELECT id FROM competencies WHERE subcategory_id=?");$st->execute([$id]);$compIds=array_map('intval',$st->fetchAll(PDO::FETCH_COLUMN)?:[]);
+        if($compIds){$in=implode(',',array_fill(0,count($compIds),'?')); $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id IN ($in)")->execute($compIds); $pdo->prepare("DELETE FROM competencies WHERE id IN ($in)")->execute($compIds);} 
+        $pdo->prepare("DELETE FROM competency_subcategories WHERE id=?")->execute([$id]);
+      } elseif($type==='competency'){
+        $pdo->prepare("DELETE FROM competency_grade_levels WHERE competency_id=?")->execute([$id]); $pdo->prepare("DELETE FROM competencies WHERE id=?")->execute([$id]);
+      } else bad('Ungültiger Typ');
+      $pdo->commit();
+      json_out(['ok'=>true,'tree'=>fetch_tree($pdo)]);
+    }
+
+    if($a==='reorder'){
+      $type=(string)($_POST['type']??''); $id=(int)($_POST['id']??0); $newParent=(int)($_POST['new_parent_id']??0);
+      $ordered=json_decode((string)($_POST['ordered_ids']??'[]'), true); if(!is_array($ordered)) bad('ordered_ids ungültig'); $ordered=array_values(array_map('intval',$ordered));
+      if(!in_array($id,$ordered,true)) bad('ID nicht in ordered_ids');
+      if($type==='category'){
+        foreach($ordered as $x){$pdo->prepare("UPDATE competency_categories SET sort_order=? WHERE id=?")->execute([array_search($x,$ordered,true)+1,$x]);}
+      } elseif($type==='subcategory'){
+        if($newParent<=0) bad('Kategorie als Parent erforderlich');
+        $pdo->prepare("UPDATE competency_subcategories SET category_id=? WHERE id=?")->execute([$newParent,$id]);
+        foreach($ordered as $x){$pdo->prepare("UPDATE competency_subcategories SET category_id=?, sort_order=? WHERE id=?")->execute([$newParent,array_search($x,$ordered,true)+1,$x]);}
+      } elseif($type==='competency'){
+        if($newParent<=0) bad('Unterkategorie als Parent erforderlich');
+        $st=$pdo->prepare("SELECT category_id FROM competency_subcategories WHERE id=?");$st->execute([$newParent]);$cat=(int)($st->fetchColumn()?:0); if($cat<=0) bad('Ziel-Unterkategorie nicht gefunden');
+        $pdo->prepare("UPDATE competencies SET subcategory_id=?, category_id=? WHERE id=?")->execute([$newParent,$cat,$id]);
+        foreach($ordered as $x){$pdo->prepare("UPDATE competencies SET subcategory_id=?, category_id=?, sort_order=? WHERE id=?")->execute([$newParent,$cat,array_search($x,$ordered,true)+1,$x]);}
+      } else bad('Ungültiger Typ');
+      normalize_order($pdo,'competency_categories');
+      json_out(['ok'=>true,'tree'=>fetch_tree($pdo)]);
+    }
+
+    bad('Unbekannte Action');
+  } catch(Throwable $e){ if($pdo->inTransaction()) $pdo->rollBack(); bad($e->getMessage()); }
 }
-
-$cats=$pdo->query("SELECT * FROM competency_categories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_ASSOC);
-$subs=$pdo->query("SELECT * FROM competency_subcategories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_ASSOC);
-$comps=$pdo->query("SELECT c.*, s.name_de AS sub_de, s.name_en AS sub_en FROM competencies c LEFT JOIN competency_subcategories s ON s.id=c.subcategory_id ORDER BY c.sort_order,c.id")->fetchAll(PDO::FETCH_ASSOC);
-$gradesByComp=[]; foreach(($pdo->query("SELECT competency_id,grade_level FROM competency_grade_levels")->fetchAll(PDO::FETCH_ASSOC)?:[]) as $r){$gradesByComp[(int)$r['competency_id']][]=(int)$r['grade_level'];}
-$subsByCat=[]; foreach($subs as $s)$subsByCat[(int)$s['category_id']][]=$s;
-$compsBySub=[]; foreach($comps as $c)$compsBySub[(int)($c['subcategory_id']??0)][]=$c;
-$compCountByCategory=[]; $compCountBySub=[];
-foreach($comps as $c){ $cid=(int)($c['category_id']??0); $sid=(int)($c['subcategory_id']??0); $compCountByCategory[$cid]=($compCountByCategory[$cid]??0)+1; if($sid>0)$compCountBySub[$sid]=($compCountBySub[$sid]??0)+1; }
 
 render_admin_header('Kompetenzen verwalten'); ?>
-<div class="card"><h1>Kompetenzen verwalten</h1><?php if($ok):?><div class="alert success"><?=h($ok)?></div><?php endif;?><?php if($err):?><div class="alert danger"><?=h($err)?></div><?php endif;?> <a class="btn" href="<?=h(url('admin/competencies.php?download_csv_template=1'))?>">CSV-Vorlage herunterladen</a></div>
-<details class="card"><summary><strong>CSV importieren</strong></summary><form method="post" enctype="multipart/form-data"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><input type="hidden" name="action" value="import_csv"><input class="input" type="file" name="csv" accept=".csv,text/csv" required><button class="btn">Import starten</button></form></details>
-<div class="card"><h3>Baumstruktur</h3>
-<?php foreach($cats as $cat): $catId=(int)$cat['id']; ?>
-<details class="drag" draggable="true" data-type="category" data-id="<?=$catId?>"><summary><strong><?=h($cat['name_de'])?></strong> <small><?=h($cat['name_en'])?></small> <button class="icon-edit" type="button" title="Bearbeiten" data-kind="category" data-json='<?=h(json_encode($cat,JSON_UNESCAPED_UNICODE))?>'>✏️</button><button class="icon-del" type="button" title="Löschen" data-action="delete_category" data-id="<?=$catId?>" data-count="<?= (int)($compCountByCategory[$catId] ?? 0) ?>">🗑️</button></summary>
-  <details style="margin-left:16px;" data-category-id="<?=$catId?>" data-subcategory-id="0"><summary>Ohne Unterkategorie</summary><?php foreach(($compsBySub[0]??[]) as $c): if((int)$c['category_id']!==$catId) continue; ?><div class="drag" draggable="true" data-type="competency" data-id="<?=$c['id']?>"><?=h($c['code'])?> — <?=h($c['text_de'])?> <button type="button" class="icon-edit" title="Bearbeiten" data-kind="competency" data-json='<?=h(json_encode($c+['grades'=>$gradesByComp[(int)$c['id']]??[]],JSON_UNESCAPED_UNICODE))?>'>✏️</button><button class="icon-del" type="button" title="Löschen" data-action="delete_competency" data-id="<?=$c['id']?>" data-count="1">🗑️</button></div><?php endforeach;?></details>
-  <?php foreach(($subsByCat[$catId]??[]) as $sub): $subId=(int)$sub['id']; ?>
-    <details class="drag" draggable="true" data-type="subcategory" data-id="<?=$subId?>" style="margin-left:16px;" data-category-id="<?=$catId?>" data-subcategory-id="<?=$subId?>"><summary><?=h($sub['name_de'])?> / <?=h($sub['name_en'])?> <button type="button" class="icon-edit" title="Bearbeiten" data-kind="subcategory" data-json='<?=h(json_encode($sub,JSON_UNESCAPED_UNICODE))?>'>✏️</button><button class="icon-del" type="button" title="Löschen" data-action="delete_subcategory" data-id="<?=$subId?>" data-count="<?= (int)($compCountBySub[$subId] ?? 0) ?>">🗑️</button></summary>
-    <?php foreach(($compsBySub[$subId]??[]) as $c): ?><div class="drag" draggable="true" data-type="competency" data-id="<?=$c['id']?>"><?=h($c['code'])?> — <?=h($c['text_de'])?> <button type="button" class="icon-edit" title="Bearbeiten" data-kind="competency" data-json='<?=h(json_encode($c+['grades'=>$gradesByComp[(int)$c['id']]??[]],JSON_UNESCAPED_UNICODE))?>'>✏️</button><button class="icon-del" type="button" title="Löschen" data-action="delete_competency" data-id="<?=$c['id']?>" data-count="1">🗑️</button></div><?php endforeach; ?>
-    </details>
-  <?php endforeach; ?>
-</details>
-<?php endforeach; ?>
+<div class="card"><h1>Kompetenzen verwalten</h1><a class="btn" href="<?=h(url('admin/competencies.php?download_csv_template=1'))?>">CSV-Vorlage herunterladen</a></div>
+<div id="msg" class="card" style="display:none;"></div>
+<div class="card">
+  <div style="display:flex;justify-content:space-between;align-items:center"><h3>Baumstruktur</h3><button id="addCategory" class="btn" type="button">+ Kategorie</button></div>
+  <div id="tree"></div>
 </div>
 
-<dialog id="editDlg"><form method="dialog" id="editForm"><h3 id="dlgTitle">Bearbeiten</h3><div id="dlgFields"></div><menu><button value="cancel" class="btn">Abbrechen</button><button id="saveBtn" value="default" class="btn">Speichern</button></menu></form></dialog>
-
-<details class="card"><summary><strong>Kategorie hinzufügen</strong></summary><form method="post"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><input type="hidden" name="action" value="add_category"><label>Deutsch</label><input class="input" name="name_de" required><label>English</label><input class="input" name="name_en" required><button class="btn">Speichern</button></form></details>
-<details class="card"><summary><strong>Unterkategorie hinzufügen</strong></summary><form method="post"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><input type="hidden" name="action" value="add_subcategory"><select class="input" name="category_id"><?php foreach($cats as $c):?><option value="<?=$c['id']?>"><?=h($c['name_de'])?></option><?php endforeach;?></select><label>Deutsch</label><input class="input" name="name_de" required><label>English</label><input class="input" name="name_en" required><button class="btn">Speichern</button></form></details>
-<details class="card"><summary><strong>Kompetenz hinzufügen</strong></summary><form method="post"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><input type="hidden" name="action" value="add_competency"><select class="input" name="category_id"><?php foreach($cats as $c):?><option value="<?=$c['id']?>"><?=h($c['name_de'])?></option><?php endforeach;?></select><select class="input" name="subcategory_id"><option value="0">Ohne Unterkategorie</option><?php foreach($subs as $s):?><option value="<?=$s['id']?>"><?=h($s['name_de'])?></option><?php endforeach;?></select><input class="input" name="code" placeholder="Code"><label>Deutsch</label><input class="input" name="text_de" required><label>English</label><input class="input" name="text_en" required><label><input type="checkbox" name="is_required" value="1"> Pflicht</label><div><strong>Klassenstufe:</strong> <?php foreach($gradeOptions as $g):?><label style="display:inline-block;margin-right:10px;"><input type="checkbox" name="grades[]" value="<?=$g?>"> <?=$g?></label><?php endforeach;?></div><button class="btn">Speichern</button></form></details>
+<dialog id="modal"><form method="dialog" id="modalForm"><h3 id="modalTitle"></h3><div id="modalFields"></div><menu><button class="btn" value="cancel">Abbrechen</button><button id="modalSave" class="btn" value="default">Speichern</button></menu></form></dialog>
 
 <style>
-.icon-edit,.icon-del{background:transparent;border:0;padding:0 4px;cursor:pointer}
-.drop-placeholder{height:10px;border:2px dashed #0b57d0;border-radius:6px;margin:4px 0}
-summary{cursor:pointer}
-.drag{cursor:move;padding:4px 2px}
-.card details{border:1px solid #e7e7e7;border-radius:8px;padding:6px 8px;margin:6px 0;background:#fff}
-.card .input{min-width:220px}
-.drop-zone{height:10px;border:1px dashed transparent;border-radius:4px;margin:3px 0}
-.drop-zone.active{border-color:#0b57d0;background:#eef5ff}
+.tree-node{border:1px solid #e7e7e7;border-radius:8px;padding:8px;margin:6px 0;background:#fff}
+.node-head{display:flex;justify-content:space-between;align-items:center;gap:8px}
+.node-title{font-weight:600}
+.node-actions button{background:transparent;border:0;cursor:pointer}
+.children{margin-left:18px}
+.drop-target{height:12px;border:2px dashed transparent;border-radius:6px;margin:4px 0}
+.drop-target.active{border-color:#0b57d0;background:#eef5ff}
+.draggable{cursor:move}
 </style>
 <script>
-const csrf = <?= json_encode(csrf_token()) ?>;
-let drag = null;
-let draggables = [];
-let dropZones = [];
+const csrf = <?=json_encode(csrf_token())?>;
+const treeEl=document.getElementById('tree');
+const msg=document.getElementById('msg');
+const modal=document.getElementById('modal');
+const modalTitle=document.getElementById('modalTitle');
+const modalFields=document.getElementById('modalFields');
+const modalSave=document.getElementById('modalSave');
+let stateTree=[]; let busy=false; let modalState=null;
+function showMsg(text,err=false){msg.style.display='block';msg.textContent=text;msg.className='card '+(err?'alert danger':'alert success');}
+async function api(data){if(busy) throw new Error('Bitte warten…'); busy=true; try{const fd=new FormData(); Object.entries(data).forEach(([k,v])=>fd.append(k, typeof v==='string'?v:JSON.stringify(v))); fd.append('csrf_token',csrf); const r=await fetch('',{method:'POST',headers:{'X-Requested-With':'XMLHttpRequest'},body:fd}); const j=await r.json(); if(!r.ok||!j.ok) throw new Error(j.error||'Fehler'); return j;} finally {busy=false;}}
+function gradeChecks(sel=[]){return `<div><strong>Klassenstufe</strong> ${[1,2,3,4].map(g=>`<label><input type="checkbox" name="grades[]" value="${g}" ${sel.includes(g)?'checked':''}> ${g}</label>`).join(' ')}</div>`}
+function render(){treeEl.innerHTML=''; if(!stateTree.length){treeEl.innerHTML='<div>Keine Kategorien vorhanden.</div>'; return;} stateTree.forEach(c=>treeEl.appendChild(renderCategory(c))); initDnd();}
+function renderCategory(c){const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='category'; el.dataset.id=c.id; el.innerHTML=`<div class="drop-target" data-type="category" data-parent="0" data-before="${c.id}"></div><div class="node-head"><span class="node-title">${escapeHtml(c.name_de)} <small>${escapeHtml(c.name_en)}</small></span><span class="node-actions"><button data-act="addSub" data-id="${c.id}">＋</button><button data-act="edit" data-type="category" data-id="${c.id}">✏️</button><button data-act="del" data-type="category" data-id="${c.id}">🗑️</button></span></div><div class="children"></div>`;
+const ch=el.querySelector('.children');
+if(!c.children.length){ch.innerHTML='<div>Keine Unterkategorien.</div>';} else c.children.forEach(s=>ch.appendChild(renderSub(s,c.id)));
+const tail=document.createElement('div'); tail.className='drop-target'; tail.dataset.type='category'; tail.dataset.parent='0'; tail.dataset.before='0'; ch.parentNode.appendChild(tail);
+return el;}
+function renderSub(s,catId){const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='subcategory'; el.dataset.id=s.id; el.dataset.parent=catId; el.innerHTML=`<div class="drop-target" data-type="subcategory" data-parent="${catId}" data-before="${s.id}"></div><div class="node-head"><span>${escapeHtml(s.name_de)} <small>${escapeHtml(s.name_en)}</small></span><span class="node-actions"><button data-act="addComp" data-id="${s.id}">＋</button><button data-act="edit" data-type="subcategory" data-id="${s.id}">✏️</button><button data-act="del" data-type="subcategory" data-id="${s.id}">🗑️</button></span></div><div class="children"></div>`;
+const ch=el.querySelector('.children'); if(!s.children.length){ch.innerHTML='<div>Keine Kompetenzen.</div>';} else s.children.forEach(k=>ch.appendChild(renderComp(k,s.id)));
+const tail=document.createElement('div'); tail.className='drop-target'; tail.dataset.type='subcategory'; tail.dataset.parent=catId; tail.dataset.before='0';
+const ct=document.createElement('div'); ct.className='drop-target'; ct.dataset.type='competency'; ct.dataset.parent=s.id; ct.dataset.before='0';
+el.appendChild(ct); el.appendChild(tail);
+return el;}
+function renderComp(k,subId){const el=document.createElement('div'); el.className='tree-node draggable'; el.draggable=true; el.dataset.type='competency'; el.dataset.id=k.id; el.dataset.parent=subId; el.innerHTML=`<div class="drop-target" data-type="competency" data-parent="${subId}" data-before="${k.id}"></div><div class="node-head"><span>${escapeHtml(k.code)} — ${escapeHtml(k.text_de)}</span><span class="node-actions"><button data-act="edit" data-type="competency" data-id="${k.id}">✏️</button><button data-act="del" data-type="competency" data-id="${k.id}">🗑️</button></span></div>`; return el;}
+function escapeHtml(s){return (s??'').toString().replace(/[&<>"']/g,m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[m]));}
 
-function clearDropZones(){ dropZones.forEach(z=>z.classList.remove('active')); }
-function removeDropZones(){ dropZones.forEach(z=>z.remove()); dropZones = []; }
-function mountDropZone(parent, beforeEl, type, beforeId, targetCategoryId='0', targetSubcategoryId='0'){
-  const dz = document.createElement('div');
-  dz.className = 'drop-zone';
-  dz.dataset.type = type;
-  dz.dataset.beforeId = String(beforeId);
-  dz.dataset.targetCategoryId = String(targetCategoryId);
-  dz.dataset.targetSubcategoryId = String(targetSubcategoryId);
-  parent.insertBefore(dz, beforeEl);
-  dropZones.push(dz);
-  dz.addEventListener('dragover', (e)=>{
-    if(!drag || drag.dataset.type!==dz.dataset.type) return;
-    e.preventDefault(); clearDropZones(); dz.classList.add('active');
-  });
-  dz.addEventListener('drop', async (e)=>{
-    if(!drag || drag.dataset.type!==dz.dataset.type) return;
-    e.preventDefault();
-    const fd = new FormData();
-    fd.append('csrf_token', csrf);
-    fd.append('action','move_item');
-    fd.append('item_type', drag.dataset.type);
-    fd.append('id', drag.dataset.id);
-    fd.append('before_id', dz.dataset.beforeId || '0');
-    fd.append('target_category_id', dz.dataset.targetCategoryId || '0');
-    fd.append('target_subcategory_id', dz.dataset.targetSubcategoryId || '0');
-    const res = await fetch('', {method:'POST', headers:{'X-Requested-With':'XMLHttpRequest'}, body:fd});
-    if(!res.ok) return;
-    // DOM update without reload
-    const targetParent = dz.parentNode;
-    targetParent.insertBefore(drag, dz.nextSibling);
-    if (drag.dataset.type === 'competency') {
-      const targetGroup = targetParent.closest('details[data-category-id]');
-      if (targetGroup) {
-        drag.dataset.categoryId = targetGroup.dataset.categoryId || '0';
-        drag.dataset.subcategoryId = targetGroup.dataset.subcategoryId || '0';
-      }
-    }
-    clearDropZones();
-    initDnD();
-  });
-}
+function findNode(type,id){for(const c of stateTree){if(type==='category'&&c.id==id) return c; for(const s of c.children||[]){if(type==='subcategory'&&s.id==id)return s; for(const k of s.children||[]){if(type==='competency'&&k.id==id)return k;}}} return null;}
+function openModal(cfg){modalState=cfg; modalTitle.textContent=cfg.title; modalFields.innerHTML=cfg.html; modal.showModal();}
 
-function initDnD(){
-  removeDropZones();
-  draggables = Array.from(document.querySelectorAll('.drag'));
+document.getElementById('addCategory').addEventListener('click',()=>openModal({mode:'create',type:'category',title:'Kategorie hinzufügen',html:'<label>Deutsch</label><input class="input" name="name_de" required><label>English</label><input class="input" name="name_en" required>'}));
+treeEl.addEventListener('click', async (e)=>{const b=e.target.closest('button[data-act]'); if(!b) return; const act=b.dataset.act; const id=Number(b.dataset.id);
+if(act==='addSub'){openModal({mode:'create',type:'subcategory',parent:id,title:'Unterkategorie hinzufügen',html:'<label>Deutsch</label><input class="input" name="name_de" required><label>English</label><input class="input" name="name_en" required>'});}
+if(act==='addComp'){openModal({mode:'create',type:'competency',parent:id,title:'Kompetenz hinzufügen',html:'<label>Code (optional)</label><input class="input" name="code"><label>Deutsch</label><input class="input" name="text_de" required><label>English</label><input class="input" name="text_en" required><label><input type="checkbox" name="is_required" value="1"> Pflicht</label>'+gradeChecks([])});}
+if(act==='edit'){const n=findNode(b.dataset.type,id); if(!n) return; if(b.dataset.type==='category') openModal({mode:'update',type:'category',id,title:'Kategorie bearbeiten',html:`<label>Deutsch</label><input class="input" name="name_de" value="${escapeHtml(n.name_de)}" required><label>English</label><input class="input" name="name_en" value="${escapeHtml(n.name_en)}" required>`});
+if(b.dataset.type==='subcategory') openModal({mode:'update',type:'subcategory',id,title:'Unterkategorie bearbeiten',html:`<label>Deutsch</label><input class="input" name="name_de" value="${escapeHtml(n.name_de)}" required><label>English</label><input class="input" name="name_en" value="${escapeHtml(n.name_en)}" required>`});
+if(b.dataset.type==='competency') openModal({mode:'update',type:'competency',id,title:'Kompetenz bearbeiten',html:`<label>Code</label><input class="input" name="code" value="${escapeHtml(n.code)}" required><label>Deutsch</label><input class="input" name="text_de" value="${escapeHtml(n.text_de)}" required><label>English</label><input class="input" name="text_en" value="${escapeHtml(n.text_en)}" required><label><input type="checkbox" name="is_required" value="1" ${n.is_required? 'checked':''}> Pflicht</label>${gradeChecks((n.grades||[]).map(Number))}`});}
+if(act==='del'){try{const t=b.dataset.type; const prev=await api({action:'delete_preview',type:t,id:String(id)}); let txt=''; if(t==='category') txt=`Diese Kategorie enthält ${prev.counts.subcategories} Unterkategorien und ${prev.counts.competencies} Kompetenzen. Wirklich löschen?`; if(t==='subcategory') txt=`Diese Unterkategorie enthält ${prev.counts.competencies} Kompetenzen. Wirklich löschen?`; if(t==='competency') txt='Diese Kompetenz wirklich löschen?'; if(!confirm(txt)) return; const res=await api({action:'delete',type:t,id:String(id)}); stateTree=res.tree; render(); showMsg('Gelöscht.'); }catch(err){showMsg(err.message,true);} }
+});
 
-  // category level zones
-  const categoryNodes = Array.from(document.querySelectorAll('.drag[data-type="category"]'));
-  for (const node of categoryNodes) mountDropZone(node.parentNode, node, 'category', node.dataset.id);
-  if (categoryNodes.length) mountDropZone(categoryNodes[0].parentNode, null, 'category', 0);
+modalSave.addEventListener('click', async (e)=>{e.preventDefault(); if(!modalState) return; const fd=new FormData(document.getElementById('modalForm')); const data={action:modalState.mode==='create'?'create':'update',type:modalState.type}; if(modalState.id) data.id=String(modalState.id); if(modalState.parent) data.parent_id=String(modalState.parent); for(const [k,v] of fd.entries()){ if(k.endsWith('[]')){ if(!data[k]) data[k]=[]; data[k].push(v);} else data[k]=v; }
+  try{ modalSave.disabled=true; const res=await api(data); stateTree=res.tree; render(); modal.close(); showMsg('Gespeichert.'); }catch(err){showMsg(err.message,true);} finally {modalSave.disabled=false;}
+});
 
-  // subcategory + competency zones per group
-  const groupDetails = Array.from(document.querySelectorAll('details[data-category-id]'));
-  for (const g of groupDetails) {
-    const cat = g.dataset.categoryId || '0';
-    const sub = g.dataset.subcategoryId || '0';
-    const directChildren = Array.from(g.children);
-    const subs = directChildren.filter(n => n.classList && n.classList.contains('drag') && n.dataset.type === 'subcategory');
-    if (sub === '0') {
-      for (const node of subs) mountDropZone(node.parentNode, node, 'subcategory', node.dataset.id, cat, '0');
-      mountDropZone(g, null, 'subcategory', 0, cat, '0');
-    }
-
-    const comps = directChildren.filter(n => n.classList && n.classList.contains('drag') && n.dataset.type === 'competency');
-    for (const node of comps) mountDropZone(node.parentNode, node, 'competency', node.dataset.id, cat, sub);
-    mountDropZone(g, null, 'competency', 0, cat, sub);
-  }
-
-  draggables.forEach(el => {
-    el.ondragstart = () => { drag = el; el.classList.add('is-dragging'); };
-    el.ondragend = () => { el.classList.remove('is-dragging'); drag = null; clearDropZones(); };
+let dragEl=null;
+function initDnd(){
+  document.querySelectorAll('.draggable').forEach(el=>{el.addEventListener('dragstart',()=>{dragEl=el;}); el.addEventListener('dragend',()=>{dragEl=null; document.querySelectorAll('.drop-target').forEach(d=>d.classList.remove('active'));});});
+  document.querySelectorAll('.drop-target').forEach(d=>{
+    d.addEventListener('dragover',(e)=>{if(!dragEl) return; if(d.dataset.type!==dragEl.dataset.type) return; e.preventDefault(); d.classList.add('active');});
+    d.addEventListener('dragleave',()=>d.classList.remove('active'));
+    d.addEventListener('drop', async (e)=>{e.preventDefault(); d.classList.remove('active'); if(!dragEl) return; const type=dragEl.dataset.type; if(d.dataset.type!==type) return; const parent=Number(d.dataset.parent||0); const before=Number(d.dataset.before||0);
+      try{
+        let siblings=[];
+        if(type==='category') siblings=Array.from(document.querySelectorAll('.draggable[data-type="category"]')).map(x=>Number(x.dataset.id));
+        if(type==='subcategory') siblings=Array.from(document.querySelectorAll(`.draggable[data-type="subcategory"][data-parent="${parent}"]`)).map(x=>Number(x.dataset.id));
+        if(type==='competency') siblings=Array.from(document.querySelectorAll(`.draggable[data-type="competency"][data-parent="${parent}"]`)).map(x=>Number(x.dataset.id));
+        const id=Number(dragEl.dataset.id); siblings=siblings.filter(x=>x!==id); if(before>0){const idx=siblings.indexOf(before); if(idx>=0) siblings.splice(idx,0,id); else siblings.push(id);} else siblings.push(id);
+        const res=await api({action:'reorder',type,id:String(id),new_parent_id:String(parent),ordered_ids:siblings});
+        stateTree=res.tree; render();
+      }catch(err){showMsg(err.message,true); const res=await api({action:'list_tree'}); stateTree=res.tree; render();}
+    });
   });
 }
-initDnD();
-document.querySelectorAll('.icon-del').forEach(btn=>btn.addEventListener('click', async ()=>{const count=Number(btn.dataset.count||0); const action=btn.dataset.action||''; const id=btn.dataset.id||''; const txt=(action==='delete_competency')?'Diese Kompetenz löschen?':`Wirklich löschen? Dabei werden ${count} Kompetenzen entfernt.`; if(!confirm(txt)) return; const fd=new FormData(); fd.append('csrf_token',csrf); fd.append('action',action); fd.append('id',id); const res=await fetch('',{method:'POST',headers:{'X-Requested-With':'XMLHttpRequest'},body:fd}); if(res.ok){ const row=btn.closest('.drag, details'); if(row) row.remove(); }}));
-const dlg=document.getElementById('editDlg'), fields=document.getElementById('dlgFields'), title=document.getElementById('dlgTitle'), save=document.getElementById('saveBtn');
-let current=null;
-function gradeRow(sel=[]){let h='<div><strong>Klassenstufe:</strong> '; for(const g of [1,2,3,4]) h+=`<label style="display:inline-block;margin-right:10px;"><input type="checkbox" name="grades[]" value="${g}" ${sel.includes(g)?'checked':''}> ${g}</label>`; return h+'</div>'}
-document.querySelectorAll('.icon-edit').forEach(b=>b.addEventListener('click',()=>{current={kind:b.dataset.kind,data:JSON.parse(b.dataset.json)}; if(current.kind==='category'){title.textContent='Kategorie bearbeiten'; fields.innerHTML=`<input type="hidden" name="id" value="${current.data.id}"><label>Deutsch</label><input class="input" name="name_de" value="${current.data.name_de||''}"><label>English</label><input class="input" name="name_en" value="${current.data.name_en||''}">`;}
-if(current.kind==='subcategory'){title.textContent='Unterkategorie bearbeiten'; fields.innerHTML=`<input type="hidden" name="id" value="${current.data.id}"><label>Deutsch</label><input class="input" name="name_de" value="${current.data.name_de||''}"><label>English</label><input class="input" name="name_en" value="${current.data.name_en||''}">`;}
-if(current.kind==='competency'){title.textContent='Kompetenz bearbeiten'; fields.innerHTML=`<input type="hidden" name="id" value="${current.data.id}"><label>Code</label><input class="input" name="code" value="${current.data.code||''}"><label>Deutsch</label><input class="input" name="text_de" value="${current.data.text_de||''}"><label>English</label><input class="input" name="text_en" value="${current.data.text_en||''}"><label><input type="checkbox" name="is_required" value="1" ${(current.data.is_required==1)?'checked':''}> Pflicht</label>${gradeRow((current.data.grades||[]).map(Number))}`;}
- dlg.showModal(); }));
-save.addEventListener('click', async (e)=>{e.preventDefault(); if(!current) return; const fd=new FormData(document.getElementById('editForm')); fd.append('csrf_token',csrf); fd.append('action', current.kind==='category'?'update_category':current.kind==='subcategory'?'update_subcategory':'update_competency'); const res=await fetch('',{method:'POST',headers:{'X-Requested-With':'XMLHttpRequest'},body:fd}); if(res.ok) dlg.close();});
+
+(async()=>{const res=await api({action:'list_tree'}); stateTree=res.tree; render();})();
 </script>
 <?php render_admin_footer();

--- a/admin/latex_templates.php
+++ b/admin/latex_templates.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/_layout.php';
+require_admin();
+
+render_admin_header(t('latex.title', 'Kompetenz-PDF erstellen'));
+$latexBuildUrl = url('admin/pdf_preview.php');
+require __DIR__ . '/../shared/latex_page.php';
+render_admin_footer();

--- a/admin/pdf_preview.php
+++ b/admin/pdf_preview.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+require_admin();
+
+require __DIR__ . '/../shared/build.php';

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1176,6 +1176,36 @@ function ensure_schema(PDO $pdo): void {
       }
     }
 
+
+    // --- Competency catalog (DB-backed for LaTeX template builder)
+    if (!db_has_table($pdo, 'competency_categories')) {
+      $pdo->exec("CREATE TABLE competency_categories (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, name_de VARCHAR(255) NOT NULL, name_en VARCHAR(255) DEFAULT '', sort_order INT NOT NULL DEFAULT 0, created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, PRIMARY KEY (id), KEY idx_comp_cat_sort (sort_order,id)) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    }
+    if (!db_has_table($pdo, 'competency_subcategories')) {
+      $pdo->exec("CREATE TABLE competency_subcategories (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, category_id BIGINT UNSIGNED NOT NULL, name_de VARCHAR(255) NOT NULL, name_en VARCHAR(255) DEFAULT '', sort_order INT NOT NULL DEFAULT 0, created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, PRIMARY KEY (id), KEY idx_comp_sub_cat (category_id,sort_order,id)) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    }
+    if (!db_has_table($pdo, 'competencies')) {
+      $pdo->exec("CREATE TABLE competencies (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, category_id BIGINT UNSIGNED DEFAULT NULL, subcategory_id BIGINT UNSIGNED DEFAULT NULL, code VARCHAR(80) DEFAULT NULL, text_de TEXT NOT NULL, text_en TEXT, is_required TINYINT(1) NOT NULL DEFAULT 0, is_active TINYINT(1) NOT NULL DEFAULT 1, sort_order INT NOT NULL DEFAULT 0, created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, PRIMARY KEY (id), KEY idx_comp_cat_sort (category_id,sort_order,id), KEY idx_comp_sub_sort (subcategory_id,sort_order,id), KEY idx_comp_active (is_active)) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    }
+
+    if (db_has_table($pdo, 'competencies')) {
+      if (!db_has_column($pdo, 'competencies', 'category_id')) {
+        $pdo->exec("ALTER TABLE competencies ADD COLUMN category_id BIGINT UNSIGNED DEFAULT NULL AFTER id");
+      }
+      try {
+        $pdo->exec("ALTER TABLE competencies MODIFY COLUMN subcategory_id BIGINT UNSIGNED DEFAULT NULL");
+      } catch (Throwable $e) {
+        // ignore
+      }
+    }
+
+        if (!db_has_table($pdo, 'competency_grade_levels')) {
+      $pdo->exec("CREATE TABLE competency_grade_levels (competency_id BIGINT UNSIGNED NOT NULL, grade_level INT NOT NULL, PRIMARY KEY (competency_id, grade_level), KEY idx_comp_grade (grade_level, competency_id)) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    }
+    if (!db_has_table($pdo, 'competency_requests')) {
+      $pdo->exec("CREATE TABLE competency_requests (id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, teacher_user_id BIGINT UNSIGNED NOT NULL, category_id BIGINT UNSIGNED DEFAULT NULL, subcategory_id BIGINT UNSIGNED DEFAULT NULL, proposal_text_de TEXT NOT NULL, proposal_text_en TEXT, status ENUM('pending','approved','rejected') NOT NULL DEFAULT 'pending', admin_note TEXT, approved_competency_id BIGINT UNSIGNED DEFAULT NULL, created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, reviewed_by_user_id BIGINT UNSIGNED DEFAULT NULL, reviewed_at DATETIME DEFAULT NULL, PRIMARY KEY (id), KEY idx_comp_req_status (status, created_at)) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    }
+
     // --- AG catalog + assignments
     ensure_ag_tables($pdo);
   } catch (Throwable $e) {

--- a/shared/_layout.php
+++ b/shared/_layout.php
@@ -31,10 +31,12 @@ function nav_items_for_role(string $role): array {
 
       // Berichte
       ['label'=>t('nav.final_reports'), 'href'=>'admin/report_preview.php', 'files'=>[
-        'export.php','parent_requests.php','report_preview.php'], 'children'=>[
+        'export.php','parent_requests.php','report_preview.php','latex_templates.php'], 'children'=>[
         ['label'=>t('nav.report_preview', 'Berichtsvorschau'), 'href'=>'admin/report_preview.php', 'files'=>['report_preview.php']],
         ['label'=>t('nav.export'), 'href'=>'admin/export.php', 'files'=>['export.php']],
         ['label'=>t('nav.parent_requests'), 'href'=>'admin/parent_requests.php', 'files'=>['parent_requests.php']],
+        ['label'=>'Kompetenzen', 'href'=>'admin/competencies.php', 'files'=>['competencies.php']],
+        ['label'=>t('nav.pdf_templates', 'PDF-Vorlagen'), 'href'=>'admin/latex_templates.php', 'files'=>['latex_templates.php']],
       ]],
 
       // Stammdaten
@@ -60,10 +62,12 @@ function nav_items_for_role(string $role): array {
 
     // Berichte
     ['label'=>t('nav.final_reports'), 'href'=>'teacher/report_preview.php', 'files'=>[
-      'export.php','parents.php','report_preview.php'], 'children'=>[
+      'export.php','parents.php','report_preview.php','latex_templates.php'], 'children'=>[
         ['label'=>t('nav.report_preview', 'Berichtsvorschau'), 'href'=>'teacher/report_preview.php', 'files'=>['report_preview.php']],
         ['label'=>t('nav.export'), 'href'=>'teacher/export.php', 'files'=>['export.php']],
         ['label'=>t('nav.parent_links'), 'href'=>'teacher/parents.php', 'files'=>['parents.php']],
+        ['label'=>'Kompetenz-Anträge', 'href'=>'teacher/competency_requests.php', 'files'=>['competency_requests.php']],
+        ['label'=>t('nav.pdf_templates', 'PDF-Vorlagen'), 'href'=>'teacher/latex_templates.php', 'files'=>['latex_templates.php']],
     ]],
       
     ['label'=>t('nav.logout'), 'href'=>'logout.php', 'files'=>['logout.php']],

--- a/shared/build.php
+++ b/shared/build.php
@@ -7,7 +7,7 @@ error_reporting(E_ALL);
 
 $endpoint = 'https://latex.ytotech.com/builds/sync';
 
-$latexDir = __DIR__ . '/latex';
+$latexDir = __DIR__ . '/../latex';
 
 function readTextFileOrFail(string $path): string {
     if (!is_file($path)) {
@@ -137,6 +137,86 @@ function parse_sections(string $content): array {
     return $sections;
 }
 
+function ensure_balanced_braces_or_fail(string $tex, string $label = 'data.tex'): void {
+    $depth = 0;
+    $len = strlen($tex);
+    for ($i = 0; $i < $len; $i++) {
+        $ch = $tex[$i];
+        if ($ch === '{') $depth++;
+        if ($ch === '}') $depth--;
+        if ($depth < 0) {
+            throw new RuntimeException($label . ' hat eine überzählige schließende Klammer an Position ' . ($i + 1));
+        }
+    }
+    if ($depth !== 0) {
+        throw new RuntimeException($label . ' hat unausgeglichene Klammern (Diff: ' . $depth . ').');
+    }
+}
+
+function latex_newcommand(string $name, string $body): string {
+    return "\\newcommand{\\" . $name . "}{%\n" . $body . "}\n";
+}
+
+function latex_macro_name_for_category(int $index, string $title): string {
+    $lettersOnly = preg_replace('/[^A-Za-z]+/', '', $title) ?? '';
+    $lettersOnly = trim($lettersOnly);
+    if ($lettersOnly === '') {
+        $words = [
+            1 => 'One', 2 => 'Two', 3 => 'Three', 4 => 'Four', 5 => 'Five',
+            6 => 'Six', 7 => 'Seven', 8 => 'Eight', 9 => 'Nine', 10 => 'Ten',
+        ];
+        $suffix = $words[$index] ?? ('Idx' . $index);
+        $lettersOnly = 'DbCat' . $suffix;
+    }
+    $lettersOnly = ucfirst($lettersOnly);
+    $name = $lettersOnly . 'Skills';
+    return preg_replace('/[^A-Za-z]/', '', $name) ?: 'DbCatSkills';
+}
+
+function with_line_numbers(string $content, int $maxLines = 120): string {
+    $lines = preg_split("/\r\n|\n|\r/", $content) ?: [];
+    $out = [];
+    $n = min(count($lines), $maxLines);
+    for ($i = 0; $i < $n; $i++) {
+        $out[] = str_pad((string)($i + 1), 4, ' ', STR_PAD_LEFT) . ': ' . $lines[$i];
+    }
+    return implode("\n", $out);
+}
+
+
+function assert_no_blank_lines_in_newcommands(string $tex): void {
+    if (!preg_match_all('/\\\\newcommand\{\\\\[A-Za-z0-9]+\}\{%\\n(.*?)\\n\}/s', $tex, $m, PREG_SET_ORDER)) {
+        return;
+    }
+    foreach ($m as $cmd) {
+        $body = (string)($cmd[1] ?? '');
+        $lines = preg_split("/\r\n|\n|\r/", $body) ?: [];
+        foreach ($lines as $idx => $line) {
+            if (trim($line) === '') {
+                throw new RuntimeException('Leere Zeile innerhalb einer \newcommand-Definition gefunden (Body-Zeile ' . ($idx + 1) . ').');
+            }
+        }
+    }
+}
+
+function assert_valid_macro_names_no_digits(string $tex): void {
+    if (!preg_match_all('/\\\\newcommand\{\\\\([A-Za-z][A-Za-z0-9]*)\}/', $tex, $m, PREG_SET_ORDER)) {
+        return;
+    }
+    foreach ($m as $hit) {
+        $macro = (string)($hit[1] ?? '');
+        if (preg_match('/\d/', $macro)) {
+            throw new RuntimeException('Invalid LaTeX macro name contains digit: ' . $macro);
+        }
+    }
+}
+
+function write_debug_data_tex(string $content): string {
+    $path = sys_get_temp_dir() . '/leb_data_debug.tex';
+    @file_put_contents($path, $content);
+    return $path;
+}
+
 function generate_selected_data_tex(string $content, array $selectedSkills, array $pagebreaks): string {
     $selectedMap = array_fill_keys($selectedSkills, true);
     $pagebreakMap = array_fill_keys($pagebreaks, true);
@@ -145,9 +225,9 @@ function generate_selected_data_tex(string $content, array $selectedSkills, arra
     $sections = parse_sections($content);
 
     if (preg_match('/\\\\newcommand\{\\\\GradeLevel\}\{[^{}]*\}/', $content, $m)) {
-        $out = $m[0] . "\n\n";
+        $out = $m[0] . "\n";
     } else {
-        $out = "\\newcommand{\\GradeLevel}{1}\n\n";
+        $out = "\\newcommand{\\GradeLevel}{1}\n";
     }
 
     foreach ($macros as $macroName => $macro) {
@@ -168,19 +248,19 @@ function generate_selected_data_tex(string $content, array $selectedSkills, arra
             }
 
             if ($pendingSubSkill !== null) {
-                $body .= "  \\SubSkill{" . $pendingSubSkill['de'] . "}{" . $pendingSubSkill['en'] . "}\n\n";
+                $body .= "  \\SubSkill{" . $pendingSubSkill['de'] . "}{" . $pendingSubSkill['en'] . "}\n";
                 $pendingSubSkill = null;
             }
 
-            $body .= "  \\SkillRow{" . $item['id'] . "}\n";
-            $body .= "    {" . $item['de'] . "}\n";
-            $body .= "    {" . $item['en'] . "}\n\n";
+            $body .= "  \\SkillRow{" . $item['id'] . "}%\n";
+            $body .= "    {" . $item['de'] . "}%\n";
+            $body .= "    {" . $item['en'] . "}%\n";
             $hasAnySkill = true;
         }
 
         $out .= "\\newcommand{\\" . $macroName . "}{%\n";
         $out .= $hasAnySkill ? $body : "";
-        $out .= "}\n\n";
+        $out .= "}\n";
     }
 
     $out .= "\\newcommand{\\AllSkillSections}{%\n";
@@ -215,6 +295,8 @@ function generate_selected_data_tex(string $content, array $selectedSkills, arra
     return $out;
 }
 
+
+
 // Diese Datei erzeugst du vorher dynamisch aus der Checkbox-Auswahl:
 $originalDataTex = readTextFileOrFail($latexDir . '/data.tex');
 
@@ -229,10 +311,48 @@ if (!is_array($pagebreaks)) {
     $pagebreaks = [];
 }
 
-$selectedSkills = array_values(array_unique(array_map('strval', $selectedSkills)));
+$selectedSkills = array_values(array_unique(array_filter(array_map('strval', $selectedSkills), static fn($v) => trim((string)$v) !== '')));
 $pagebreaks = array_values(array_unique(array_map('strval', $pagebreaks)));
 
+if ((string)($_POST['source'] ?? '') === 'db' && function_exists('db')) {
+    $pdo = db();
+    $selectedGrade = (int)($_POST['grade_level'] ?? 1);
+    if ($selectedGrade < 1 || $selectedGrade > 4) $selectedGrade = 1;
+    $stReq = $pdo->prepare("SELECT c.code FROM competencies c INNER JOIN competency_grade_levels cgl ON cgl.competency_id=c.id WHERE c.is_active=1 AND c.is_required=1 AND cgl.grade_level=?");
+    $stReq->execute([$selectedGrade]);
+    $reqRows = $stReq->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    foreach ($reqRows as $code) {
+        $c = trim((string)$code);
+        if ($c !== '') {
+            $selectedSkills[] = $c;
+        }
+    }
+    $selectedSkills = array_values(array_unique(array_filter($selectedSkills, static fn($v) => trim((string)$v) !== '')));
+}
+
+
 $generatedDataTex = generate_selected_data_tex($originalDataTex, $selectedSkills, $pagebreaks);
+if ((string)($_POST['source'] ?? '') === 'db' && function_exists('db')) {
+    $pdo = db();
+    $selectedGrade = (int)($_POST['grade_level'] ?? 1);
+    if ($selectedGrade < 1 || $selectedGrade > 4) $selectedGrade = 1;
+    $generatedDataTex = generate_db_data_tex($pdo, $selectedSkills, $pagebreaks);
+    $generatedDataTex = preg_replace('/\\newcommand\{\\GradeLevel\}\{[^{}]*\}/', '\\newcommand{\\GradeLevel}{' . $selectedGrade . '}', $generatedDataTex) ?: $generatedDataTex;
+}
+
+try {
+    ensure_balanced_braces_or_fail($generatedDataTex, 'data.tex');
+    assert_no_blank_lines_in_newcommands($generatedDataTex);
+    assert_valid_macro_names_no_digits($generatedDataTex);
+    $debugPath = write_debug_data_tex($generatedDataTex);
+} catch (Throwable $e) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo "Fehler bei data.tex-Generierung: " . $e->getMessage() . "\n";
+    echo "Debug-Datei: " . sys_get_temp_dir() . "/leb_data_debug.tex\n";
+    echo with_line_numbers($generatedDataTex, 120);
+    exit;
+}
 
 $resources = [
     [
@@ -386,14 +506,17 @@ $isPdf = strncmp($body, '%PDF-', 5) === 0;
 if (!$isPdf) {
     http_response_code(500);
     header('Content-Type: text/plain; charset=utf-8');
-    echo "LaTeX konnte nicht kompiliert werden.\n\n";
+    echo "LaTeX konnte nicht kompiliert werden.\n";
     echo "HTTP Status: " . $statusCode . "\n";
-    echo "Content-Type: " . $contentType . "\n\n";
+    echo "Content-Type: " . $contentType . "\n";
+    echo "Debug-Datei: " . ($debugPath ?? (sys_get_temp_dir() . "/leb_data_debug.tex")) . "\n";
+    echo "data.tex (erste 120 Zeilen):\n";
+    echo with_line_numbers($generatedDataTex, 120) . "\n";
     echo $body;
     exit;
 }
 
-$pdfFilename = 'Vorlage.pdf';
+$pdfFilename = 'vorlage.pdf';
 
 while (ob_get_level() > 0) {
     ob_end_clean();
@@ -408,3 +531,104 @@ header('Content-Length: ' . strlen($body));
 
 echo $body;
 exit;
+function latex_escape(string $t): string {
+    $map = [
+        '\\' => '\\textbackslash{}',
+        '{' => '\\{',
+        '}' => '\\}',
+        '%' => '\\%',
+        '&' => '\\&',
+        '#' => '\\#',
+        '_' => '\\_',
+        '$' => '\\$',
+        '^' => '\\textasciicircum{}',
+        '~' => '\\textasciitilde{}',
+    ];
+    return strtr($t, $map);
+}
+
+function generate_db_data_tex(PDO $pdo, array $selectedCodes, array $pagebreakCategoryIds = []): string {
+    if (!$selectedCodes) {
+        return "\\newcommand{\\GradeLevel}{1}\n\\newcommand{\\AllSkillSections}{}\n";
+    }
+
+    $in = implode(',', array_fill(0, count($selectedCodes), '?'));
+    $sql = "SELECT c.code, c.text_de, c.text_en, COALESCE(c.category_id, s.category_id) AS category_id, s.name_de AS sub_de, s.name_en AS sub_en, cat.name_de AS cat_de, cat.name_en AS cat_en "
+         . "FROM competencies c "
+         . "LEFT JOIN competency_subcategories s ON s.id=c.subcategory_id "
+         . "LEFT JOIN competency_categories cat ON cat.id=COALESCE(c.category_id,s.category_id) "
+         . "WHERE c.code IN ($in) AND c.is_active=1 AND c.code IS NOT NULL AND c.code <> '' "
+         . "ORDER BY cat.sort_order, cat.id, CASE WHEN c.subcategory_id IS NULL OR c.subcategory_id=0 THEN 0 ELSE 1 END, s.sort_order, s.id, c.sort_order, c.id";
+
+    $st = $pdo->prepare($sql);
+    $st->execute($selectedCodes);
+    $rows = $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+    $sections = [];
+    foreach ($rows as $r) {
+        $catId = (int)($r['category_id'] ?? 0);
+        if ($catId <= 0) {
+            continue;
+        }
+        $catDe = trim((string)($r['cat_de'] ?? 'Sonstiges'));
+        if ($catDe === '') $catDe = 'Sonstiges';
+        $sub = trim((string)($r['sub_de'] ?? ''));
+        if (!isset($sections[$catId])) {
+            $sections[$catId] = [
+                'de' => $catDe,
+                'en' => (string)($r['cat_en'] ?? ''),
+                'subs' => [],
+            ];
+        }
+        if (!isset($sections[$catId]['subs'][$sub])) {
+            $sections[$catId]['subs'][$sub] = [
+                'en' => (string)($r['sub_en'] ?? ''),
+                'items' => [],
+            ];
+        }
+        $sections[$catId]['subs'][$sub]['items'][] = $r;
+    }
+
+    $out = "% AUTO-GENERATED FROM DB\n";
+    $out .= "\\newcommand{\\GradeLevel}{1}\n";
+    $i = 1;
+    foreach ($sections as $catId => $catData) {
+        $catDe = (string)($catData['de'] ?? 'Sonstiges');
+        $macro = latex_macro_name_for_category($i, $catDe);
+        $out .= "% SECTION: " . latex_escape($catDe) . "\n";
+        $macroBody = "";
+        foreach (($catData['subs'] ?? []) as $subDe => $subData) {
+            if ($subDe !== '') {
+                $macroBody .= "  \\SubSkill{" . latex_escape($subDe) . "}{" . latex_escape((string)($subData['en'] ?? '')) . "}\n";
+            }
+            foreach (($subData['items'] ?? []) as $it) {
+                $code = trim((string)($it['code'] ?? ''));
+                if ($code === '') {
+                    continue;
+                }
+                $macroBody .= "  \\SkillRow{" . latex_escape($code) . "}%\n";
+                $macroBody .= "    {" . latex_escape((string)$it['text_de']) . "}%\n";
+                $macroBody .= "    {" . latex_escape((string)($it['text_en'] ?? '')) . "}\n";
+            }
+        }
+        $out .= latex_newcommand($macro, $macroBody);
+        $sections[$catId]['macro'] = $macro;
+        $i++;
+    }
+
+    $out .= "\\newcommand{\\AllSkillSections}{%\n";
+    $pagebreakMap = [];
+    foreach ($pagebreakCategoryIds as $id) {
+        $parsed = (int)$id;
+        if ($parsed > 0) {
+            $pagebreakMap[$parsed] = true;
+        }
+    }
+    foreach ($sections as $catId => $catData) {
+        $cmd = isset($pagebreakMap[(int)$catId]) ? 'SkillSectionPageBreak' : 'SkillSection';
+        $out .= "  \\" . $cmd . "{" . latex_escape((string)($catData['de'] ?? 'Sonstiges')) . "}{" . latex_escape((string)($catData['en'] ?? '')) . "}{\\" . $catData['macro'] . "}%\n";
+    }
+    $out .= "}\n";
+
+    return $out;
+}

--- a/shared/latex_page.php
+++ b/shared/latex_page.php
@@ -1,0 +1,184 @@
+<?php
+declare(strict_types=1);
+
+function db_competency_sections(PDO $pdo, int $gradeLevel): array {
+    $sql = "SELECT c.id, c.text_de, c.text_en, c.is_required, c.code, c.subcategory_id, COALESCE(c.category_id, s.category_id) AS category_id, s.name_de AS sub_de, s.name_en AS sub_en, cat.name_de AS cat_de, cat.name_en AS cat_en FROM competencies c LEFT JOIN competency_subcategories s ON s.id=c.subcategory_id LEFT JOIN competency_categories cat ON cat.id=COALESCE(c.category_id, s.category_id) INNER JOIN competency_grade_levels cgl ON cgl.competency_id=c.id WHERE c.is_active=1 AND cgl.grade_level=? ORDER BY cat.sort_order, cat.id, CASE WHEN c.subcategory_id IS NULL OR c.subcategory_id=0 THEN 0 ELSE 1 END, s.sort_order, s.id, c.sort_order, c.id";
+    $st = $pdo->prepare($sql);
+    $st->execute([$gradeLevel]);
+    $rows = $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    $sections = [];
+    foreach ($rows as $r) {
+        $catId = (int)($r['category_id'] ?? 0);
+        if ($catId <= 0) { continue; }
+        if (!isset($sections[$catId])) {
+            $sections[$catId] = [
+                'de' => (string)($r['cat_de'] ?? ''),
+                'en' => (string)($r['cat_en'] ?? ''),
+                'direct' => [],
+                'subs' => [],
+            ];
+        }
+
+        $subId = (int)($r['subcategory_id'] ?? 0);
+        if ($subId <= 0) {
+            $sections[$catId]['direct'][] = $r;
+            continue;
+        }
+
+        if (!isset($sections[$catId]['subs'][$subId])) {
+            $sections[$catId]['subs'][$subId] = [
+                'de' => (string)($r['sub_de'] ?? ''),
+                'en' => (string)($r['sub_en'] ?? ''),
+                'items' => [],
+            ];
+        }
+        $sections[$catId]['subs'][$subId]['items'][] = $r;
+    }
+    return $sections;
+}
+
+$pdo = db();
+$selectedGrade = (int)($_GET['grade_level'] ?? $_POST['grade_level'] ?? 1);
+if ($selectedGrade < 1 || $selectedGrade > 4) $selectedGrade = 1;
+$sectionsDb = db_competency_sections($pdo, $selectedGrade);
+?>
+
+<h1><?= h(t('latex.title', 'Kompetenz-PDF erstellen')) ?></h1>
+<p><?= h(t('latex.desc', 'Wähle die Kompetenzen aus, die im PDF erscheinen sollen.')) ?></p>
+
+<form id="pdfForm" method="post" action="<?= h($latexBuildUrl) ?>">
+<input type="hidden" name="source" value="db">
+<input type="hidden" name="grade_level" value="<?= h((string)$selectedGrade) ?>">
+<div class="card" style="padding:12px;margin:12px 0;">
+  <label><strong>Klassenstufe</strong></label>
+  <select class="input" id="gradeLevelSelect">
+    <?php for($g=1;$g<=4;$g++): ?><option value="<?= $g ?>" <?= $selectedGrade===$g?'selected':'' ?>><?= $g ?></option><?php endfor; ?>
+  </select>
+</div>
+<?php foreach ($sectionsDb as $sectionId => $section): ?>
+  <details class="card" style="padding:12px 16px; margin:16px 0;" open>
+    <summary><h2 style="display:inline;"><?= h($section['de']) ?> | <span style="font-style:italic;color:#666;"><?= h((string)($section['en'] ?? '')) ?></span></h2></summary>
+    <label style="display:block; margin:8px 0 12px 0;">
+      <input type="checkbox" name="pagebreaks[]" value="<?= h((string)$sectionId) ?>">
+      Seitenumbruch vor dieser Kategorie
+    </label>
+
+    <?php if (!empty($section['direct'])): ?>
+      <details style="margin-top:12px; margin-left:12px;" open>
+        <summary><strong>Ohne Unterkategorie</strong></summary>
+        <?php foreach ($section['direct'] as $item): ?>
+          <label style="display:block; margin:8px 0 8px 18px;">
+            <input type="checkbox" name="skills[]" value="<?= h((string)$item['code']) ?>" <?= ((int)($item['is_required'] ?? 0) === 1) ? 'checked disabled' : 'checked' ?>>
+            <?php if ((int)($item['is_required'] ?? 0) === 1): ?><input type="hidden" name="skills[]" value="<?= h((string)$item['code']) ?>"><?php endif; ?>
+            <?= h((string)$item['text_de']) ?>
+            <br><span style="font-style:italic;color:#666;"><?= h((string)($item['text_en'] ?? '')) ?></span>
+          </label>
+        <?php endforeach; ?>
+      </details>
+    <?php endif; ?>
+
+    <?php foreach (($section['subs'] ?? []) as $sub): ?>
+      <details style="margin-top:12px; margin-left:12px;" open>
+        <summary><strong><?= h((string)$sub['de']) ?></strong> | <span style="font-style:italic;color:#666;"><?= h((string)($sub['en'] ?? '')) ?></span></summary>
+        <?php foreach (($sub['items'] ?? []) as $item): ?>
+          <label style="display:block; margin:8px 0 8px 18px;">
+            <input type="checkbox" name="skills[]" value="<?= h((string)$item['code']) ?>" <?= ((int)($item['is_required'] ?? 0) === 1) ? 'checked disabled' : 'checked' ?>>
+            <?php if ((int)($item['is_required'] ?? 0) === 1): ?><input type="hidden" name="skills[]" value="<?= h((string)$item['code']) ?>"><?php endif; ?>
+            <?= h((string)$item['text_de']) ?>
+            <br><span style="font-style:italic;color:#666;"><?= h((string)($item['text_en'] ?? '')) ?></span>
+          </label>
+        <?php endforeach; ?>
+      </details>
+    <?php endforeach; ?>
+  </details>
+<?php endforeach; ?>
+
+<button class="btn" type="submit" id="createPdfButton">PDF erstellen</button>
+</form>
+
+<style>
+  @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+</style>
+<div id="pdfLoadingOverlay" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,.45); z-index:9999; align-items:center; justify-content:center;">
+  <div class="card" style="padding:18px 22px; font-weight:600; display:flex; gap:12px; align-items:center;">
+    <span style="width:18px; height:18px; border:3px solid #d0d7de; border-top-color:#0b57d0; border-radius:50%; display:inline-block; animation:spin .8s linear infinite;"></span>
+    <span>PDF wird erstellt … bitte warten.</span>
+  </div>
+</div>
+
+<div id="pdfPreviewWrap" style="display:none; margin-top:24px;">
+  <iframe id="pdfPreview" style="width:100%; height:90vh;"></iframe>
+</div>
+
+<div id="pdfDebug" class="card" style="display:none; margin-top:16px; border-left:4px solid #b42318;">
+  <h3 style="margin-top:0;">Fehlerdetails</h3>
+  <pre id="pdfDebugText" style="white-space:pre-wrap; overflow:auto; max-height:280px;"></pre>
+</div>
+
+<script>
+const form = document.getElementById('pdfForm');
+const pdfPreview = document.getElementById('pdfPreview');
+const pdfPreviewWrap = document.getElementById('pdfPreviewWrap');
+const createPdfButton = document.getElementById('createPdfButton');
+const pdfLoadingOverlay = document.getElementById('pdfLoadingOverlay');
+const pdfDebug = document.getElementById('pdfDebug');
+const pdfDebugText = document.getElementById('pdfDebugText');
+let currentPdfUrl = null;
+
+document.getElementById('gradeLevelSelect').addEventListener('change', (e) => {
+  const u = new URL(window.location.href);
+  u.searchParams.set('grade_level', e.target.value);
+  window.location.href = u.toString();
+});
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  createPdfButton.disabled = true;
+  pdfLoadingOverlay.style.display = 'flex';
+
+  try {
+    pdfDebug.style.display = 'none';
+    pdfDebugText.textContent = '';
+
+    const response = await fetch(form.action, { method: 'POST', body: new FormData(form) });
+    const contentType = (response.headers.get('content-type') || '').toLowerCase();
+
+    if (!response.ok) {
+      const text = await response.text();
+      const msg = text || 'PDF konnte nicht erstellt werden.';
+      pdfDebugText.textContent = msg;
+      pdfDebug.style.display = 'block';
+      console.error('PDF build failed', { status: response.status, contentType, body: msg });
+      return;
+    }
+
+    if (!contentType.includes('application/pdf')) {
+      const text = await response.text();
+      const msg = text || 'Unerwartete Serverantwort (kein PDF).';
+      pdfDebugText.textContent = msg;
+      pdfDebug.style.display = 'block';
+      console.error('PDF build returned non-PDF response', { status: response.status, contentType, body: msg });
+      return;
+    }
+
+    const blob = await response.blob();
+
+    if (currentPdfUrl) {
+      URL.revokeObjectURL(currentPdfUrl);
+    }
+
+    currentPdfUrl = URL.createObjectURL(blob);
+    pdfPreview.src = currentPdfUrl;
+    pdfPreviewWrap.style.display = 'block';
+    pdfPreviewWrap.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  } catch (error) {
+    const msg = (error && error.message) ? error.message : 'Unbekannter Fehler bei der PDF-Erstellung.';
+    pdfDebugText.textContent = msg;
+    pdfDebug.style.display = 'block';
+    console.error('PDF build exception', error);
+  } finally {
+    createPdfButton.disabled = false;
+    pdfLoadingOverlay.style.display = 'none';
+  }
+});
+</script>

--- a/teacher/build.php
+++ b/teacher/build.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+require_teacher();
+
+require __DIR__ . '/../shared/build.php';

--- a/teacher/competency_requests.php
+++ b/teacher/competency_requests.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../bootstrap.php'; require __DIR__ . '/_layout.php'; require_teacher();
+$pdo=db(); $ok=null; $err=null;
+if($_SERVER['REQUEST_METHOD']==='POST'){ try{ csrf_verify(); $cat=(int)($_POST['category_id']??0); $sub=(int)($_POST['subcategory_id']??0); $text=trim((string)($_POST['proposal_text_de']??'')); if($text==='') throw new RuntimeException('Text fehlt'); $pdo->prepare("INSERT INTO competency_requests(teacher_user_id,category_id,subcategory_id,proposal_text_de,proposal_text_en,status) VALUES (?,?,?,?,?,'pending')")->execute([(int)current_user()['id'],$cat?:null,$sub?:null,$text,trim((string)($_POST['proposal_text_en']??''))]); $adminMails=$pdo->query("SELECT email FROM users WHERE role='admin' AND is_active=1 AND deleted_at IS NULL")->fetchAll(PDO::FETCH_COLUMN)?:[]; foreach($adminMails as $m){ if(filter_var($m,FILTER_VALIDATE_EMAIL)){ @send_email((string)$m,'Neue Kompetenz-Anfrage','<p>Es liegt ein neuer Kompetenz-Antrag vor.</p><p>'.h($text).'</p>'); }} $ok='Antrag gesendet.'; }catch(Throwable $e){$err=$e->getMessage();}}
+$cats=$pdo->query("SELECT * FROM competency_categories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_ASSOC);
+$subs=$pdo->query("SELECT * FROM competency_subcategories ORDER BY category_id,sort_order,id")->fetchAll(PDO::FETCH_ASSOC);
+render_teacher_header('Kompetenz-Anträge'); ?>
+<div class="card"><h1>Neue Kompetenz beantragen</h1><?php if($ok):?><div class="alert success"><?=h($ok)?></div><?php endif; ?><?php if($err):?><div class="alert danger"><?=h($err)?></div><?php endif; ?>
+<form method="post"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><label>Kategorie</label><select class="input" name="category_id"><option value="">-</option><?php foreach($cats as $c):?><option value="<?=$c['id']?>"><?=h($c['name_de'])?></option><?php endforeach;?></select><label>Unterkategorie</label><select class="input" name="subcategory_id"><option value="">-</option><?php foreach($subs as $s):?><option value="<?=$s['id']?>"><?=h($s['name_de'])?></option><?php endforeach;?></select><label>Vorschlag (DE)</label><textarea class="input" name="proposal_text_de" required></textarea><label>Vorschlag (EN)</label><textarea class="input" name="proposal_text_en"></textarea><button class="btn">Antrag senden</button></form></div>
+<?php render_teacher_footer();

--- a/teacher/latex_templates.php
+++ b/teacher/latex_templates.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/_layout.php';
+require_teacher();
+
+render_teacher_header(t('latex.title', 'Kompetenz-PDF erstellen'));
+$latexBuildUrl = url('teacher/pdf_preview.php');
+require __DIR__ . '/../shared/latex_page.php';
+render_teacher_footer();

--- a/teacher/pdf_preview.php
+++ b/teacher/pdf_preview.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../bootstrap.php';
+require_teacher();
+
+require __DIR__ . '/../shared/build.php';


### PR DESCRIPTION
### Motivation
- Provide a DB-backed competency catalog so admins can manage competencies and teachers can request new ones and include them in LaTeX-based PDFs. 
- Let users build competency PDFs from either a static LaTeX `data.tex` or from the competency DB filtered by grade level. 
- Improve robustness and debuggability of LaTeX generation with validation and clearer error output.

### Description
- Add database schema and migration logic in `bootstrap.php` for `competency_categories`, `competency_subcategories`, `competencies`, `competency_grade_levels`, and `competency_requests` and ensure compatibility with existing tables. 
- Implement admin tooling in `admin/competencies.php` (CRUD, drag-and-drop ordering, CSV import, grade-level links), `admin/latex_templates.php`, `admin/pdf_preview.php`, and admin `build.php`, and teacher equivalents in `teacher/*` including `teacher/competency_requests.php`. 
- Extend and harden LaTeX build flow in `shared/build.php` (support `source=db`, generate `data.tex` from DB with `generate_db_data_tex`, validation helpers `ensure_balanced_braces_or_fail`, `assert_no_blank_lines_in_newcommands`, `assert_valid_macro_names_no_digits`, debug dump of `data.tex`, change `latex` directory path, and improved response/debug output). 
- Add `shared/latex_page.php` for the UI that selects competencies and page-breaks for PDFs, and update navigation in `shared/_layout.php` to expose the new pages.

### Testing
- Ran PHP syntax checks (`php -l`) over the added and modified PHP files and they passed. 
- No automated unit tests were added as part of this change; please run the project test suite or smoke tests in your environment to validate DB migrations and LaTeX service integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ed8c0574832ea0ad03903e35b48a)