### PR TITLE
Selectable LaTeX layout templates with admin upload and secure build selection

### DIFF
--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -209,9 +209,83 @@ if($_SERVER['REQUEST_METHOD']==='POST' && isset($_SERVER['HTTP_X_REQUESTED_WITH'
   } catch(Throwable $e){ if($pdo->inTransaction()) $pdo->rollBack(); bad($e->getMessage()); }
 }
 
+
+
+$reqHighlightId = (int)($_GET['request_id'] ?? 0);
+
+if ($_SERVER['REQUEST_METHOD']==='POST' && !isset($_SERVER['HTTP_X_REQUESTED_WITH']) && (string)($_POST['action']??'')==='review_competency_request') {
+  try { csrf_verify();
+    $requestId = (int)($_POST['request_id'] ?? 0);
+    $decision = (string)($_POST['decision'] ?? '');
+    $adminComment = trim((string)($_POST['admin_comment'] ?? ''));
+    if ($requestId<=0 || !in_array($decision,['approve','reject'],true)) throw new RuntimeException('Ungültige Aktion.');
+    $st=$pdo->prepare("SELECT * FROM competency_requests WHERE id=? LIMIT 1"); $st->execute([$requestId]); $req=$st->fetch(PDO::FETCH_ASSOC);
+    if(!$req) throw new RuntimeException('Antrag nicht gefunden.');
+    if((string)$req['status']!=='pending') throw new RuntimeException('Antrag wurde bereits bearbeitet.');
+
+    $pdo->beginTransaction();
+    if($decision==='approve'){
+      $catId=(int)($req['category_id']??0); $subId=(int)($req['subcategory_id']??0);
+      if($catId<=0) throw new RuntimeException('Ungültige Kategorie im Antrag.');
+      if($subId>0){ $stSub=$pdo->prepare("SELECT category_id FROM competency_subcategories WHERE id=? LIMIT 1"); $stSub->execute([$subId]); $sCat=(int)($stSub->fetchColumn()?:0); if($sCat!==$catId) throw new RuntimeException('Unterkategorie passt nicht zur Kategorie.'); }
+      $stDup=$pdo->prepare("SELECT approved_competency_id FROM competency_requests WHERE id=? AND status='approved' LIMIT 1"); $stDup->execute([$requestId]);
+      $already=(int)($stDup->fetchColumn()?:0);
+      if($already<=0){
+        $stCat=$pdo->prepare("SELECT name_de FROM competency_categories WHERE id=? LIMIT 1"); $stCat->execute([$catId]); $catDe=(string)($stCat->fetchColumn()?:('CAT'.$catId));
+        $code = next_comp_code($pdo, $catId, $catDe);
+        $sort = $subId>0 ? max_sort($pdo,'competencies','subcategory_id=?',[$subId])+1 : max_sort($pdo,'competencies','category_id=? AND subcategory_id IS NULL',[$catId])+1;
+        $meta=json_decode((string)($req['admin_note']??''),true); if(!is_array($meta)) $meta=[];
+        $isRequired=(int)($meta['is_required']??0)===1?1:0;
+        $pdo->prepare("INSERT INTO competencies(category_id,subcategory_id,code,text_de,text_en,is_required,sort_order) VALUES (?,?,?,?,?,?,?)")
+          ->execute([$catId,$subId>0?$subId:null,$code,(string)$req['proposal_text_de'],(string)($req['proposal_text_en']??''),$isRequired,$sort]);
+        $compId=(int)$pdo->lastInsertId();
+        foreach((array)($meta['grade_levels']??[]) as $g){$gi=(int)$g; if($gi>=1&&$gi<=4){$pdo->prepare("INSERT INTO competency_grade_levels(competency_id,grade_level) VALUES (?,?)")->execute([$compId,$gi]);}}
+      } else { $compId = $already; }
+      $pdo->prepare("UPDATE competency_requests SET status='approved', reviewed_by_user_id=?, reviewed_at=NOW(), approved_competency_id=?, admin_note=? WHERE id=? AND status='pending'")
+          ->execute([(int)current_user()['id'],$compId,$adminComment,$requestId]);
+    } else {
+      $pdo->prepare("UPDATE competency_requests SET status='rejected', reviewed_by_user_id=?, reviewed_at=NOW(), admin_note=? WHERE id=? AND status='pending'")
+          ->execute([(int)current_user()['id'],$adminComment,$requestId]);
+    }
+    $pdo->commit();
+    header('Location: '.url('admin/competencies.php?request_id='.$requestId.'#competency-request-'.$requestId)); exit;
+  } catch(Throwable $e){ if($pdo->inTransaction()) $pdo->rollBack(); $_SESSION['competency_requests_error']=$e->getMessage(); header('Location: '.url('admin/competencies.php#competency-requests')); exit; }
+}
+
+$requestsRows = $pdo->query("SELECT cr.*, u.display_name AS teacher_name, u.email AS teacher_email, cat.name_de AS cat_de, sub.name_de AS sub_de FROM competency_requests cr LEFT JOIN users u ON u.id=cr.teacher_user_id LEFT JOIN competency_categories cat ON cat.id=cr.category_id LEFT JOIN competency_subcategories sub ON sub.id=cr.subcategory_id ORDER BY FIELD(cr.status,'pending','approved','rejected'), cr.created_at DESC, cr.id DESC")->fetchAll(PDO::FETCH_ASSOC) ?: [];
+$pendingRequests = array_values(array_filter($requestsRows, static fn($r)=>(string)$r['status']==='pending'));
+$doneRequests = array_values(array_filter($requestsRows, static fn($r)=>(string)$r['status']!=='pending'));
+
 render_admin_header('Kompetenzen verwalten'); ?>
 <div class="card"><h1>Kompetenzen verwalten</h1></div>
 <div id="msg" class="card" style="display:none;"></div>
+
+<?php if(isset($_SESSION['competency_requests_error'])): ?><div class="card alert danger"><?=h((string)$_SESSION['competency_requests_error']); unset($_SESSION['competency_requests_error']);?></div><?php endif; ?>
+<div class="card" id="competency-requests">
+  <h2>Kompetenzanträge</h2>
+  <p class="muted">Offene Anträge zuerst. Direktlink: <code>#competency-requests</code></p>
+  <?php if(!$pendingRequests): ?><p class="muted">Keine offenen Anträge.</p><?php endif; ?>
+  <?php foreach($pendingRequests as $r): $rid=(int)$r['id']; $meta=json_decode((string)($r['admin_note']??''),true); if(!is_array($meta)) $meta=[]; $hl=$reqHighlightId===$rid; ?>
+  <div id="competency-request-<?= $rid ?>" class="card" style="margin:10px 0; border-left:4px solid <?= $hl ? '#f59e0b' : '#0b57d0' ?>; background:<?= $hl ? '#fffbea' : '#fff' ?>;">
+    <div><strong><?=h((string)($r['teacher_name']?:$r['teacher_email']?:'Lehrkraft'))?></strong> · <?=h((string)$r['created_at'])?> · Status: <strong>offen</strong></div>
+    <div>Kategorie: <?=h((string)($r['cat_de']??'—'))?> | Unterkategorie: <?=h((string)($r['sub_de']?:'Ohne Unterkategorie'))?></div>
+    <div><strong>DE:</strong> <?=nl2br(h((string)$r['proposal_text_de']))?></div>
+    <div><strong>EN:</strong> <?=nl2br(h((string)($r['proposal_text_en']?:'—')))?></div>
+    <div>Klassenstufen: <?=h(implode(', ', array_map('strval', (array)($meta['grade_levels']??[]))) ?: '—')?> · Typ: <?= ((int)($meta['is_required']??0)===1?'Pflicht':'Optional') ?></div>
+    <div style="display:flex;gap:8px;margin-top:8px;flex-wrap:wrap;">
+      <form method="post" onsubmit="return confirm('Antrag genehmigen und als Kompetenz anlegen?');"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><input type="hidden" name="action" value="review_competency_request"><input type="hidden" name="request_id" value="<?= $rid ?>"><input type="hidden" name="decision" value="approve"><input class="input" type="text" name="admin_comment" placeholder="Kommentar (optional)"><button class="btn" type="submit">Genehmigen</button></form>
+      <form method="post" onsubmit="return confirm('Antrag ablehnen?');"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><input type="hidden" name="action" value="review_competency_request"><input type="hidden" name="request_id" value="<?= $rid ?>"><input type="hidden" name="decision" value="reject"><input class="input" type="text" name="admin_comment" placeholder="Begründung (optional)"><button class="btn" type="submit">Ablehnen</button></form>
+    </div>
+  </div>
+  <?php endforeach; ?>
+  <details style="margin-top:10px;"><summary><strong>Archiv (genehmigt/abgelehnt)</strong></summary>
+    <?php foreach($doneRequests as $r): $rid=(int)$r['id']; $meta=json_decode((string)($r['admin_note']??''),true); ?>
+      <div id="competency-request-<?= $rid ?>" class="card" style="margin:8px 0;"><strong>#<?= $rid ?></strong> · <?=h((string)$r['status'])?> · <?=h((string)($r['teacher_name']?:$r['teacher_email']?:'Lehrkraft'))?> · <?=h((string)$r['created_at'])?><br>Kategorie: <?=h((string)($r['cat_de']??'—'))?> | Unterkategorie: <?=h((string)($r['sub_de']?:'Ohne Unterkategorie'))?><br><?=nl2br(h((string)$r['proposal_text_de']))?><br><small>Kommentar: <?=h(is_array($meta)?((string)($meta['comment']??'')):(string)($r['admin_note']??''))?></small></div>
+    <?php endforeach; ?>
+  </details>
+</div>
+<?php if($reqHighlightId>0): ?><script>(function(){const el=document.getElementById('competency-request-<?= (int)$reqHighlightId ?>'); if(el){el.scrollIntoView({behavior:'smooth',block:'center'});}})();</script><?php endif; ?>
+
 <?php if(isset($_SESSION['competency_import_flash'])): $importFlash=$_SESSION['competency_import_flash']; unset($_SESSION['competency_import_flash']); ?>
 <div class="card alert success">
   <strong>Import abgeschlossen:</strong>

--- a/admin/competencies.php
+++ b/admin/competencies.php
@@ -241,11 +241,13 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && !isset($_SERVER['HTTP_X_REQUESTED_WIT
         $compId=(int)$pdo->lastInsertId();
         foreach((array)($meta['grade_levels']??[]) as $g){$gi=(int)$g; if($gi>=1&&$gi<=4){$pdo->prepare("INSERT INTO competency_grade_levels(competency_id,grade_level) VALUES (?,?)")->execute([$compId,$gi]);}}
       } else { $compId = $already; }
+      $meta=json_decode((string)($req['admin_note']??''),true); if(!is_array($meta)) $meta=[]; $meta['comment']=$adminComment;
       $pdo->prepare("UPDATE competency_requests SET status='approved', reviewed_by_user_id=?, reviewed_at=NOW(), approved_competency_id=?, admin_note=? WHERE id=? AND status='pending'")
-          ->execute([(int)current_user()['id'],$compId,$adminComment,$requestId]);
+          ->execute([(int)current_user()['id'],$compId,json_encode($meta,JSON_UNESCAPED_UNICODE),$requestId]);
     } else {
+      $meta=json_decode((string)($req['admin_note']??''),true); if(!is_array($meta)) $meta=[]; $meta['comment']=$adminComment;
       $pdo->prepare("UPDATE competency_requests SET status='rejected', reviewed_by_user_id=?, reviewed_at=NOW(), admin_note=? WHERE id=? AND status='pending'")
-          ->execute([(int)current_user()['id'],$adminComment,$requestId]);
+          ->execute([(int)current_user()['id'],json_encode($meta,JSON_UNESCAPED_UNICODE),$requestId]);
     }
     $pdo->commit();
     header('Location: '.url('admin/competencies.php?request_id='.$requestId.'#competency-request-'.$requestId)); exit;

--- a/admin/latex_templates.php
+++ b/admin/latex_templates.php
@@ -12,7 +12,13 @@ ensure_latex_layout_storage_dir();
 $msg = '';
 $err = '';
 
+function is_system_annual_template(array $tpl): bool {
+    return ((string)($tpl['key_name'] ?? '') === 'annual_report')
+        && ((string)($tpl['file_path'] ?? '') === 'latex/layout.tex');
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_verify();
     $action = (string)($_POST['layout_action'] ?? '');
     try {
         if ($action === 'set_default') {
@@ -25,9 +31,40 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $msg = 'Standardvorlage gesetzt.';
         } elseif ($action === 'toggle_active') {
             $id = (int)($_POST['template_id'] ?? 0);
+            $stChk = $pdo->prepare("SELECT id, is_default FROM latex_layout_templates WHERE id=? LIMIT 1");
+            $stChk->execute([$id]);
+            $cur = $stChk->fetch(PDO::FETCH_ASSOC) ?: null;
+            if (!$cur) throw new RuntimeException('Vorlage nicht gefunden.');
+            if ((int)($cur['is_default'] ?? 0) === 1) throw new RuntimeException('Standardvorlage kann nicht deaktiviert werden.');
             $st = $pdo->prepare("UPDATE latex_layout_templates SET is_active = IF(is_active=1,0,1) WHERE id=?");
             $st->execute([$id]);
             $msg = 'Aktiv-Status aktualisiert.';
+        } elseif ($action === 'delete') {
+            $id = (int)($_POST['template_id'] ?? 0);
+            $st = $pdo->prepare("SELECT * FROM latex_layout_templates WHERE id=? LIMIT 1");
+            $st->execute([$id]);
+            $tpl = $st->fetch(PDO::FETCH_ASSOC) ?: null;
+            if (!$tpl) throw new RuntimeException('Vorlage nicht gefunden.');
+            if ((int)($tpl['is_default'] ?? 0) === 1) throw new RuntimeException('Standardvorlage kann nicht gelöscht werden.');
+            if (is_system_annual_template($tpl)) throw new RuntimeException('Systemvorlage Jahreszeugnis kann nicht gelöscht werden.');
+
+            $filePathRel = (string)($tpl['file_path'] ?? '');
+            $fileAbs = latex_layout_absolute_path($filePathRel);
+            $uploadRoot = realpath(latex_layout_storage_dir()) ?: latex_layout_storage_dir();
+            $fileReal = realpath($fileAbs);
+            $canDeleteFile = false;
+            if ($fileReal !== false) {
+                $prefix = rtrim(str_replace('\\', '/', $uploadRoot), '/') . '/';
+                $fileNorm = str_replace('\\', '/', $fileReal);
+                $canDeleteFile = strncmp($fileNorm, $prefix, strlen($prefix)) === 0;
+            }
+
+            $pdo->prepare("DELETE FROM latex_layout_templates WHERE id=?")->execute([$id]);
+
+            if ($canDeleteFile && is_file($fileAbs)) {
+                @unlink($fileAbs);
+            }
+            $msg = 'Layoutvorlage gelöscht.';
         } elseif ($action === 'upload') {
             $displayName = trim((string)($_POST['display_name'] ?? ''));
             $keyName = trim((string)($_POST['key_name'] ?? ''));
@@ -42,6 +79,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $tmp = (string)$_FILES['layout_file']['tmp_name'];
             $content = (string)file_get_contents($tmp);
             if ($content === '' || stripos($content, '<?php') !== false) throw new RuntimeException('Ungültiger Dateiinhalt.');
+
             $st = $pdo->prepare("INSERT INTO latex_layout_templates (key_name, display_name, file_path, is_default, is_active, created_at, updated_at) VALUES (?,?,?,?,?,NOW(),NOW()) ON DUPLICATE KEY UPDATE display_name=VALUES(display_name), is_active=VALUES(is_active), updated_at=NOW()");
             $st->execute([$keyName, $displayName, '', 0, $isActive]);
             $id = (int)$pdo->query("SELECT id FROM latex_layout_templates WHERE key_name=" . $pdo->quote($keyName))->fetchColumn();
@@ -56,37 +94,79 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
             $msg = 'Layoutvorlage gespeichert.';
         }
-    } catch (Throwable $e) { $err = $e->getMessage(); }
+    } catch (Throwable $e) {
+        $err = $e->getMessage();
+    }
 }
+
 $templates = get_latex_layout_templates($pdo, false);
 
 render_admin_header(t('latex.title', 'Kompetenz-PDF erstellen'));
-?>
-<?php if($msg): ?><div class="card" style="border-left:4px solid #067647;"><?= h($msg) ?></div><?php endif; ?>
-<?php if($err): ?><div class="card" style="border-left:4px solid #b42318;"><?= h($err) ?></div><?php endif; ?>
-<div class="card" style="margin-bottom:16px;">
-  <h3>Layoutvorlagen / Titelseiten</h3>
-  <p>Die Layout-Datei muss dieselben Makros bereitstellen wie die bestehende layout.tex, insbesondere \CoverPage und \AGSection.</p>
-  <table class="table"><tr><th>Name</th><th>Key</th><th>Aktiv</th><th>Standard</th><th>Datei</th><th>Aktionen</th></tr>
-  <?php foreach($templates as $tpl): $exists=is_file(latex_layout_absolute_path((string)$tpl['file_path'])); ?>
-    <tr><td><?= h((string)$tpl['display_name']) ?></td><td><?= h((string)$tpl['key_name']) ?></td><td><?= ((int)$tpl['is_active']===1?'Ja':'Nein') ?></td><td><?= ((int)$tpl['is_default']===1?'Ja':'Nein') ?></td><td><?= $exists?'Ja':'Nein' ?></td>
-    <td>
-      <form method="post" style="display:inline"><input type="hidden" name="layout_action" value="toggle_active"><input type="hidden" name="template_id" value="<?= (int)$tpl['id'] ?>"><button class="btn" type="submit">Aktiv/Inaktiv</button></form>
-      <form method="post" style="display:inline"><input type="hidden" name="layout_action" value="set_default"><input type="hidden" name="template_id" value="<?= (int)$tpl['id'] ?>"><button class="btn" type="submit">Als Standard</button></form>
-    </td></tr>
-  <?php endforeach; ?></table>
-  <h4>Neue Layoutvorlage hochladen / ersetzen</h4>
-  <form method="post" enctype="multipart/form-data">
-    <input type="hidden" name="layout_action" value="upload">
-    <label>Anzeigename <input class="input" name="display_name" required></label>
-    <label>Key <input class="input" name="key_name" required pattern="[a-z0-9_-]+"></label>
-    <label>Datei (.tex) <input class="input" type="file" name="layout_file" accept=".tex" required></label>
-    <label><input type="checkbox" name="is_active" checked> Aktiv</label>
-    <label><input type="checkbox" name="is_default"> Als Standard setzen</label>
-    <button class="btn" type="submit">Layoutvorlage hochladen</button>
-  </form>
-</div>
-<?php
 $latexBuildUrl = url('admin/pdf_preview.php');
 require __DIR__ . '/../shared/latex_page.php';
+?>
+
+<?php if($msg): ?><div class="card" style="border-left:4px solid #067647;"><?= h($msg) ?></div><?php endif; ?>
+<?php if($err): ?><div class="card" style="border-left:4px solid #b42318;"><?= h($err) ?></div><?php endif; ?>
+
+<details class="card" style="margin-top:20px;">
+  <summary><strong>Layoutvorlagen / Titelseiten</strong></summary>
+  <div style="margin-top:10px;">
+    <p>Die Layout-Datei muss dieselben Makros bereitstellen wie die bestehende layout.tex, insbesondere \CoverPage und \AGSection.</p>
+    <table class="table">
+      <tr><th>Name</th><th>Key</th><th>Aktiv</th><th>Standard</th><th>Datei</th><th>Aktionen</th></tr>
+      <?php foreach($templates as $tpl):
+        $exists = is_file(latex_layout_absolute_path((string)$tpl['file_path']));
+        $isDefault = ((int)$tpl['is_default'] === 1);
+        $isSystemAnnual = is_system_annual_template($tpl);
+        $canDelete = !$isDefault && !$isSystemAnnual;
+      ?>
+        <tr>
+          <td><?= h((string)$tpl['display_name']) ?></td>
+          <td><?= h((string)$tpl['key_name']) ?></td>
+          <td><?= ((int)$tpl['is_active']===1?'Ja':'Nein') ?></td>
+          <td><?= $isDefault ? 'Ja' : 'Nein' ?></td>
+          <td><?= $exists?'Ja':'Nein' ?></td>
+          <td>
+            <form method="post" style="display:inline">
+              <input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>">
+              <input type="hidden" name="layout_action" value="toggle_active">
+              <input type="hidden" name="template_id" value="<?= (int)$tpl['id'] ?>">
+              <button class="btn" type="submit" <?= $isDefault ? 'disabled title="Standardvorlage kann nicht deaktiviert werden."' : '' ?>>Aktiv/Inaktiv</button>
+            </form>
+            <form method="post" style="display:inline">
+              <input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>">
+              <input type="hidden" name="layout_action" value="set_default">
+              <input type="hidden" name="template_id" value="<?= (int)$tpl['id'] ?>">
+              <button class="btn" type="submit" <?= ((int)$tpl['is_active']!==1) ? 'disabled title="Nur aktive Vorlagen können Standard sein."' : '' ?>>Als Standard</button>
+            </form>
+            <?php if ($canDelete): ?>
+              <form method="post" style="display:inline" onsubmit="return confirm('Vorlage wirklich löschen?');">
+                <input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>">
+                <input type="hidden" name="layout_action" value="delete">
+                <input type="hidden" name="template_id" value="<?= (int)$tpl['id'] ?>">
+                <button class="btn" type="submit">Löschen</button>
+              </form>
+            <?php else: ?>
+              <button class="btn" type="button" disabled title="Standardvorlage kann nicht gelöscht werden.">Löschen</button>
+            <?php endif; ?>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+    </table>
+
+    <h4>Neue Layoutvorlage hochladen / ersetzen</h4>
+    <form method="post" enctype="multipart/form-data">
+      <input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>">
+      <input type="hidden" name="layout_action" value="upload">
+      <label>Anzeigename <input class="input" name="display_name" required></label>
+      <label>Key <input class="input" name="key_name" required pattern="[a-z0-9_-]+"></label>
+      <label>Datei (.tex) <input class="input" type="file" name="layout_file" accept=".tex" required></label>
+      <label><input type="checkbox" name="is_active" checked> Aktiv</label>
+      <label><input type="checkbox" name="is_default"> Als Standard setzen</label>
+      <button class="btn" type="submit">Layoutvorlage hochladen</button>
+    </form>
+  </div>
+</details>
+<?php
 render_admin_footer();

--- a/admin/latex_templates.php
+++ b/admin/latex_templates.php
@@ -83,7 +83,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $st = $pdo->prepare("INSERT INTO latex_layout_templates (key_name, display_name, file_path, is_default, is_active, created_at, updated_at) VALUES (?,?,?,?,?,NOW(),NOW()) ON DUPLICATE KEY UPDATE display_name=VALUES(display_name), is_active=VALUES(is_active), updated_at=NOW()");
             $st->execute([$keyName, $displayName, '', 0, $isActive]);
             $id = (int)$pdo->query("SELECT id FROM latex_layout_templates WHERE key_name=" . $pdo->quote($keyName))->fetchColumn();
-            $stored = 'uploads/latex_layouts/layout_template_' . $id . '.tex';
+            $uploadsRel = trim((string)(app_config()['app']['uploads_dir'] ?? 'uploads'), '/\\');
+            if ($uploadsRel === '') { $uploadsRel = 'uploads'; }
+            $stored = $uploadsRel . '/latex_layouts/layout_template_' . $id . '.tex';
             $abs = latex_layout_absolute_path($stored);
             if (!move_uploaded_file($tmp, $abs)) throw new RuntimeException('Datei konnte nicht gespeichert werden.');
             $st2 = $pdo->prepare("UPDATE latex_layout_templates SET file_path=?, is_active=?, updated_at=NOW() WHERE id=?");

--- a/admin/latex_templates.php
+++ b/admin/latex_templates.php
@@ -3,9 +3,90 @@ declare(strict_types=1);
 
 require __DIR__ . '/../bootstrap.php';
 require __DIR__ . '/_layout.php';
+require_once __DIR__ . '/../shared/latex_layout_templates.php';
 require_admin();
 
+$pdo = db();
+ensure_default_latex_layout_template($pdo);
+ensure_latex_layout_storage_dir();
+$msg = '';
+$err = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = (string)($_POST['layout_action'] ?? '');
+    try {
+        if ($action === 'set_default') {
+            $id = (int)($_POST['template_id'] ?? 0);
+            $tpl = find_active_latex_layout_template($pdo, $id);
+            if (!$tpl) throw new RuntimeException('Vorlage nicht gefunden oder inaktiv.');
+            $pdo->exec("UPDATE latex_layout_templates SET is_default=0");
+            $st = $pdo->prepare("UPDATE latex_layout_templates SET is_default=1 WHERE id=?");
+            $st->execute([$id]);
+            $msg = 'Standardvorlage gesetzt.';
+        } elseif ($action === 'toggle_active') {
+            $id = (int)($_POST['template_id'] ?? 0);
+            $st = $pdo->prepare("UPDATE latex_layout_templates SET is_active = IF(is_active=1,0,1) WHERE id=?");
+            $st->execute([$id]);
+            $msg = 'Aktiv-Status aktualisiert.';
+        } elseif ($action === 'upload') {
+            $displayName = trim((string)($_POST['display_name'] ?? ''));
+            $keyName = trim((string)($_POST['key_name'] ?? ''));
+            $isActive = isset($_POST['is_active']) ? 1 : 0;
+            $setDefault = isset($_POST['is_default']) ? 1 : 0;
+            if ($displayName === '') throw new RuntimeException('Anzeigename darf nicht leer sein.');
+            if (!preg_match('/^[a-z0-9_-]+$/', $keyName)) throw new RuntimeException('Key enthält ungültige Zeichen.');
+            if (!isset($_FILES['layout_file']) || (int)$_FILES['layout_file']['error'] !== UPLOAD_ERR_OK) throw new RuntimeException('Upload fehlgeschlagen.');
+            $orig = (string)($_FILES['layout_file']['name'] ?? '');
+            if (basename($orig) !== $orig) throw new RuntimeException('Ungültiger Dateiname.');
+            if (strtolower(pathinfo($orig, PATHINFO_EXTENSION)) !== 'tex') throw new RuntimeException('Nur .tex erlaubt.');
+            $tmp = (string)$_FILES['layout_file']['tmp_name'];
+            $content = (string)file_get_contents($tmp);
+            if ($content === '' || stripos($content, '<?php') !== false) throw new RuntimeException('Ungültiger Dateiinhalt.');
+            $st = $pdo->prepare("INSERT INTO latex_layout_templates (key_name, display_name, file_path, is_default, is_active, created_at, updated_at) VALUES (?,?,?,?,?,NOW(),NOW()) ON DUPLICATE KEY UPDATE display_name=VALUES(display_name), is_active=VALUES(is_active), updated_at=NOW()");
+            $st->execute([$keyName, $displayName, '', 0, $isActive]);
+            $id = (int)$pdo->query("SELECT id FROM latex_layout_templates WHERE key_name=" . $pdo->quote($keyName))->fetchColumn();
+            $stored = 'uploads/latex_layouts/layout_template_' . $id . '.tex';
+            $abs = latex_layout_absolute_path($stored);
+            if (!move_uploaded_file($tmp, $abs)) throw new RuntimeException('Datei konnte nicht gespeichert werden.');
+            $st2 = $pdo->prepare("UPDATE latex_layout_templates SET file_path=?, is_active=?, updated_at=NOW() WHERE id=?");
+            $st2->execute([$stored, $isActive, $id]);
+            if ($setDefault) {
+                $pdo->exec("UPDATE latex_layout_templates SET is_default=0");
+                $pdo->prepare("UPDATE latex_layout_templates SET is_default=1 WHERE id=?")->execute([$id]);
+            }
+            $msg = 'Layoutvorlage gespeichert.';
+        }
+    } catch (Throwable $e) { $err = $e->getMessage(); }
+}
+$templates = get_latex_layout_templates($pdo, false);
+
 render_admin_header(t('latex.title', 'Kompetenz-PDF erstellen'));
+?>
+<?php if($msg): ?><div class="card" style="border-left:4px solid #067647;"><?= h($msg) ?></div><?php endif; ?>
+<?php if($err): ?><div class="card" style="border-left:4px solid #b42318;"><?= h($err) ?></div><?php endif; ?>
+<div class="card" style="margin-bottom:16px;">
+  <h3>Layoutvorlagen / Titelseiten</h3>
+  <p>Die Layout-Datei muss dieselben Makros bereitstellen wie die bestehende layout.tex, insbesondere \CoverPage und \AGSection.</p>
+  <table class="table"><tr><th>Name</th><th>Key</th><th>Aktiv</th><th>Standard</th><th>Datei</th><th>Aktionen</th></tr>
+  <?php foreach($templates as $tpl): $exists=is_file(latex_layout_absolute_path((string)$tpl['file_path'])); ?>
+    <tr><td><?= h((string)$tpl['display_name']) ?></td><td><?= h((string)$tpl['key_name']) ?></td><td><?= ((int)$tpl['is_active']===1?'Ja':'Nein') ?></td><td><?= ((int)$tpl['is_default']===1?'Ja':'Nein') ?></td><td><?= $exists?'Ja':'Nein' ?></td>
+    <td>
+      <form method="post" style="display:inline"><input type="hidden" name="layout_action" value="toggle_active"><input type="hidden" name="template_id" value="<?= (int)$tpl['id'] ?>"><button class="btn" type="submit">Aktiv/Inaktiv</button></form>
+      <form method="post" style="display:inline"><input type="hidden" name="layout_action" value="set_default"><input type="hidden" name="template_id" value="<?= (int)$tpl['id'] ?>"><button class="btn" type="submit">Als Standard</button></form>
+    </td></tr>
+  <?php endforeach; ?></table>
+  <h4>Neue Layoutvorlage hochladen / ersetzen</h4>
+  <form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="layout_action" value="upload">
+    <label>Anzeigename <input class="input" name="display_name" required></label>
+    <label>Key <input class="input" name="key_name" required pattern="[a-z0-9_-]+"></label>
+    <label>Datei (.tex) <input class="input" type="file" name="layout_file" accept=".tex" required></label>
+    <label><input type="checkbox" name="is_active" checked> Aktiv</label>
+    <label><input type="checkbox" name="is_default"> Als Standard setzen</label>
+    <button class="btn" type="submit">Layoutvorlage hochladen</button>
+  </form>
+</div>
+<?php
 $latexBuildUrl = url('admin/pdf_preview.php');
 require __DIR__ . '/../shared/latex_page.php';
 render_admin_footer();

--- a/admin/latex_templates.php
+++ b/admin/latex_templates.php
@@ -12,10 +12,6 @@ ensure_latex_layout_storage_dir();
 $msg = '';
 $err = '';
 
-function is_system_annual_template(array $tpl): bool {
-    return ((string)($tpl['key_name'] ?? '') === 'annual_report')
-        && ((string)($tpl['file_path'] ?? '') === 'latex/layout.tex');
-}
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     csrf_verify();
@@ -25,9 +21,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $id = (int)($_POST['template_id'] ?? 0);
             $tpl = find_active_latex_layout_template($pdo, $id);
             if (!$tpl) throw new RuntimeException('Vorlage nicht gefunden oder inaktiv.');
+            $pdo->beginTransaction();
             $pdo->exec("UPDATE latex_layout_templates SET is_default=0");
             $st = $pdo->prepare("UPDATE latex_layout_templates SET is_default=1 WHERE id=?");
             $st->execute([$id]);
+            $countDefault = (int)$pdo->query("SELECT COUNT(*) FROM latex_layout_templates WHERE is_default=1")->fetchColumn();
+            if ($countDefault !== 1) { throw new RuntimeException('Standardvorlage konnte nicht eindeutig gesetzt werden.'); }
+            $pdo->commit();
             $msg = 'Standardvorlage gesetzt.';
         } elseif ($action === 'toggle_active') {
             $id = (int)($_POST['template_id'] ?? 0);
@@ -46,7 +46,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $tpl = $st->fetch(PDO::FETCH_ASSOC) ?: null;
             if (!$tpl) throw new RuntimeException('Vorlage nicht gefunden.');
             if ((int)($tpl['is_default'] ?? 0) === 1) throw new RuntimeException('Standardvorlage kann nicht gelöscht werden.');
-            if (is_system_annual_template($tpl)) throw new RuntimeException('Systemvorlage Jahreszeugnis kann nicht gelöscht werden.');
 
             $filePathRel = (string)($tpl['file_path'] ?? '');
             $fileAbs = latex_layout_absolute_path($filePathRel);
@@ -91,12 +90,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $st2 = $pdo->prepare("UPDATE latex_layout_templates SET file_path=?, is_active=?, updated_at=NOW() WHERE id=?");
             $st2->execute([$stored, $isActive, $id]);
             if ($setDefault) {
+                $pdo->beginTransaction();
                 $pdo->exec("UPDATE latex_layout_templates SET is_default=0");
                 $pdo->prepare("UPDATE latex_layout_templates SET is_default=1 WHERE id=?")->execute([$id]);
+                $countDefault = (int)$pdo->query("SELECT COUNT(*) FROM latex_layout_templates WHERE is_default=1")->fetchColumn();
+                if ($countDefault !== 1) { throw new RuntimeException('Standardvorlage konnte nicht eindeutig gesetzt werden.'); }
+                $pdo->commit();
             }
             $msg = 'Layoutvorlage gespeichert.';
         }
     } catch (Throwable $e) {
+        if ($pdo->inTransaction()) { $pdo->rollBack(); }
         $err = $e->getMessage();
     }
 }
@@ -120,8 +124,7 @@ require __DIR__ . '/../shared/latex_page.php';
       <?php foreach($templates as $tpl):
         $exists = is_file(latex_layout_absolute_path((string)$tpl['file_path']));
         $isDefault = ((int)$tpl['is_default'] === 1);
-        $isSystemAnnual = is_system_annual_template($tpl);
-        $canDelete = !$isDefault && !$isSystemAnnual;
+        $canDelete = !$isDefault;
       ?>
         <tr>
           <td><?= h((string)$tpl['display_name']) ?></td>

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -973,7 +973,37 @@ function ensure_schema(PDO $pdo): void {
       );
     }
 
-    // --- parent_portal_links: admin-approved, time-boxed Eltern-Zugänge
+    
+    if (!db_has_table($pdo, 'latex_layout_templates')) {
+      $pdo->exec(
+        "CREATE TABLE latex_layout_templates (
+" .
+        "  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+" .
+        "  key_name VARCHAR(120) COLLATE utf8mb4_unicode_ci NOT NULL,
+" .
+        "  display_name VARCHAR(190) COLLATE utf8mb4_unicode_ci NOT NULL,
+" .
+        "  file_path VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+" .
+        "  is_default TINYINT(1) NOT NULL DEFAULT 0,
+" .
+        "  is_active TINYINT(1) NOT NULL DEFAULT 1,
+" .
+        "  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+" .
+        "  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+" .
+        "  PRIMARY KEY (id),
+" .
+        "  UNIQUE KEY uq_latex_layout_templates_key (key_name),
+" .
+        "  KEY idx_latex_layout_templates_default_active (is_default, is_active)
+" .
+        ") CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+      );
+    }
+// --- parent_portal_links: admin-approved, time-boxed Eltern-Zugänge
     if (!db_has_table($pdo, 'parent_portal_links')) {
       $pdo->exec(
         "CREATE TABLE parent_portal_links (\n" .

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1269,7 +1269,13 @@ function current_user(): ?array {
 }
 
 function require_login(): void {
-  if (!current_user()) redirect('login.php');
+  if (!current_user()) {
+    $req = (string)($_SERVER['REQUEST_URI'] ?? '/');
+    $path = (string)(parse_url($req, PHP_URL_PATH) ?? '/');
+    $query = (string)(parse_url($req, PHP_URL_QUERY) ?? '');
+    $next = $path . ($query !== '' ? ('?' . $query) : '');
+    redirect('login.php?next=' . rawurlencode($next));
+  }
 }
 
 function get_role(): string {
@@ -1285,11 +1291,19 @@ function get_role(): string {
 }
 
 function require_admin(): void {
-  require_login();
+  if (!current_user()) {
+    $req = (string)($_SERVER['REQUEST_URI'] ?? '/');
+    $path = (string)(parse_url($req, PHP_URL_PATH) ?? '/');
+    $query = (string)(parse_url($req, PHP_URL_QUERY) ?? '');
+    $next = $path . ($query !== '' ? ('?' . $query) : '');
+    redirect('login.php?next=' . rawurlencode($next));
+  }
   if (get_role() !== 'admin') {
-    http_response_code(403);
-    echo "403 Forbidden";
-    exit;
+    $req = (string)($_SERVER['REQUEST_URI'] ?? '/');
+    $path = (string)(parse_url($req, PHP_URL_PATH) ?? '/');
+    $query = (string)(parse_url($req, PHP_URL_QUERY) ?? '');
+    $next = $path . ($query !== '' ? ('?' . $query) : '');
+    redirect('login.php?next=' . rawurlencode($next) . '&need_admin=1');
   }
 }
 

--- a/login.php
+++ b/login.php
@@ -5,6 +5,25 @@ require __DIR__ . '/bootstrap.php';
 $err = '';
 $email = $_POST['email'] ?? '';
 $pass  = $_POST['password'] ?? '';
+$nextRaw = (string)($_GET['next'] ?? $_POST['next'] ?? '');
+$needAdmin = ((string)($_GET['need_admin'] ?? '') === '1');
+
+function safe_login_next_path(string $nextRaw): string {
+  $nextRaw = trim($nextRaw);
+  if ($nextRaw === '') return '';
+  if (preg_match('~^[a-z][a-z0-9+.-]*://~i', $nextRaw)) return '';
+  if (strpos($nextRaw, '//') === 0) return '';
+  $parts = parse_url($nextRaw);
+  if ($parts === false) return '';
+  if (isset($parts['host']) || isset($parts['scheme'])) return '';
+  $path = (string)($parts['path'] ?? '');
+  if ($path === '' || $path[0] !== '/') return '';
+  if (strpos($path, '/..') !== false || strpos($path, "\0") !== false) return '';
+  $query = (string)($parts['query'] ?? '');
+  return $path . ($query !== '' ? ('?' . $query) : '');
+}
+
+$next = safe_login_next_path($nextRaw);
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   try {
     csrf_verify();
@@ -34,6 +53,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           'actual_role' => $actualRole,
         ];
         audit('login', (int)$u['id']);
+        if ($next !== '') {
+          header('Location: ' . APP_BASE_URL . $next);
+          exit;
+        }
         if ($actualRole === 'admin') {
           redirect('role_select.php');
         }
@@ -77,9 +100,13 @@ $logo = $b['logo_path'] ?? '';
       <?php if ($err): ?>
         <div class="alert danger"><strong><?=h($err)?></strong></div>
       <?php endif; ?>
+      <?php if ($needAdmin): ?>
+        <div class="alert danger"><strong>Für diesen Bereich sind Adminrechte erforderlich. Bitte mit einem Admin-Konto anmelden.</strong></div>
+      <?php endif; ?>
 
       <form id="loginForm" method="post" autocomplete="off">
         <input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>">
+        <input type="hidden" name="next" value="<?=h($next)?>">
         <label><?=h(t('auth.login.email_label'))?></label>
         <input name="email" type="email" value="<?=h((string)$email)?>" required>
 

--- a/shared/build.php
+++ b/shared/build.php
@@ -8,6 +8,7 @@ error_reporting(E_ALL);
 $endpoint = 'https://latex.ytotech.com/builds/sync';
 
 $latexDir = __DIR__ . '/../latex';
+require_once __DIR__ . '/latex_layout_templates.php';
 
 function readTextFileOrFail(string $path): string {
     if (!is_file($path)) {
@@ -378,6 +379,28 @@ try {
     exit;
 }
 
+
+$pdoForLayout = function_exists('db') ? db() : null;
+$selectedLayoutPath = 'latex/layout.tex';
+if ($pdoForLayout instanceof PDO) {
+    ensure_default_latex_layout_template($pdoForLayout);
+    $layoutTemplateId = (int)($_POST['layout_template_id'] ?? 0);
+    $layout = $layoutTemplateId > 0 ? find_active_latex_layout_template($pdoForLayout, $layoutTemplateId) : null;
+    if (!$layout) {
+        $layout = get_default_latex_layout_template($pdoForLayout);
+    }
+    if ($layout && !empty($layout['file_path'])) {
+        $selectedLayoutPath = (string)$layout['file_path'];
+    }
+}
+$layoutAbsolute = latex_layout_absolute_path($selectedLayoutPath);
+if (!is_file($layoutAbsolute)) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo 'Layoutvorlage nicht gefunden.';
+    exit;
+}
+
 $resources = [
     [
         'main' => true,
@@ -386,7 +409,7 @@ $resources = [
 
     [
         'path' => 'layout.tex',
-        'file' => readBase64FileOrFail($latexDir . '/layout.tex'),
+        'file' => readBase64FileOrFail($layoutAbsolute),
     ],
     [
         'path' => 'skills.tex',

--- a/shared/latex_layout_templates.php
+++ b/shared/latex_layout_templates.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+function latex_layout_storage_dir(): string {
+    $cfg = app_config();
+    $uploadsRel = (string)($cfg['app']['uploads_dir'] ?? 'uploads');
+    $base = realpath(__DIR__ . '/..') ?: (__DIR__ . '/..');
+    return $base . '/' . trim($uploadsRel, '/\\') . '/latex_layouts';
+}
+
+function ensure_latex_layout_storage_dir(): void {
+    $dir = latex_layout_storage_dir();
+    if (!is_dir($dir)) {
+        @mkdir($dir, 0755, true);
+    }
+    $htaccess = $dir . '/.htaccess';
+    if (!is_file($htaccess)) {
+        @file_put_contents($htaccess, "Options -ExecCGI\nAddType text/plain .php .phtml .php3 .php4 .php5 .phar\n");
+    }
+}
+
+function ensure_default_latex_layout_template(PDO $pdo): void {
+    $count = (int)$pdo->query("SELECT COUNT(*) FROM latex_layout_templates")->fetchColumn();
+    if ($count > 0) return;
+    $defaultPath = 'latex/layout.tex';
+    $st = $pdo->prepare("INSERT INTO latex_layout_templates (key_name, display_name, file_path, is_default, is_active, created_at, updated_at) VALUES ('annual_report','Jahreszeugnis',?,1,1,NOW(),NOW())");
+    $st->execute([$defaultPath]);
+}
+
+function get_latex_layout_templates(PDO $pdo, bool $onlyActive = false): array {
+    $sql = "SELECT * FROM latex_layout_templates" . ($onlyActive ? " WHERE is_active=1" : "") . " ORDER BY is_default DESC, display_name ASC, id ASC";
+    return $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC) ?: [];
+}
+
+function get_default_latex_layout_template(PDO $pdo): ?array {
+    $st = $pdo->query("SELECT * FROM latex_layout_templates WHERE is_default=1 AND is_active=1 ORDER BY id ASC LIMIT 1");
+    $row = $st->fetch(PDO::FETCH_ASSOC);
+    return $row ?: null;
+}
+
+function find_active_latex_layout_template(PDO $pdo, int $id): ?array {
+    $st = $pdo->prepare("SELECT * FROM latex_layout_templates WHERE id=? AND is_active=1 LIMIT 1");
+    $st->execute([$id]);
+    $row = $st->fetch(PDO::FETCH_ASSOC);
+    return $row ?: null;
+}
+
+function latex_layout_absolute_path(string $filePath): string {
+    $root = realpath(__DIR__ . '/..') ?: (__DIR__ . '/..');
+    return $root . '/' . ltrim(str_replace('..', '', $filePath), '/\\');
+}

--- a/shared/latex_page.php
+++ b/shared/latex_page.php
@@ -37,7 +37,12 @@ function db_competency_sections(PDO $pdo, int $gradeLevel): array {
     return $sections;
 }
 
+require_once __DIR__ . '/latex_layout_templates.php';
 $pdo = db();
+ensure_default_latex_layout_template($pdo);
+$layoutTemplates = get_latex_layout_templates($pdo, true);
+$defaultLayout = get_default_latex_layout_template($pdo);
+$defaultLayoutId = (int)($defaultLayout['id'] ?? ($layoutTemplates[0]['id'] ?? 0));
 $selectedGrade = (int)($_GET['grade_level'] ?? $_POST['grade_level'] ?? 1);
 if ($selectedGrade < 1 || $selectedGrade > 4) $selectedGrade = 1;
 $sectionsDb = db_competency_sections($pdo, $selectedGrade);
@@ -65,6 +70,15 @@ $sectionsDb = db_competency_sections($pdo, $selectedGrade);
     <input type="hidden" name="show_ag" value="0">
     <input type="checkbox" name="show_ag" value="1" checked> AG-Bereich anzeigen
   </label>
+</div>
+
+<div class="card" style="padding:12px;margin:12px 0;">
+  <label><strong>Titelseitenvorlage</strong></label>
+  <select class="input" name="layout_template_id">
+    <?php foreach ($layoutTemplates as $tpl): ?>
+      <option value="<?= h((string)$tpl['id']) ?>" <?= ((int)$tpl['id'] === $defaultLayoutId) ? 'selected' : '' ?>><?= h((string)$tpl['display_name']) ?> (<?= h((string)$tpl['key_name']) ?>)</option>
+    <?php endforeach; ?>
+  </select>
 </div>
 <div style="display:flex;gap:8px;margin:8px 0 12px;">
   <button type="button" class="btn" id="collapseAllBtn">Alle einklappen</button>

--- a/teacher/competency_requests.php
+++ b/teacher/competency_requests.php
@@ -44,6 +44,54 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $meta = json_encode(['grade_levels'=>$grades,'is_required'=>$isRequired], JSON_UNESCAPED_UNICODE);
     $stIns = $pdo->prepare("INSERT INTO competency_requests(teacher_user_id,category_id,subcategory_id,proposal_text_de,proposal_text_en,status,admin_note,reviewed_by_user_id,reviewed_at,approved_competency_id) VALUES (?,?,?,?,?,'pending',?,?,?,?)");
     $stIns->execute([$teacherId, $cat, $subId, $textDe, $textEn, $meta, null, null, null]);
+    $requestId = (int)$pdo->lastInsertId();
+
+    // Admin-Benachrichtigung nach erfolgreichem Insert (darf Antragstellung nicht blockieren)
+    try {
+      $adminLink = absolute_url('admin/competencies.php?request_id=' . $requestId . '#competency-request-' . $requestId);
+      $teacherName = trim((string)(current_user()['display_name'] ?? current_user()['email'] ?? 'Lehrkraft'));
+      $subLabel = $subId ? (string)($subRow['name_de'] ?? '') : 'Ohne Unterkategorie';
+      $gradesTxt = $grades ? implode(', ', $grades) : '—';
+      $reqTxt = $isRequired ? 'Pflicht' : 'Optional';
+      $createdTxt = (new DateTimeImmutable('now', user_timezone()))->format('d.m.Y H:i');
+
+      $subject = 'Neuer Kompetenzantrag zur Prüfung';
+      $html = '<div style="font-family:Arial,sans-serif;line-height:1.45">'
+        . '<h2 style="margin:0 0 12px">Neuer Kompetenzantrag zur Prüfung</h2>'
+        . '<p>Eine Lehrkraft hat einen neuen Kompetenzantrag eingereicht.</p>'
+        . '<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;background:#f8fafc;border:1px solid #e2e8f0">'
+        . '<tr><td><strong>Lehrkraft</strong></td><td>' . h($teacherName) . '</td></tr>'
+        . '<tr><td><strong>Kategorie</strong></td><td>' . h((string)$catRow['name_de']) . '</td></tr>'
+        . '<tr><td><strong>Unterkategorie</strong></td><td>' . h($subLabel) . '</td></tr>'
+        . '<tr><td><strong>Kompetenz (DE)</strong></td><td>' . h($textDe) . '</td></tr>'
+        . '<tr><td><strong>Kompetenz (EN)</strong></td><td>' . h($textEn) . '</td></tr>'
+        . '<tr><td><strong>Klassenstufen</strong></td><td>' . h($gradesTxt) . '</td></tr>'
+        . '<tr><td><strong>Typ</strong></td><td>' . h($reqTxt) . '</td></tr>'
+        . '<tr><td><strong>Eingereicht am</strong></td><td>' . h($createdTxt) . '</td></tr>'
+        . '</table>'
+        . '<p style="margin-top:14px"><a href="' . h($adminLink) . '" style="display:inline-block;background:#0b57d0;color:#fff;text-decoration:none;padding:10px 14px;border-radius:8px;">Antrag in der Administration öffnen</a></p>'
+        . '<p style="font-size:12px;color:#64748b">Direktlink: <a href="' . h($adminLink) . '">' . h($adminLink) . '</a></p>'
+        . '</div>';
+
+      $admins = $pdo->query("SELECT email FROM users WHERE role='admin' AND is_active=1 AND deleted_at IS NULL AND email IS NOT NULL AND email<>''")->fetchAll(PDO::FETCH_COLUMN) ?: [];
+      if (!$admins) {
+        error_log('[competency request mail] no admin recipients found');
+      } else {
+        foreach ($admins as $m) {
+          $mail = (string)$m;
+          if (!filter_var($mail, FILTER_VALIDATE_EMAIL)) {
+            error_log('[competency request mail] invalid admin email skipped: ' . $mail);
+            continue;
+          }
+          $sent = @send_email($mail, $subject, $html);
+          if (!$sent) {
+            error_log('[competency request mail] failed for recipient: ' . $mail);
+          }
+        }
+      }
+    } catch (Throwable $mailError) {
+      error_log('[competency request mail] exception: ' . $mailError->getMessage());
+    }
 
     $ok = 'Antrag wurde gesendet. Die Administration prüft den Vorschlag, bevor die Kompetenz übernommen wird.';
   } catch (Throwable $e) {

--- a/teacher/competency_requests.php
+++ b/teacher/competency_requests.php
@@ -1,11 +1,153 @@
 <?php
 declare(strict_types=1);
-require __DIR__ . '/../bootstrap.php'; require __DIR__ . '/_layout.php'; require_teacher();
-$pdo=db(); $ok=null; $err=null;
-if($_SERVER['REQUEST_METHOD']==='POST'){ try{ csrf_verify(); $cat=(int)($_POST['category_id']??0); $sub=(int)($_POST['subcategory_id']??0); $text=trim((string)($_POST['proposal_text_de']??'')); if($text==='') throw new RuntimeException('Text fehlt'); $pdo->prepare("INSERT INTO competency_requests(teacher_user_id,category_id,subcategory_id,proposal_text_de,proposal_text_en,status) VALUES (?,?,?,?,?,'pending')")->execute([(int)current_user()['id'],$cat?:null,$sub?:null,$text,trim((string)($_POST['proposal_text_en']??''))]); $adminMails=$pdo->query("SELECT email FROM users WHERE role='admin' AND is_active=1 AND deleted_at IS NULL")->fetchAll(PDO::FETCH_COLUMN)?:[]; foreach($adminMails as $m){ if(filter_var($m,FILTER_VALIDATE_EMAIL)){ @send_email((string)$m,'Neue Kompetenz-Anfrage','<p>Es liegt ein neuer Kompetenz-Antrag vor.</p><p>'.h($text).'</p>'); }} $ok='Antrag gesendet.'; }catch(Throwable $e){$err=$e->getMessage();}}
-$cats=$pdo->query("SELECT * FROM competency_categories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_ASSOC);
-$subs=$pdo->query("SELECT * FROM competency_subcategories ORDER BY category_id,sort_order,id")->fetchAll(PDO::FETCH_ASSOC);
-render_teacher_header('Kompetenz-Anträge'); ?>
-<div class="card"><h1>Neue Kompetenz beantragen</h1><?php if($ok):?><div class="alert success"><?=h($ok)?></div><?php endif; ?><?php if($err):?><div class="alert danger"><?=h($err)?></div><?php endif; ?>
-<form method="post"><input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>"><label>Kategorie</label><select class="input" name="category_id"><option value="">-</option><?php foreach($cats as $c):?><option value="<?=$c['id']?>"><?=h($c['name_de'])?></option><?php endforeach;?></select><label>Unterkategorie</label><select class="input" name="subcategory_id"><option value="">-</option><?php foreach($subs as $s):?><option value="<?=$s['id']?>"><?=h($s['name_de'])?></option><?php endforeach;?></select><label>Vorschlag (DE)</label><textarea class="input" name="proposal_text_de" required></textarea><label>Vorschlag (EN)</label><textarea class="input" name="proposal_text_en"></textarea><button class="btn">Antrag senden</button></form></div>
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/_layout.php';
+require_teacher();
+
+$pdo = db();
+$ok = null; $err = null;
+
+$cats = $pdo->query("SELECT id,name_de,name_en FROM competency_categories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_ASSOC) ?: [];
+$subs = $pdo->query("SELECT id,category_id,name_de,name_en FROM competency_subcategories ORDER BY category_id,sort_order,id")->fetchAll(PDO::FETCH_ASSOC) ?: [];
+$subsByCat = [];
+foreach ($subs as $s) { $subsByCat[(int)$s['category_id']][] = $s; }
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  try {
+    csrf_verify();
+    $cat = (int)($_POST['category_id'] ?? 0);
+    $sub = (int)($_POST['subcategory_id'] ?? 0);
+    $textDe = trim((string)($_POST['proposal_text_de'] ?? ''));
+    $textEn = trim((string)($_POST['proposal_text_en'] ?? ''));
+    $isRequired = isset($_POST['is_required']) ? 1 : 0;
+    $grades = array_values(array_unique(array_map('intval', (array)($_POST['grade_levels'] ?? []))));
+    $grades = array_values(array_filter($grades, static fn(int $g): bool => $g >= 1 && $g <= 4));
+
+    if ($cat <= 0) throw new RuntimeException('Bitte eine Kategorie wählen.');
+    if ($textDe === '') throw new RuntimeException('Kompetenztext (DE) fehlt.');
+
+    $stCat = $pdo->prepare("SELECT id,name_de FROM competency_categories WHERE id=? LIMIT 1");
+    $stCat->execute([$cat]);
+    $catRow = $stCat->fetch(PDO::FETCH_ASSOC);
+    if (!$catRow) throw new RuntimeException('Kategorie nicht gefunden.');
+
+    $subId = null;
+    if ($sub > 0) {
+      $stSub = $pdo->prepare("SELECT id,name_de FROM competency_subcategories WHERE id=? AND category_id=? LIMIT 1");
+      $stSub->execute([$sub, $cat]);
+      $subRow = $stSub->fetch(PDO::FETCH_ASSOC);
+      if (!$subRow) throw new RuntimeException('Unterkategorie passt nicht zur gewählten Kategorie.');
+      $subId = (int)$subRow['id'];
+    }
+
+    $stIns = $pdo->prepare("INSERT INTO competency_requests(teacher_user_id,category_id,subcategory_id,proposal_text_de,proposal_text_en,status,admin_note,reviewed_by_user_id,reviewed_at,approved_competency_id) VALUES (?,?,?,?,?,'pending',?,?,?,?)");
+    $meta = json_encode(['grade_levels'=>$grades,'is_required'=>$isRequired], JSON_UNESCAPED_UNICODE);
+    $stIns->execute([(int)current_user()['id'], $cat, $subId, $textDe, $textEn, $meta, null, null, null]);
+    $requestId = (int)$pdo->lastInsertId();
+
+    $adminLink = absolute_url('admin/competencies.php?request_id=' . $requestId . '#competency-request-' . $requestId);
+    $teacherName = trim((string)(current_user()['display_name'] ?? current_user()['email'] ?? 'Lehrkraft'));
+    $subLabel = $subId ? (string)($subRow['name_de'] ?? '') : 'Ohne Unterkategorie';
+    $gradesTxt = $grades ? implode(', ', $grades) : '—';
+    $reqTxt = $isRequired ? 'Pflicht' : 'Optional';
+    $createdTxt = (new DateTimeImmutable('now', user_timezone()))->format('d.m.Y H:i');
+    $subject = 'Neuer Kompetenzantrag zur Prüfung';
+    $html = '<div style="font-family:Arial,sans-serif;line-height:1.45">'
+      . '<h2 style="margin:0 0 12px">Neuer Kompetenzantrag zur Prüfung</h2>'
+      . '<p>Eine Lehrkraft hat einen neuen Kompetenzantrag eingereicht.</p>'
+      . '<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;background:#f8fafc;border:1px solid #e2e8f0">'
+      . '<tr><td><strong>Lehrkraft</strong></td><td>' . h($teacherName) . '</td></tr>'
+      . '<tr><td><strong>Kategorie</strong></td><td>' . h((string)$catRow['name_de']) . '</td></tr>'
+      . '<tr><td><strong>Unterkategorie</strong></td><td>' . h($subLabel) . '</td></tr>'
+      . '<tr><td><strong>Kompetenz (DE)</strong></td><td>' . nl2br(h($textDe)) . '</td></tr>'
+      . '<tr><td><strong>Kompetenz (EN)</strong></td><td>' . nl2br(h($textEn !== '' ? $textEn : '—')) . '</td></tr>'
+      . '<tr><td><strong>Klassenstufen</strong></td><td>' . h($gradesTxt) . '</td></tr>'
+      . '<tr><td><strong>Typ</strong></td><td>' . h($reqTxt) . '</td></tr>'
+      . '<tr><td><strong>Eingereicht am</strong></td><td>' . h($createdTxt) . '</td></tr>'
+      . '</table>'
+      . '<p style="margin-top:14px"><a href="' . h($adminLink) . '" style="display:inline-block;background:#0b57d0;color:#fff;text-decoration:none;padding:10px 14px;border-radius:8px;">Antrag in der Administration öffnen</a></p>'
+      . '<p style="font-size:12px;color:#64748b">Direktlink: <a href="' . h($adminLink) . '">' . h($adminLink) . '</a></p>'
+      . '</div>';
+
+    $admins = $pdo->query("SELECT email FROM users WHERE role='admin' AND is_active=1 AND deleted_at IS NULL")->fetchAll(PDO::FETCH_COLUMN) ?: [];
+    foreach ($admins as $m) { if (filter_var((string)$m, FILTER_VALIDATE_EMAIL)) @send_email((string)$m, $subject, $html); }
+
+    $ok = 'Antrag wurde gesendet. Die Administration prüft den Vorschlag, bevor er übernommen wird.';
+  } catch (Throwable $e) {
+    $err = $e->getMessage();
+  }
+}
+
+render_teacher_header('Kompetenz-Anträge');
+?>
+<div class="card">
+  <h1>Neue Kompetenz beantragen</h1>
+  <p class="muted">Der Antrag wird von der Administration geprüft, bevor die Kompetenz in Vorlagen übernommen wird.</p>
+  <?php if($ok): ?><div class="alert success" style="margin-bottom:10px;"><?=h($ok)?></div><?php endif; ?>
+  <?php if($err): ?><div class="alert danger" style="margin-bottom:10px;"><?=h($err)?></div><?php endif; ?>
+
+  <form method="post" style="display:flex;flex-direction:column;gap:14px;">
+    <input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>">
+
+    <div class="card" style="padding:12px;">
+      <h3 style="margin-top:0;">Zuordnung</h3>
+      <label>Kategorie</label>
+      <select class="input" name="category_id" id="category_id" required>
+        <option value="">Bitte wählen…</option>
+        <?php foreach($cats as $c): ?>
+          <option value="<?= (int)$c['id'] ?>"><?= h((string)$c['name_de']) ?></option>
+        <?php endforeach; ?>
+      </select>
+      <label style="margin-top:8px;">Unterkategorie</label>
+      <select class="input" name="subcategory_id" id="subcategory_id">
+        <option value="">Ohne Unterkategorie</option>
+      </select>
+      <small id="sub_hint" class="muted">Bitte zuerst eine Kategorie wählen.</small>
+    </div>
+
+    <div class="card" style="padding:12px;">
+      <h3 style="margin-top:0;">Kompetenztext</h3>
+      <label>Deutsch (Pflicht)</label>
+      <textarea class="input" name="proposal_text_de" required rows="4"></textarea>
+      <label style="margin-top:8px;">Englisch (optional)</label>
+      <textarea class="input" name="proposal_text_en" rows="3"></textarea>
+    </div>
+
+    <div class="card" style="padding:12px;">
+      <h3 style="margin-top:0;">Optionen</h3>
+      <label><input type="checkbox" name="is_required" value="1"> Pflichtkompetenz</label>
+      <div style="margin-top:8px;display:flex;gap:10px;flex-wrap:wrap;">
+        <?php foreach([1,2,3,4] as $g): ?><label><input type="checkbox" name="grade_levels[]" value="<?= $g ?>"> Klasse <?= $g ?></label><?php endforeach; ?>
+      </div>
+    </div>
+
+    <div style="display:flex;justify-content:flex-end;gap:8px;">
+      <button class="btn" type="submit">Antrag senden</button>
+    </div>
+  </form>
+</div>
+<script>
+const SUBS_BY_CAT = <?= json_encode($subsByCat, JSON_UNESCAPED_UNICODE) ?>;
+const catEl = document.getElementById('category_id');
+const subEl = document.getElementById('subcategory_id');
+const hint = document.getElementById('sub_hint');
+function updateSubOptions(){
+  const catId = String(catEl.value || '');
+  const subs = SUBS_BY_CAT[catId] || [];
+  subEl.innerHTML = '';
+  const optNone = document.createElement('option');
+  optNone.value = '';
+  optNone.textContent = 'Ohne Unterkategorie';
+  subEl.appendChild(optNone);
+  subs.forEach(s=>{
+    const o=document.createElement('option');
+    o.value=String(s.id);
+    o.textContent=String(s.name_de || '');
+    subEl.appendChild(o);
+  });
+  hint.textContent = catId === '' ? 'Bitte zuerst eine Kategorie wählen.' : (subs.length ? 'Nur Unterkategorien der gewählten Kategorie sind auswählbar.' : 'Für diese Kategorie sind keine Unterkategorien vorhanden.');
+}
+catEl.addEventListener('change', updateSubOptions);
+updateSubOptions();
+</script>
 <?php render_teacher_footer();

--- a/teacher/competency_requests.php
+++ b/teacher/competency_requests.php
@@ -69,7 +69,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         . '<tr><td><strong>Typ</strong></td><td>' . h($reqTxt) . '</td></tr>'
         . '<tr><td><strong>Eingereicht am</strong></td><td>' . h($createdTxt) . '</td></tr>'
         . '</table>'
-        . '<p style="margin-top:14px"><a href="' . h($adminLink) . '" style="display:inline-block;background:#0b57d0;color:#fff;text-decoration:none;padding:10px 14px;border-radius:8px;">Antrag in der Administration öffnen</a></p>'
+        . '<p style="margin-top:14px"><a href="' . h($adminLink) . '" style="display:inline-block;background:#0b57d0;color:#ffffff !important;text-decoration:none;padding:12px 18px;border-radius:8px;font-weight:700;">Antrag in der Administration öffnen</a></p>'
         . '<p style="font-size:12px;color:#64748b">Direktlink: <a href="' . h($adminLink) . '">' . h($adminLink) . '</a></p>'
         . '</div>';
 

--- a/teacher/competency_requests.php
+++ b/teacher/competency_requests.php
@@ -6,6 +6,7 @@ require_teacher();
 
 $pdo = db();
 $ok = null; $err = null;
+$teacherId = (int)(current_user()['id'] ?? 0);
 
 $cats = $pdo->query("SELECT id,name_de,name_en FROM competency_categories ORDER BY sort_order,id")->fetchAll(PDO::FETCH_ASSOC) ?: [];
 $subs = $pdo->query("SELECT id,category_id,name_de,name_en FROM competency_subcategories ORDER BY category_id,sort_order,id")->fetchAll(PDO::FETCH_ASSOC) ?: [];
@@ -24,14 +25,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $grades = array_values(array_filter($grades, static fn(int $g): bool => $g >= 1 && $g <= 4));
 
     if ($cat <= 0) throw new RuntimeException('Bitte eine Kategorie wählen.');
-    if ($textDe === '') throw new RuntimeException('Kompetenztext (DE) fehlt.');
+    if ($textDe === '' || $textEn === '') throw new RuntimeException('Kompetenztext (DE/EN) fehlt.');
 
     $stCat = $pdo->prepare("SELECT id,name_de FROM competency_categories WHERE id=? LIMIT 1");
     $stCat->execute([$cat]);
     $catRow = $stCat->fetch(PDO::FETCH_ASSOC);
     if (!$catRow) throw new RuntimeException('Kategorie nicht gefunden.');
 
-    $subId = null;
+    $subId = null; $subRow = null;
     if ($sub > 0) {
       $stSub = $pdo->prepare("SELECT id,name_de FROM competency_subcategories WHERE id=? AND category_id=? LIMIT 1");
       $stSub->execute([$sub, $cat]);
@@ -40,92 +41,108 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       $subId = (int)$subRow['id'];
     }
 
-    $stIns = $pdo->prepare("INSERT INTO competency_requests(teacher_user_id,category_id,subcategory_id,proposal_text_de,proposal_text_en,status,admin_note,reviewed_by_user_id,reviewed_at,approved_competency_id) VALUES (?,?,?,?,?,'pending',?,?,?,?)");
     $meta = json_encode(['grade_levels'=>$grades,'is_required'=>$isRequired], JSON_UNESCAPED_UNICODE);
-    $stIns->execute([(int)current_user()['id'], $cat, $subId, $textDe, $textEn, $meta, null, null, null]);
-    $requestId = (int)$pdo->lastInsertId();
+    $stIns = $pdo->prepare("INSERT INTO competency_requests(teacher_user_id,category_id,subcategory_id,proposal_text_de,proposal_text_en,status,admin_note,reviewed_by_user_id,reviewed_at,approved_competency_id) VALUES (?,?,?,?,?,'pending',?,?,?,?)");
+    $stIns->execute([$teacherId, $cat, $subId, $textDe, $textEn, $meta, null, null, null]);
 
-    $adminLink = absolute_url('admin/competencies.php?request_id=' . $requestId . '#competency-request-' . $requestId);
-    $teacherName = trim((string)(current_user()['display_name'] ?? current_user()['email'] ?? 'Lehrkraft'));
-    $subLabel = $subId ? (string)($subRow['name_de'] ?? '') : 'Ohne Unterkategorie';
-    $gradesTxt = $grades ? implode(', ', $grades) : '—';
-    $reqTxt = $isRequired ? 'Pflicht' : 'Optional';
-    $createdTxt = (new DateTimeImmutable('now', user_timezone()))->format('d.m.Y H:i');
-    $subject = 'Neuer Kompetenzantrag zur Prüfung';
-    $html = '<div style="font-family:Arial,sans-serif;line-height:1.45">'
-      . '<h2 style="margin:0 0 12px">Neuer Kompetenzantrag zur Prüfung</h2>'
-      . '<p>Eine Lehrkraft hat einen neuen Kompetenzantrag eingereicht.</p>'
-      . '<table cellpadding="6" cellspacing="0" style="border-collapse:collapse;background:#f8fafc;border:1px solid #e2e8f0">'
-      . '<tr><td><strong>Lehrkraft</strong></td><td>' . h($teacherName) . '</td></tr>'
-      . '<tr><td><strong>Kategorie</strong></td><td>' . h((string)$catRow['name_de']) . '</td></tr>'
-      . '<tr><td><strong>Unterkategorie</strong></td><td>' . h($subLabel) . '</td></tr>'
-      . '<tr><td><strong>Kompetenz (DE)</strong></td><td>' . nl2br(h($textDe)) . '</td></tr>'
-      . '<tr><td><strong>Kompetenz (EN)</strong></td><td>' . nl2br(h($textEn !== '' ? $textEn : '—')) . '</td></tr>'
-      . '<tr><td><strong>Klassenstufen</strong></td><td>' . h($gradesTxt) . '</td></tr>'
-      . '<tr><td><strong>Typ</strong></td><td>' . h($reqTxt) . '</td></tr>'
-      . '<tr><td><strong>Eingereicht am</strong></td><td>' . h($createdTxt) . '</td></tr>'
-      . '</table>'
-      . '<p style="margin-top:14px"><a href="' . h($adminLink) . '" style="display:inline-block;background:#0b57d0;color:#fff;text-decoration:none;padding:10px 14px;border-radius:8px;">Antrag in der Administration öffnen</a></p>'
-      . '<p style="font-size:12px;color:#64748b">Direktlink: <a href="' . h($adminLink) . '">' . h($adminLink) . '</a></p>'
-      . '</div>';
-
-    $admins = $pdo->query("SELECT email FROM users WHERE role='admin' AND is_active=1 AND deleted_at IS NULL")->fetchAll(PDO::FETCH_COLUMN) ?: [];
-    foreach ($admins as $m) { if (filter_var((string)$m, FILTER_VALIDATE_EMAIL)) @send_email((string)$m, $subject, $html); }
-
-    $ok = 'Antrag wurde gesendet. Die Administration prüft den Vorschlag, bevor er übernommen wird.';
+    $ok = 'Antrag wurde gesendet. Die Administration prüft den Vorschlag, bevor die Kompetenz übernommen wird.';
   } catch (Throwable $e) {
     $err = $e->getMessage();
   }
 }
 
+$myRequests = $pdo->prepare("SELECT cr.*, cat.name_de AS cat_de, sub.name_de AS sub_de FROM competency_requests cr LEFT JOIN competency_categories cat ON cat.id=cr.category_id LEFT JOIN competency_subcategories sub ON sub.id=cr.subcategory_id WHERE cr.teacher_user_id=? ORDER BY cr.created_at DESC, cr.id DESC");
+$myRequests->execute([$teacherId]);
+$requests = $myRequests->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
 render_teacher_header('Kompetenz-Anträge');
 ?>
 <div class="card">
   <h1>Neue Kompetenz beantragen</h1>
-  <p class="muted">Der Antrag wird von der Administration geprüft, bevor die Kompetenz in Vorlagen übernommen wird.</p>
+  <p class="muted">Der Antrag wird von der Administration geprüft, bevor die Kompetenz übernommen wird.</p>
   <?php if($ok): ?><div class="alert success" style="margin-bottom:10px;"><?=h($ok)?></div><?php endif; ?>
   <?php if($err): ?><div class="alert danger" style="margin-bottom:10px;"><?=h($err)?></div><?php endif; ?>
 
-  <form method="post" style="display:flex;flex-direction:column;gap:14px;">
+  <form method="post" class="form-grid">
     <input type="hidden" name="csrf_token" value="<?=h(csrf_token())?>">
 
-    <div class="card" style="padding:12px;">
-      <h3 style="margin-top:0;">Zuordnung</h3>
-      <label>Kategorie</label>
+    <div class="form-group">
+      <label class="form-label">Kategorie</label>
       <select class="input" name="category_id" id="category_id" required>
         <option value="">Bitte wählen…</option>
-        <?php foreach($cats as $c): ?>
-          <option value="<?= (int)$c['id'] ?>"><?= h((string)$c['name_de']) ?></option>
-        <?php endforeach; ?>
+        <?php foreach($cats as $c): ?><option value="<?= (int)$c['id'] ?>"><?= h((string)$c['name_de']) ?></option><?php endforeach; ?>
       </select>
-      <label style="margin-top:8px;">Unterkategorie</label>
-      <select class="input" name="subcategory_id" id="subcategory_id">
-        <option value="">Ohne Unterkategorie</option>
-      </select>
+    </div>
+    <div class="form-group">
+      <label class="form-label">Unterkategorie</label>
+      <select class="input" name="subcategory_id" id="subcategory_id"><option value="">Ohne Unterkategorie</option></select>
       <small id="sub_hint" class="muted">Bitte zuerst eine Kategorie wählen.</small>
     </div>
-
-    <div class="card" style="padding:12px;">
-      <h3 style="margin-top:0;">Kompetenztext</h3>
-      <label>Deutsch (Pflicht)</label>
-      <textarea class="input" name="proposal_text_de" required rows="4"></textarea>
-      <label style="margin-top:8px;">Englisch (optional)</label>
-      <textarea class="input" name="proposal_text_en" rows="3"></textarea>
+    <div class="form-group">
+      <label class="form-label">Kompetenz (Deutsch)</label>
+      <input class="input" type="text" name="proposal_text_de" required>
     </div>
-
-    <div class="card" style="padding:12px;">
-      <h3 style="margin-top:0;">Optionen</h3>
-      <label><input type="checkbox" name="is_required" value="1"> Pflichtkompetenz</label>
-      <div style="margin-top:8px;display:flex;gap:10px;flex-wrap:wrap;">
-        <?php foreach([1,2,3,4] as $g): ?><label><input type="checkbox" name="grade_levels[]" value="<?= $g ?>"> Klasse <?= $g ?></label><?php endforeach; ?>
-      </div>
+    <div class="form-group">
+      <label class="form-label">Kompetenz (English)</label>
+      <input class="input" type="text" name="proposal_text_en" required>
     </div>
-
-    <div style="display:flex;justify-content:flex-end;gap:8px;">
-      <button class="btn" type="submit">Antrag senden</button>
+    <div class="form-group">
+      <label class="choice-chip required-choice"><input type="checkbox" name="is_required" value="1"><span>🔒 Pflichtkompetenz</span></label>
     </div>
+    <div class="form-group">
+      <div class="form-label">Klassenstufen</div>
+      <div class="choice-row"><?php foreach([1,2,3,4] as $g): ?><label class="choice-chip grade-choice grade-<?= $g ?>"><input type="checkbox" name="grade_levels[]" value="<?= $g ?>"><span><?= $g ?></span></label><?php endforeach; ?></div>
+    </div>
+    <div style="display:flex;justify-content:flex-end;"><button class="btn" type="submit">Antrag senden</button></div>
   </form>
 </div>
+
+<div class="card" style="margin-top:14px;">
+  <h2>Meine Kompetenzanträge</h2>
+  <?php if(!$requests): ?><p class="muted">Noch keine Anträge vorhanden.</p><?php endif; ?>
+  <?php foreach($requests as $r):
+    $meta = json_decode((string)($r['admin_note'] ?? ''), true); if(!is_array($meta)) $meta=[];
+    $status=(string)($r['status']??'pending');
+    $stLabel=$status==='approved'?'Genehmigt':($status==='rejected'?'Abgelehnt':'Offen');
+    $stColor=$status==='approved'?'#067647':($status==='rejected'?'#b42318':'#0b57d0');
+    $grades=(array)($meta['grade_levels']??[]);
+    $comment=trim((string)($meta['comment']??''));
+  ?>
+    <div class="card" style="margin:10px 0;border-left:4px solid <?=h($stColor)?>;">
+      <div style="display:flex;justify-content:space-between;gap:8px;align-items:center;">
+        <strong><?=h($stLabel)?></strong>
+        <span class="chip" style="background:<?=h($stColor)?>;color:#fff;"><?=h($status)?></span>
+      </div>
+      <div class="muted" style="margin-top:6px;">Kategorie: <?=h((string)($r['cat_de']??'—'))?> · Unterkategorie: <?=h((string)($r['sub_de']?:'Ohne Unterkategorie'))?></div>
+      <div style="margin-top:8px;"><strong>DE:</strong> <?=h((string)$r['proposal_text_de'])?></div>
+      <div><strong>EN:</strong> <?=h((string)($r['proposal_text_en']?:'—'))?></div>
+      <div style="margin-top:6px;">Klassenstufen:
+        <?php if($grades): foreach($grades as $g): ?><span class="chip grade-chip grade-<?= (int)$g ?>"><?= (int)$g ?></span><?php endforeach; else: ?> <span class="muted">—</span><?php endif; ?>
+        <span class="chip"><?= ((int)($meta['is_required']??0)===1?'Pflicht':'Optional') ?></span>
+      </div>
+      <div class="muted" style="margin-top:6px;">Erstellt: <?=h((string)$r['created_at'])?><?php if(!empty($r['reviewed_at'])): ?> · Bearbeitet: <?=h((string)$r['reviewed_at'])?><?php endif; ?></div>
+      <?php if($comment!==''): ?><div style="margin-top:8px;padding:8px 10px;border-radius:8px;background:#f8fafc;border:1px solid #e2e8f0;"><strong>Admin-Kommentar:</strong><br><?=nl2br(h($comment))?></div><?php endif; ?>
+    </div>
+  <?php endforeach; ?>
+</div>
+
+<style>
+.form-grid{display:flex;flex-direction:column;gap:14px}
+.form-group{display:flex;flex-direction:column;gap:6px}
+.form-label{font-size:13px;font-weight:700;color:#334155}
+.choice-row{display:flex;flex-wrap:wrap;gap:8px}
+.choice-chip{display:inline-flex;align-items:center;gap:7px;border:1px solid #cbd5e1;background:#f8fafc;border-radius:999px;padding:7px 11px;cursor:pointer;font-size:13px;font-weight:600;color:#334155;user-select:none}
+.choice-chip input{width:auto;margin:0}
+.choice-chip:has(input:checked){border-color:#0b57d0;background:#eef5ff;color:#0b57d0}
+.required-choice:has(input:checked){border-color:#1f355e;background:#e7edf9;color:#1f355e}
+.grade-choice.grade-1:has(input:checked){border-color:#1f4f99;background:#eaf3ff;color:#1f4f99}
+.grade-choice.grade-2:has(input:checked){border-color:#1f7a45;background:#ecfff4;color:#1f7a45}
+.grade-choice.grade-3:has(input:checked){border-color:#9a5a12;background:#fff5e8;color:#9a5a12}
+.grade-choice.grade-4:has(input:checked){border-color:#5a33a2;background:#f3edff;color:#5a33a2}
+.input{border:1px solid #cbd5e1;border-radius:12px;padding:10px 12px}
+.grade-chip{font-weight:600}
+.grade-1{background:#eaf3ff;color:#1f4f99}.grade-2{background:#ecfff4;color:#1f7a45}.grade-3{background:#fff5e8;color:#9a5a12}.grade-4{background:#f3edff;color:#5a33a2}
+</style>
 <script>
 const SUBS_BY_CAT = <?= json_encode($subsByCat, JSON_UNESCAPED_UNICODE) ?>;
 const catEl = document.getElementById('category_id');
@@ -135,19 +152,10 @@ function updateSubOptions(){
   const catId = String(catEl.value || '');
   const subs = SUBS_BY_CAT[catId] || [];
   subEl.innerHTML = '';
-  const optNone = document.createElement('option');
-  optNone.value = '';
-  optNone.textContent = 'Ohne Unterkategorie';
-  subEl.appendChild(optNone);
-  subs.forEach(s=>{
-    const o=document.createElement('option');
-    o.value=String(s.id);
-    o.textContent=String(s.name_de || '');
-    subEl.appendChild(o);
-  });
+  const optNone = document.createElement('option'); optNone.value=''; optNone.textContent='Ohne Unterkategorie'; subEl.appendChild(optNone);
+  subs.forEach(s=>{const o=document.createElement('option'); o.value=String(s.id); o.textContent=String(s.name_de||''); subEl.appendChild(o);});
   hint.textContent = catId === '' ? 'Bitte zuerst eine Kategorie wählen.' : (subs.length ? 'Nur Unterkategorien der gewählten Kategorie sind auswählbar.' : 'Für diese Kategorie sind keine Unterkategorien vorhanden.');
 }
-catEl.addEventListener('change', updateSubOptions);
-updateSubOptions();
+catEl.addEventListener('change', updateSubOptions); updateSubOptions();
 </script>
 <?php render_teacher_footer();


### PR DESCRIPTION
### Motivation
- Allow switching between multiple LaTeX layout/titelseitenvorlagen (e.g. Jahreszeugnis, Lernentwicklungsbericht) while keeping `main.tex` unchanged and still using `\input{layout.tex}` during the PDF build. 
- Provide an admin-managed upload/manage UI for alternative layout files and a safe runtime mechanism to choose a layout for each PDF build. 

### Description
- Added a new DB-backed template concept via a runtime schema entry `latex_layout_templates` with fields `id, key_name, display_name, file_path, is_default, is_active, created_at, updated_at` that is ensured in `ensure_schema()` so existing installs get a fallback without manual migration. 
- Implemented helper functions in `shared/latex_layout_templates.php` to create the storage folder (`uploads/latex_layouts`), seed a default `annual_report` -> `Jahreszeugnis` pointing to the existing `latex/layout.tex`, list/lookup active/default templates, and resolve safe absolute paths. 
- Admin UI is implemented in `admin/latex_templates.php` with listing, toggle active, set default and an upload form that validates `display_name` and `key_name`, restricts uploads to `.tex`, rejects path components and `<?php` in content, and stores files as `uploads/latex_layouts/layout_template_{id}.tex`. 
- Teacher and Admin PDF forms now show a select `layout_template_id` built from active templates in `shared/latex_page.php`, and the build pipeline in `shared/build.php` validates the posted `layout_template_id`, falls back to the default if necessary, checks the file exists, and uses that file as the build resource mapped to `layout.tex` so `main.tex` remains unchanged. 
- Security measures include Admin-only uploads, strict `key_name` regex, basename checks, extension/content validation, server-controlled stored filenames (no user paths), DB whitelist of allowed templates, and clear error/fallback when a layout file is missing. 

### Testing
- PHP syntax checks were run with `php -l` for `shared/latex_layout_templates.php`, `shared/latex_page.php`, `shared/build.php`, `admin/latex_templates.php` and `bootstrap.php` and all returned no syntax errors. 
- The runtime schema-ensure was added to `bootstrap.php` and the new code paths were exercised by the lint and by invoking the updated pages without throwing syntax/runtime parse errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1243e84aa0832e90fa6ba81350d911)