### PR TITLE
Support subgroup/section metadata and UI grouping; preserve group labels with hyphens

### DIFF
--- a/student/ajax/wizard_api.php
+++ b/student/ajax/wizard_api.php
@@ -122,27 +122,48 @@ function resolve_option_value_text(PDO $pdo, array $meta, ?string $valueJsonRaw,
   return $out;
 }
 
+function meta_first_string(array $meta, array $keys): string {
+  foreach ($keys as $key) {
+    $v = $meta[$key] ?? null;
+    if (is_string($v) || is_numeric($v)) {
+      $s = trim((string)$v);
+      if ($s !== '') return $s;
+    }
+  }
+  return '';
+}
+
+function meta_rcff_first_string(array $meta, array $keys): string {
+  $rcff = is_array($meta['rcff'] ?? null) ? $meta['rcff'] : [];
+  return meta_first_string($rcff, $keys);
+}
+
 function group_parts_from_meta(array $meta): array {
-  $raw = trim((string)($meta['group'] ?? ''));
-  if ($raw === '') return ['group' => 'Allgemein', 'subgroup' => ''];
+  $raw = meta_first_string($meta, ['group', 'category', 'category_de', 'group_label']);
+  if ($raw === '') $raw = meta_rcff_first_string($meta, ['category_de', 'category']);
 
   $parts = array_values(array_filter(array_map('trim', explode('/', $raw)), fn($p) => $p !== ''));
-  if (!$parts) return ['group' => 'Allgemein', 'subgroup' => ''];
 
-  $group = $parts[0];
+  // Group and subgroup labels are free-form text and may contain hyphens (e.g.
+  // "Sozial-Emotionales Lernen" / "Selbst- und Fremdwahrnehmung"). Keep
+  // labels intact; field-name normalization is handled separately in
+  // base_field_key().
+  $group = $parts[0] ?? '';
+  if ($group === '') $group = 'Allgemein';
 
-  // Normalize: ignore suffix after '-' (e.g. "Ger1-T" -> "Ger1")
-  if ($group !== '' && strpos($group, '-') !== false) {
-    $group = explode('-', $group, 2)[0];
-    $group = trim($group);
-  }
-
-  $subgroup = '';
-  if (count($parts) > 1) {
+  $subgroup = meta_first_string($meta, ['subgroup', 'sub_group', 'subcategory', 'subcategory_de', 'subgroup_label']);
+  if ($subgroup === '') $subgroup = meta_rcff_first_string($meta, ['subcategory_de', 'subcategory']);
+  if ($subgroup === '' && count($parts) > 1) {
     $subgroup = implode(' / ', array_slice($parts, 1));
   }
 
-  return ['group' => $group !== '' ? $group : 'Allgemein', 'subgroup' => $subgroup];
+  return ['group' => $group, 'subgroup' => $subgroup];
+}
+
+function subgroup_title_en_from_meta(array $meta): string {
+  $title = meta_first_string($meta, ['subgroup_title_en', 'subcategory_en', 'subgroup_label_en']);
+  if ($title !== '') return $title;
+  return meta_rcff_first_string($meta, ['subcategory_en']);
 }
 
 function group_key_from_meta(array $meta): string {
@@ -193,8 +214,8 @@ function group_title_override_lang(string $groupKey, string $lang): string {
 
 function group_title_from_meta(array $meta, string $groupKey, string $lang): string {
   if ($lang === 'en') {
-    $t = (string)($meta['group_title_en'] ?? '');
-    $t = trim($t);
+    $t = meta_first_string($meta, ['group_title_en', 'category_en']);
+    if ($t === '') $t = meta_rcff_first_string($meta, ['category_en']);
     if ($t !== '') return $t;
   }
   return group_title_override_lang($groupKey, $lang);
@@ -426,8 +447,12 @@ function load_all_fields_lookup(PDO $pdo, int $templateId, int $reportId): array
 }
 
 function load_child_fields(PDO $pdo, int $templateId): array {
+  $select = 'id, field_name, field_type, label, label_en, help_text, is_multiline, options_json, meta_json, sort_order';
+  foreach (['group_label', 'group_label_en', 'subgroup_label', 'subgroup_label_en'] as $column) {
+    if (db_has_column($pdo, 'template_fields', $column)) $select .= ', ' . $column;
+  }
   $st = $pdo->prepare(
-    "SELECT id, field_name, field_type, label, label_en, help_text, is_multiline, options_json, meta_json, sort_order
+    "SELECT $select
      FROM template_fields
      WHERE template_id=? AND can_child_edit=1
      ORDER BY sort_order ASC, id ASC"
@@ -682,6 +707,15 @@ try {
         continue;
       }
       $meta = meta_read($r['meta_json'] ?? null);
+      foreach ([
+        'group_label' => 'group',
+        'group_label_en' => 'group_title_en',
+        'subgroup_label' => 'subgroup',
+        'subgroup_label_en' => 'subgroup_title_en',
+      ] as $column => $metaKey) {
+        $v = trim((string)($r[$column] ?? ''));
+        if ($v !== '' && trim((string)($meta[$metaKey] ?? '')) === '') $meta[$metaKey] = $v;
+      }
 
       $gParts = group_parts_from_meta($meta);
       $gKey = $gParts['group'];
@@ -729,7 +763,7 @@ try {
         'multiline' => (int)($r['is_multiline'] ?? 0) === 1,
         'group' => $gKey,
         'subgroup' => $gParts['subgroup'],
-        'subgroup_title_en' => (string)($meta['subgroup_title_en'] ?? ''),
+        'subgroup_title_en' => subgroup_title_en_from_meta($meta),
         'options' => $opts,     // includes label_en now (for option-list templates)
         'value' => $val,
         'max_length' => pdf_max_len_from_meta($meta),

--- a/student/index.php
+++ b/student/index.php
@@ -190,6 +190,7 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
       white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
       max-width: 190px;
     }
+    .nav a.item.section-step .lbl{ font-weight:750; }
 
     .save-status{
       margin-top:4px;
@@ -247,6 +248,15 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     }
     .section-h .t{ font-weight:850; }
     .section-h .s{ color: var(--muted); font-size:12px; }
+    .subsection-h{
+      margin: 0 0 12px;
+      padding: 11px 13px;
+      border-radius: 14px;
+      border: 1px solid rgba(11,87,208,0.18);
+      background: rgba(11,87,208,0.06);
+    }
+    .subsection-h .t{ font-weight:900; }
+    .subsection-h .s{ color: var(--muted); font-size:12px; margin-top:2px; }
 
     .group-intro{
       border: 1px solid var(--border);
@@ -758,7 +768,8 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
         return String(elBody.innerText || '').trim();
       }
       if (cur && cur.kind === 'group_intro') {
-        const groupLabel = cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt');
+        const subgroupTitle = String(cur.subgroupTitle || '').trim();
+        const groupLabel = (cur.introLevel === 'subgroup' && subgroupTitle) ? sectionTitle(cur.groupTitle || cur.group, { title: subgroupTitle }) : (cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt'));
         const intro = t('student.js.group_intro_tts', 'Weiter geht es mit dem Thema');
         return `${intro} ${groupLabel}.`.trim();
       }
@@ -766,7 +777,7 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
         const idx = buildFieldNameIndex();
         const fieldLabel = resolveTextTemplate(String(cur.field?.label || cur.field?.name || tfmt('student.js.question_label', 'Frage {index}', { index: 1 })), idx);
         if (includeGroup) {
-          const groupLabel = cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt');
+          const groupLabel = cur.subgroupTitle ? sectionTitle(cur.groupTitle || cur.group, { title: cur.subgroupTitle }) : (cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt'));
           return `${groupLabel}. ${fieldLabel}`.trim();
         }
         return String(fieldLabel || '').trim();
@@ -1270,6 +1281,67 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     return (Array.isArray(state.steps) ? state.steps : []).filter(s => s && !s.is_intro);
   }
 
+  function subgroupLabelForField(f){
+    const key = String(f?.subgroup || '').trim();
+    if (!key) return '';
+    if (currentLang === 'en') {
+      const titleEn = String(f?.subgroup_title_en || '').trim();
+      if (titleEn) return titleEn;
+    }
+    return key;
+  }
+
+  function sectionTitle(groupTitle, section){
+    const group = String(groupTitle || t('student.js.section', 'Abschnitt'));
+    const sub = String(section?.title || '').trim();
+    return sub ? `${group} – ${sub}` : group;
+  }
+
+  function stableSectionHash(value){
+    let h = 2166136261;
+    const raw = String(value || '');
+    for (let i = 0; i < raw.length; i += 1) {
+      h ^= raw.charCodeAt(i);
+      h = Math.imul(h, 16777619);
+    }
+    return (h >>> 0).toString(36);
+  }
+
+  function groupIntroKey(groupKey){
+    return 'gi:group:' + stableSectionHash(groupKey);
+  }
+
+  function sectionIntroKey(sectionKey){
+    return 'gi:section:' + String(sectionKey || '');
+  }
+
+  function groupSections(g){
+    const gKey = String(g?.key || g?.title || t('student.js.section', 'Abschnitt'));
+    const fields = Array.isArray(g?.fields) ? g.fields : [];
+    const sections = [];
+    const bySubgroup = new Map();
+    for (const f of fields) {
+      const rawSubgroup = String(f?.subgroup || '').trim();
+      const mapKey = rawSubgroup === '' ? '__none__' : rawSubgroup;
+      if (!bySubgroup.has(mapKey)) {
+        const title = rawSubgroup === '' ? '' : subgroupLabelForField(f);
+        const sectionKey = 'sec:' + stableSectionHash(`${gKey}\u001f${rawSubgroup}`) + ':' + sections.length;
+        const section = {
+          key: sectionKey,
+          groupKey: gKey,
+          subgroupKey: rawSubgroup,
+          title,
+          fields: []
+        };
+        bySubgroup.set(mapKey, section);
+        sections.push(section);
+      }
+      bySubgroup.get(mapKey).fields.push(f);
+    }
+    return sections.filter(section => Array.isArray(section.fields) && section.fields.length > 0);
+  }
+
+
   function buildFlatSteps(){
     const steps = Array.isArray(state.steps) ? state.steps : [];
     const intro = steps.find(s => s && s.is_intro);
@@ -1287,66 +1359,65 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
       out.push({ kind:'intro', key:'intro', title:'Start', intro_html:'' });
     }
 
-    if (displayMode === 'groups') {
-      for (const g of groups) {
-        out.push({
-          kind:'group',
-          key: String(g.key || g.title || 'Abschnitt'),
-          title: String(g.title || g.key || 'Abschnitt'),
-          group: String(g.key || g.title || 'Abschnitt'),
-          fields: Array.isArray(g.fields) ? g.fields : []
-        });
-      }
-    } else if (displayMode === 'items') {
-      for (const g of groups) {
-        const gKey = String(g.key || g.title || 'Abschnitt');
-        const gTitle = String(g.title || g.key || 'Abschnitt');
-        const fields = Array.isArray(g.fields) ? g.fields : [];
+    for (const g of groups) {
+      const gKey = String(g.key || g.title || 'Abschnitt');
+      const gTitle = String(g.title || g.key || 'Abschnitt');
+      const sections = groupSections(g);
+      if (!sections.length) continue;
+      const allFields = sections.flatMap(section => section.fields);
 
-        out.push({
-          kind: 'group_intro',
-          key: 'gi:' + gKey,
-          title: gTitle,
-          group: gKey,
-          groupTitle: gTitle,
-          fields: fields
-        });
+      out.push({
+        kind: 'group_intro',
+        introLevel: 'group',
+        key: groupIntroKey(gKey),
+        title: gTitle,
+        group: gKey,
+        groupTitle: gTitle,
+        subgroup: '',
+        subgroupTitle: '',
+        fields: allFields
+      });
 
-        for (const f of fields) {
+      for (const section of sections) {
+        const title = sectionTitle(gTitle, section);
+        if (section.title) {
           out.push({
-            kind:'field',
-            key: gKey + ':' + String(f.id),
-            title: gTitle,
+            kind: 'group_intro',
+            introLevel: 'subgroup',
+            key: sectionIntroKey(section.key),
+            title,
             group: gKey,
             groupTitle: gTitle,
-            field: f
+            subgroup: section.subgroupKey,
+            subgroupTitle: section.title,
+            fields: section.fields
           });
         }
-      }
-    } else {
-      for (const g of groups) {
-        const gKey = String(g.key || g.title || 'Abschnitt');
-        const gTitle = String(g.title || g.key || 'Abschnitt');
-        const fields = Array.isArray(g.fields) ? g.fields : [];
 
-        out.push({
-          kind: 'group_intro',
-          key: 'gi:' + gKey,
-          title: gTitle,
-          group: gKey,
-          groupTitle: gTitle,
-          fields: fields
-        });
-
-        for (const f of fields) {
+        if (displayMode === 'groups') {
           out.push({
-            kind:'field',
-            key: gKey + ':' + String(f.id),
-            title: gTitle,
+            kind:'group',
+            key: section.key,
+            title,
             group: gKey,
             groupTitle: gTitle,
-            field: f
+            subgroup: section.subgroupKey,
+            subgroupTitle: section.title,
+            fields: section.fields
           });
+        } else {
+          for (const f of section.fields) {
+            out.push({
+              kind:'field',
+              key: section.key + ':' + String(f.id),
+              title,
+              group: gKey,
+              groupTitle: gTitle,
+              subgroup: section.subgroupKey,
+              subgroupTitle: section.title,
+              field: f
+            });
+          }
         }
       }
     }
@@ -1395,11 +1466,19 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
       </div>
     </div>`);
 
-    function stepIndexForGroupKey(gKey){
-      if (displayMode === 'groups') {
-        return flatSteps.findIndex(s => s.kind==='group' && String(s.group)===String(gKey));
+    function stepIndexForGroup(gKey){
+      return flatSteps.findIndex(s => s.kind === 'group_intro' && s.introLevel === 'group' && String(s.group) === String(gKey));
+    }
+
+    function stepIndexForSection(section){
+      if (section && section.title) {
+        return flatSteps.findIndex(s => s.kind === 'group_intro' && s.introLevel === 'subgroup' && String(s.key) === String(sectionIntroKey(section.key)));
       }
-      return flatSteps.findIndex(s => s.kind==='group_intro' && String(s.group)===String(gKey));
+      if (displayMode === 'groups') {
+        return flatSteps.findIndex(s => s.kind === 'group' && String(s.key) === String(section?.key || ''));
+      }
+      const firstField = Array.isArray(section?.fields) ? section.fields[0] : null;
+      return firstField ? flatSteps.findIndex(s => s.kind === 'field' && String(s.key) === String(section.key + ':' + String(firstField.id))) : -1;
     }
 
     for (const g of groups) {
@@ -1409,11 +1488,13 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
       const st = groupStats(fields);
       const badgeCls = (st.missing === 0) ? 'ok' : 'miss';
       const badgeTxt = (st.missing === 0) ? '✓' : String(st.missing);
+      const sections = groupSections(g);
+      if (!sections.length) continue;
+      const groupIdx = stepIndexForGroup(gKey);
 
       if (displayMode === 'groups') {
-        const idx = stepIndexForGroupKey(gKey);
-        html.push(`<div class="group" data-group="${esc(gKey)}">
-          <div class="group-h" data-jump="${idx}">
+        html.push(`<div class="group" data-group="${esc(gKey)}" data-kind="category">
+          <div class="group-h" data-jump="${groupIdx}">
             <div class="left">
               <div class="title">${esc(gTitle)}</div>
               <div class="sub">${st.done}/${st.total}</div>
@@ -1421,11 +1502,26 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
             <span class="badge-mini ${badgeCls}">${esc(badgeTxt)}</span>
           </div>
         </div>`);
-      } else {
-        const idx = stepIndexForGroupKey(gKey);
 
+        sections.forEach(section => {
+          const idx = stepIndexForSection(section);
+          const sectionStats = groupStats(section.fields);
+          const sectionBadgeCls = (sectionStats.missing === 0) ? 'ok' : 'miss';
+          const sectionBadgeTxt = (sectionStats.missing === 0) ? '✓' : String(sectionStats.missing);
+          const title = section.title || gTitle;
+          html.push(`<div class="group" data-group="${esc(gKey)}" data-section="${esc(section.key)}">
+            <div class="group-h" data-jump="${idx}">
+              <div class="left">
+                <div class="title">${esc(title)}</div>
+                <div class="sub">${sectionStats.done}/${sectionStats.total}</div>
+              </div>
+              <span class="badge-mini ${sectionBadgeCls}">${esc(sectionBadgeTxt)}</span>
+            </div>
+          </div>`);
+        });
+      } else {
         html.push(`<div class="group" data-group="${esc(gKey)}">
-          <div class="group-h" data-toggle="${esc(gKey)}" data-jump="${idx}">
+          <div class="group-h" data-toggle="${esc(gKey)}" data-jump="${groupIdx}">
             <div class="left">
               <div class="title">${esc(gTitle)}</div>
               <div class="sub">${st.done}/${st.total}</div>
@@ -1433,18 +1529,34 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
             <span class="badge-mini ${badgeCls}">${esc(badgeTxt)}</span>
           </div>
           <div class="items">` +
-            fields.map((f, i) => {
-              const missing = fieldIsMissing(f);
-              const stepIdx = flatSteps.findIndex(s => s.kind==='field' && String(s.group)===String(gKey) && String(s.field?.id)===String(f.id));
-              const active = stepIdx === activeStep;
-              const fullLbl = String(f.label || f.name || tfmt('student.js.question_label', 'Frage {index}', { index: i + 1 }));
-              return `<a class="item ${missing?'missing':'ok'} ${active?'active':''}" data-jump="${stepIdx}" title="${esc(fullLbl)}">
+            sections.map(section => {
+              const sectionIdx = stepIndexForSection(section);
+              const sectionStats = groupStats(section.fields);
+              const sectionMissing = sectionStats.missing > 0;
+              const sectionActive = sectionIdx === activeStep;
+              const sectionLabel = sectionTitle(gTitle, section);
+              const showSectionIntro = Boolean(section.title);
+              const sectionIntro = showSectionIntro ? `<a class="item section-step ${sectionMissing?'missing':'ok'} ${sectionActive?'active':''}" data-jump="${sectionIdx}" title="${esc(sectionLabel)}">
                 <div class="txt">
                   <span class="dot" aria-hidden="true"></span>
-                  <span class="lbl">${esc(tfmt('student.js.question_label', 'Frage {index}', { index: i + 1 }))}</span>
+                  <span class="lbl">${esc(section.title)}</span>
                 </div>
-                <span class="badge-mini ${missing?'miss':'ok'}">${missing?'!':'✓'}</span>
-              </a>`;
+                <span class="badge-mini ${sectionMissing?'miss':'ok'}">${sectionMissing ? String(sectionStats.missing) : '✓'}</span>
+              </a>` : '';
+              const fieldItems = section.fields.map((f, i) => {
+                const missing = fieldIsMissing(f);
+                const stepIdx = flatSteps.findIndex(s => s.kind === 'field' && String(s.key) === String(section.key + ':' + String(f.id)));
+                const active = stepIdx === activeStep;
+                const fullLbl = String(f.label || f.name || tfmt('student.js.question_label', 'Frage {index}', { index: i + 1 }));
+                return `<a class="item ${missing?'missing':'ok'} ${active?'active':''}" data-jump="${stepIdx}" title="${esc(fullLbl)}">
+                  <div class="txt">
+                    <span class="dot" aria-hidden="true"></span>
+                    <span class="lbl">${esc(tfmt('student.js.question_label', 'Frage {index}', { index: i + 1 }))}</span>
+                  </div>
+                  <span class="badge-mini ${missing?'miss':'ok'}">${missing?'!':'✓'}</span>
+                </a>`;
+              }).join('');
+              return sectionIntro + fieldItems;
             }).join('') +
           `</div>
         </div>`);
@@ -1820,12 +1932,14 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     return null;
   }
 
-  function firstFieldIndexForGroup(groupKey){
-    if (!Array.isArray(flatSteps)) return null;
+  function firstFieldIndexForSectionStep(matchStep){
+    if (!Array.isArray(flatSteps) || !matchStep) return null;
     for (let i = 0; i < flatSteps.length; i += 1) {
       const step = flatSteps[i];
       if (!step || step.kind !== 'field') continue;
-      if (String(step.group) === String(groupKey)) return i;
+      if (String(step.group) !== String(matchStep.group)) continue;
+      if (String(step.subgroup || '') !== String(matchStep.subgroup || '')) continue;
+      return i;
     }
     return null;
   }
@@ -1840,9 +1954,9 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     if (typeof missingIdx !== 'number') return 0;
     const step = flatSteps[missingIdx];
     if (step && step.kind === 'field' && displayMode !== 'groups') {
-      const firstIdx = firstFieldIndexForGroup(step.group);
+      const firstIdx = firstFieldIndexForSectionStep(step);
       if (firstIdx === missingIdx) {
-        const giIdx = flatSteps.findIndex(s => s.kind === 'group_intro' && String(s.group) === String(step.group));
+        const giIdx = flatSteps.findIndex(s => s.kind === 'group_intro' && String(s.group) === String(step.group) && String(s.subgroup || '') === String(step.subgroup || ''));
         if (giIdx >= 0) return giIdx;
       }
     }
@@ -2023,9 +2137,13 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     }
 
     else if (cur.kind === 'group') {
-      elTitle.textContent = cur.title;
-      elSub.textContent = isBeginnerMode ? '' : t('student.js.group_sub', 'Du kannst weiterklicken und später zurückspringen, wenn etwas fehlt.');
-      elBody.innerHTML = ((cur.fields || []).map(f => renderFieldBlock(f)).join('') || `<p class="muted">${esc(t('student.js.no_fields', 'Keine Felder.'))}</p>`);
+      const subgroupTitle = String(cur.subgroupTitle || '').trim();
+      elTitle.textContent = cur.groupTitle || cur.title;
+      elSub.textContent = isBeginnerMode ? '' : (subgroupTitle || t('student.js.group_sub', 'Du kannst weiterklicken und später zurückspringen, wenn etwas fehlt.'));
+      const headerHtml = subgroupTitle
+        ? `<div class="subsection-h"><div class="t">${esc(subgroupTitle)}</div><div class="s">${esc(cur.groupTitle || cur.group || '')}</div></div>`
+        : '';
+      elBody.innerHTML = headerHtml + (((cur.fields || []).map(f => renderFieldBlock(f)).join('')) || `<p class="muted">${esc(t('student.js.no_fields', 'Keine Felder.'))}</p>`);
       attachFieldHandlers(elBody);
       btnNext.textContent = t('student.js.cta_next', t('student.buttons.next', 'Weiter'));
       btnNext.disabled = false;
@@ -2034,23 +2152,29 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
 
     else if (cur.kind === 'group_intro') {
       const fields = Array.isArray(cur.fields) ? cur.fields : [];
-      const groupLabel = cur.groupTitle || cur.title || t('student.js.section', 'Abschnitt');
-      elTitle.textContent = isBeginnerMode ? groupLabel : groupLabel;
-      elSub.textContent = isBeginnerMode ? '' : t('student.js.group_intro_sub', 'Bevor es losgeht: kurze Übersicht.');
+      const subgroupTitle = String(cur.subgroupTitle || '').trim();
+      const isSubgroupIntro = cur.introLevel === 'subgroup' && subgroupTitle !== '';
+      const heading = isSubgroupIntro ? subgroupTitle : (cur.groupTitle || cur.title || t('student.js.section', 'Abschnitt'));
+      const context = isSubgroupIntro ? (cur.groupTitle || cur.group || '') : '';
+      elTitle.textContent = heading;
+      elSub.textContent = isBeginnerMode ? context : (context || t('student.js.group_intro_sub', 'Bevor es losgeht: kurze Übersicht.'));
+      const contextHtml = context ? `<div class="muted" style="margin-bottom:8px;">${esc(context)}</div>` : '';
       elBody.innerHTML = isBeginnerMode
         ? `<div class="group-intro">
-            <h2 style="margin:0; font-weight:900; font-size:28px;">${esc(groupLabel)}</h2>
+            ${contextHtml}
+            <h2 style="margin:0; font-weight:900; font-size:28px;">${esc(heading)}</h2>
           </div>`
         : `<div class="group-intro">
             <p class="kicker">${esc(t('student.js.group_intro_kicker', 'Neuer Abschnitt'))}</p>
-            <h3>${esc(groupLabel)}</h3>
+            ${contextHtml}
+            <h3>${esc(heading)}</h3>
             <div class="muted">${esc(tfmt('student.js.group_intro_hint', 'Hier kommen {count} Fragen. Du kannst jederzeit im Menü springen.', { count: fields.length }))}</div>
             <div style="margin-top:12px;"><button class="btn" type="button" id="btnStartGroup">${esc(t('student.js.cta_begin_group', 'Starten'))}</button></div>
           </div>`;
       const b = document.getElementById('btnStartGroup');
       if (b) {
         b.addEventListener('click', () => {
-          const idx = flatSteps.findIndex(s => s.kind === 'field' && String(s.group) === String(cur.group));
+          const idx = flatSteps.findIndex(s => s.kind === 'field' && String(s.group) === String(cur.group) && String(s.subgroup || '') === String(cur.subgroup || ''));
           if (idx >= 0) { activeStep = idx; render(); }
           else { activeStep = Math.min(activeStep + 1, flatSteps.length - 1); render(); }
         });
@@ -2067,9 +2191,10 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
       const f = cur.field;
       const idx = buildFieldNameIndex();
       const fieldLabel = resolveTextTemplate(String(f.label || f.name || tfmt('student.js.question_label', 'Frage {index}', { index: 1 })), idx);
-      elTitle.textContent = isBeginnerMode ? fieldLabel : cur.groupTitle;
+      const sectionLabel = cur.subgroupTitle ? sectionTitle(cur.groupTitle || cur.group, { title: cur.subgroupTitle }) : (cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt'));
+      elTitle.textContent = isBeginnerMode ? fieldLabel : sectionLabel;
       elSub.textContent = isBeginnerMode
-        ? (cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt'))
+        ? sectionLabel
         : t('student.js.field_sub', 'Eine Frage nach der anderen. Du kannst jederzeit zurückspringen.');
       elBody.innerHTML = renderFieldBlock(f, { showLabel: !isBeginnerMode, showHelp: !isBeginnerMode });
       attachFieldHandlers(elBody);

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -839,11 +839,11 @@ function group_parts_from_meta(array $meta): array {
   $parts = array_values(array_filter(array_map('trim', explode('/', $raw)), fn($p) => $p !== ''));
   if (!$parts) return ['group' => 'Allgemein', 'subgroup' => ''];
 
+  // Group labels are free-form text and may contain hyphens (e.g.
+  // "Sozial-Emotionales Lernen"). Keep the original label intact; do not
+  // parse technical suffixes from group names here. Field-name normalization is
+  // handled separately in base_field_key().
   $group = $parts[0];
-  if ($group !== '' && strpos($group, '-') !== false) {
-    $group = explode('-', $group, 2)[0];
-    $group = trim($group);
-  }
 
   $subgroup = '';
   if (count($parts) > 1) {


### PR DESCRIPTION
### Motivation

- Make group/subgroup metadata extraction more flexible (support multiple meta keys and legacy `rcff` payloads) and preserve original group labels that contain hyphens.  
- Surface subgroup/section titles in the student UI so long templates can be split into logical subsections and beginner-mode narration can announce section context.  
- Allow `template_fields` to carry explicit `group_label*` / `subgroup_label*` columns and propagate those into runtime metadata.  

### Description

- Add helper functions `meta_first_string()` and `meta_rcff_first_string()` and use them to read category/group/subgroup/title values from multiple meta keys and legacy `rcff` structure.  
- Refactor `group_parts_from_meta()` and `group_title_from_meta()` to stop stripping hyphen suffixes from group labels and to prefer more meta keys (`category`, `category_de`, `group_label`, etc.).  
- In `load_child_fields()` include optional columns `group_label`, `group_label_en`, `subgroup_label`, `subgroup_label_en` when present in the DB and merge their values into `meta` during field loading; use `subgroup_title_en_from_meta()` when building field data.  
- Student UI changes in `student/index.php`: introduce section/subgroup concepts (functions `groupSections()`, `sectionTitle()`, `stableSectionHash()`, `groupIntroKey()`/`sectionIntroKey()`), build flat steps with `introLevel` (`group`/`subgroup`), render subsection headers (`.subsection-h`), and update navigation to show sections with aggregated badges and per-field links.  
- Adjust step-selection logic to match subgroup-aware keys and ensure beginner-mode TTS and intro behavior use the new section titles.  
- Update teacher side `group_parts_from_meta()` to keep original group label text intact and document rationale in comments.  

### Testing

- Ran PHP syntax checks (`php -l`) across modified PHP files with no parse errors.  
- Executed the project's automated PHP test suite (`vendor/bin/phpunit`) and JavaScript unit/lint checks (`npm test` / `npm run lint`) where configured, and all tests passed.  
- Performed automated UI navigation smoke checks to confirm new nav entries and section-start actions are generated (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da862ede0832e93aa7886a9b845c1)