### PR TITLE
Preserve hyphenated group labels in data entry

### DIFF
--- a/student/ajax/wizard_api.php
+++ b/student/ajax/wizard_api.php
@@ -129,13 +129,11 @@ function group_parts_from_meta(array $meta): array {
   $parts = array_values(array_filter(array_map('trim', explode('/', $raw)), fn($p) => $p !== ''));
   if (!$parts) return ['group' => 'Allgemein', 'subgroup' => ''];
 
+  // Group labels are free-form text and may contain hyphens (e.g.
+  // "Sozial-Emotionales Lernen"). Keep the original label intact; do not
+  // parse technical suffixes from group names here. Field-name normalization is
+  // handled separately in base_field_key().
   $group = $parts[0];
-
-  // Normalize: ignore suffix after '-' (e.g. "Ger1-T" -> "Ger1")
-  if ($group !== '' && strpos($group, '-') !== false) {
-    $group = explode('-', $group, 2)[0];
-    $group = trim($group);
-  }
 
   $subgroup = '';
   if (count($parts) > 1) {

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -839,11 +839,11 @@ function group_parts_from_meta(array $meta): array {
   $parts = array_values(array_filter(array_map('trim', explode('/', $raw)), fn($p) => $p !== ''));
   if (!$parts) return ['group' => 'Allgemein', 'subgroup' => ''];
 
+  // Group labels are free-form text and may contain hyphens (e.g.
+  // "Sozial-Emotionales Lernen"). Keep the original label intact; do not
+  // parse technical suffixes from group names here. Field-name normalization is
+  // handled separately in base_field_key().
   $group = $parts[0];
-  if ($group !== '' && strpos($group, '-') !== false) {
-    $group = explode('-', $group, 2)[0];
-    $group = trim($group);
-  }
 
   $subgroup = '';
   if (count($parts) > 1) {


### PR DESCRIPTION
### Motivation
- Gruppennamen mit Bindestrich wurden bei der Dateneingabe abgeschnitten, weil die Helperfunktionen Group-Labels am ersten `-` normalisierten; das verhindert korrekte Anzeige und Gruppierung von Labels wie „Sozial-Emotionales Lernen“. 
- Der Fix soll nur die Anzeige/Verarbeitung von Gruppenlabels in der Schüler- und Lehrerdateneingabe reparieren, ohne technische Feldnamen oder RCFF-Matching zu verändern.

### Description
- Entfernt die Hyphen-Abschneide-Logik in `group_parts_from_meta()` und lässt das Original-Label unverändert; eine erklärende Kommentarzeile wurde ergänzt. (Dateien: `teacher/ajax/entry_api.php`, `student/ajax/wizard_api.php`.)
- Die Funktion liefert weiterhin `group` und `subgroup` (bei `/`-getrennten Werten) unverändert zurück, sodass Gruppierung und UI-Keys wie bisher funktionieren, aber mit vollständigen Labels.
- Die technische Feldnamen-Normalisierung bleibt separat in `base_field_key()` unverändert, sodass Feldnamen wie `DEU-001`, `skillcb-cid-477-1`, `ENG-001-S`/`-T` nicht betroffen sind.
- JavaScript-Logik wurde nicht geändert, da die Ursache in PHP lag; Clientseitige Gruppenselektion nutzt weiterhin `::` für subgroup-filtering und ist damit sicher gegenüber Bindestrichen in Labels.

### Testing
- Syntax-Checks: `php -l teacher/ajax/entry_api.php` und `php -l student/ajax/wizard_api.php` — beide bestanden.
- Ein kurzes Inline-PHP-Checkskript prüfte, dass folgende Fälle korrekt erhalten bleiben: `Sozial-Emotionales Lernen`, `Sachunterricht – Natur-Technik`, `Self-Assessment`, `Teacher-Student Rating`, `Sozial-Emotionales Lernen / Selbst- und Fremdwahrnehmung`, `Social-Emotional Learning` und dass hyphenierte Feldnamen (`DEU-001`, `skillcb-cid-477-1`, `ENG-001-S`, `ENG-001-T`) weiterhin durch die bestehende Normalisierungspfad verarbeitet werden — alle Prüfungen erfolgreich.
- Änderungen wurden in einem Commit erfasst; es wurden keine automatisierten Test-Suiten gefunden/ausgeführt in diesem Repo-Layout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da862ede0832e93aa7886a9b845c1)