### PR TITLE
Add shared group-key helpers; support subgroup sections and legacy group-key aliases

### DIFF
--- a/shared/group_keys.php
+++ b/shared/group_keys.php
@@ -1,0 +1,87 @@
+<?php
+// Shared helpers for display-safe group labels and backward-compatible group keys.
+declare(strict_types=1);
+
+function app_group_meta_first_string(array $meta, array $keys): string {
+  foreach ($keys as $key) {
+    $v = $meta[$key] ?? null;
+    if (is_string($v) || is_numeric($v)) {
+      $s = trim((string)$v);
+      if ($s !== '') return $s;
+    }
+  }
+  return '';
+}
+
+function app_group_meta_rcff_first_string(array $meta, array $keys): string {
+  $rcff = is_array($meta['rcff'] ?? null) ? $meta['rcff'] : [];
+  return app_group_meta_first_string($rcff, $keys);
+}
+
+function app_group_parts_from_meta(array $meta): array {
+  $raw = app_group_meta_first_string($meta, ['group', 'category', 'category_de', 'group_label']);
+  if ($raw === '') $raw = app_group_meta_rcff_first_string($meta, ['category_de', 'category']);
+
+  $parts = array_values(array_filter(array_map('trim', explode('/', $raw)), fn($p) => $p !== ''));
+
+  // Group and subgroup labels are free-form display text. Keep hyphens intact;
+  // legacy hyphen truncation is exposed only as an alias for old DB rows.
+  $group = $parts[0] ?? '';
+  if ($group === '') $group = 'Allgemein';
+
+  $subgroup = app_group_meta_first_string($meta, ['subgroup', 'sub_group', 'subcategory', 'subcategory_de', 'subgroup_label']);
+  if ($subgroup === '') $subgroup = app_group_meta_rcff_first_string($meta, ['subcategory_de', 'subcategory']);
+  if ($subgroup === '' && count($parts) > 1) {
+    $subgroup = implode(' / ', array_slice($parts, 1));
+  }
+
+  return ['group' => $group, 'subgroup' => $subgroup];
+}
+
+function app_group_label_from_meta(array $meta): string {
+  $parts = app_group_parts_from_meta($meta);
+  return (string)$parts['group'];
+}
+
+function app_group_key_from_meta(array $meta): string {
+  // Current technical key: full group label. New rows are stored with this key.
+  return app_group_label_from_meta($meta);
+}
+
+function app_legacy_group_key_from_label(string $label): string {
+  $label = trim($label);
+  if ($label === '') return '';
+  $pos = strpos($label, '-');
+  if ($pos === false) return $label;
+  $legacy = trim(substr($label, 0, $pos));
+  return $legacy !== '' ? $legacy : $label;
+}
+
+function app_group_key_aliases_from_label(string $label): array {
+  $aliases = [];
+  foreach ([$label, app_legacy_group_key_from_label($label)] as $candidate) {
+    $candidate = trim((string)$candidate);
+    if ($candidate !== '' && !in_array($candidate, $aliases, true)) $aliases[] = $candidate;
+  }
+  return $aliases;
+}
+
+function app_group_key_aliases_from_meta(array $meta): array {
+  return app_group_key_aliases_from_label(app_group_key_from_meta($meta));
+}
+
+function app_group_key_matches_map(array $map, array $aliases): bool {
+  foreach ($aliases as $alias) {
+    $alias = trim((string)$alias);
+    if ($alias !== '' && !empty($map[$alias])) return true;
+  }
+  return false;
+}
+
+function app_group_entry_from_alias_map(array $map, array $aliases): ?array {
+  foreach ($aliases as $alias) {
+    $alias = trim((string)$alias);
+    if ($alias !== '' && isset($map[$alias]) && is_array($map[$alias])) return $map[$alias];
+  }
+  return null;
+}

--- a/student/ajax/wizard_api.php
+++ b/student/ajax/wizard_api.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require __DIR__ . '/../../bootstrap.php';
+require_once __DIR__ . '/../../shared/group_keys.php';
 require __DIR__ . '/../../shared/value_history.php';
 require_student();
 
@@ -122,32 +123,34 @@ function resolve_option_value_text(PDO $pdo, array $meta, ?string $valueJsonRaw,
   return $out;
 }
 
+function meta_first_string(array $meta, array $keys): string {
+  return app_group_meta_first_string($meta, $keys);
+}
+
+function meta_rcff_first_string(array $meta, array $keys): string {
+  return app_group_meta_rcff_first_string($meta, $keys);
+}
+
 function group_parts_from_meta(array $meta): array {
-  $raw = trim((string)($meta['group'] ?? ''));
-  if ($raw === '') return ['group' => 'Allgemein', 'subgroup' => ''];
+  return app_group_parts_from_meta($meta);
+}
 
-  $parts = array_values(array_filter(array_map('trim', explode('/', $raw)), fn($p) => $p !== ''));
-  if (!$parts) return ['group' => 'Allgemein', 'subgroup' => ''];
-
-  $group = $parts[0];
-
-  // Normalize: ignore suffix after '-' (e.g. "Ger1-T" -> "Ger1")
-  if ($group !== '' && strpos($group, '-') !== false) {
-    $group = explode('-', $group, 2)[0];
-    $group = trim($group);
-  }
-
-  $subgroup = '';
-  if (count($parts) > 1) {
-    $subgroup = implode(' / ', array_slice($parts, 1));
-  }
-
-  return ['group' => $group !== '' ? $group : 'Allgemein', 'subgroup' => $subgroup];
+function subgroup_title_en_from_meta(array $meta): string {
+  $title = app_group_meta_first_string($meta, ['subgroup_title_en', 'subcategory_en', 'subgroup_label_en']);
+  if ($title !== '') return $title;
+  return app_group_meta_rcff_first_string($meta, ['subcategory_en']);
 }
 
 function group_key_from_meta(array $meta): string {
-  $parts = group_parts_from_meta($meta);
-  return $parts['group'];
+  return app_group_key_from_meta($meta);
+}
+
+function group_key_aliases_from_meta(array $meta): array {
+  return app_group_key_aliases_from_meta($meta);
+}
+
+function group_key_unlocked(array $unlockMap, array $aliases): bool {
+  return app_group_key_matches_map($unlockMap, $aliases);
 }
 
 function base_field_key(string $fieldName): string {
@@ -193,8 +196,8 @@ function group_title_override_lang(string $groupKey, string $lang): string {
 
 function group_title_from_meta(array $meta, string $groupKey, string $lang): string {
   if ($lang === 'en') {
-    $t = (string)($meta['group_title_en'] ?? '');
-    $t = trim($t);
+    $t = meta_first_string($meta, ['group_title_en', 'category_en']);
+    if ($t === '') $t = meta_rcff_first_string($meta, ['category_en']);
     if ($t !== '') return $t;
   }
   return group_title_override_lang($groupKey, $lang);
@@ -426,8 +429,12 @@ function load_all_fields_lookup(PDO $pdo, int $templateId, int $reportId): array
 }
 
 function load_child_fields(PDO $pdo, int $templateId): array {
+  $select = 'id, field_name, field_type, label, label_en, help_text, is_multiline, options_json, meta_json, sort_order';
+  foreach (['group_label', 'group_label_en', 'subgroup_label', 'subgroup_label_en'] as $column) {
+    if (db_has_column($pdo, 'template_fields', $column)) $select .= ', ' . $column;
+  }
   $st = $pdo->prepare(
-    "SELECT id, field_name, field_type, label, label_en, help_text, is_multiline, options_json, meta_json, sort_order
+    "SELECT $select
      FROM template_fields
      WHERE template_id=? AND can_child_edit=1
      ORDER BY sort_order ASC, id ASC"
@@ -682,15 +689,26 @@ try {
         continue;
       }
       $meta = meta_read($r['meta_json'] ?? null);
+      foreach ([
+        'group_label' => 'group',
+        'group_label_en' => 'group_title_en',
+        'subgroup_label' => 'subgroup',
+        'subgroup_label_en' => 'subgroup_title_en',
+      ] as $column => $metaKey) {
+        $v = trim((string)($r[$column] ?? ''));
+        if ($v !== '' && trim((string)($meta[$metaKey] ?? '')) === '') $meta[$metaKey] = $v;
+      }
 
       $gParts = group_parts_from_meta($meta);
       $gKey = $gParts['group'];
       $gTitle = group_title_from_meta($meta, $gKey, $lang);
 
+      $gAliases = group_key_aliases_from_meta($meta);
       if (!isset($groups[$gKey])) {
-        $groups[$gKey] = ['key' => $gKey, 'title' => $gTitle, 'fields' => []];
+        $groups[$gKey] = ['key' => $gKey, 'title' => $gTitle, 'aliases' => $gAliases, 'fields' => []];
       } else {
         $groups[$gKey]['title'] = $gTitle;
+        $groups[$gKey]['aliases'] = array_values(array_unique(array_merge($groups[$gKey]['aliases'] ?? [], $gAliases)));
       }
 
       $opts = [];
@@ -729,7 +747,7 @@ try {
         'multiline' => (int)($r['is_multiline'] ?? 0) === 1,
         'group' => $gKey,
         'subgroup' => $gParts['subgroup'],
-        'subgroup_title_en' => (string)($meta['subgroup_title_en'] ?? ''),
+        'subgroup_title_en' => subgroup_title_en_from_meta($meta),
         'options' => $opts,     // includes label_en now (for option-list templates)
         'value' => $val,
         'max_length' => pdf_max_len_from_meta($meta),
@@ -760,7 +778,8 @@ try {
 
     if ($groupUnlocks['active']) {
       foreach ($groups as $gKey => $gData) {
-        if (empty($groupUnlocks['map'][$gKey])) unset($groups[$gKey]);
+        $aliases = is_array($gData['aliases'] ?? null) ? $gData['aliases'] : [$gKey];
+        if (!group_key_unlocked($groupUnlocks['map'], $aliases)) unset($groups[$gKey]);
       }
       if (!$groups) $childCanEdit = false;
     }
@@ -800,8 +819,12 @@ try {
     $fieldId = (int)($data['template_field_id'] ?? 0);
     if ($fieldId <= 0) throw new RuntimeException('template_field_id fehlt.');
 
+    $fieldSelect = 'id, field_name, field_type, meta_json';
+    foreach (['group_label', 'group_label_en', 'subgroup_label', 'subgroup_label_en'] as $column) {
+      if (db_has_column($pdo, 'template_fields', $column)) $fieldSelect .= ', ' . $column;
+    }
     $st = $pdo->prepare(
-      "SELECT id, field_name, field_type, meta_json
+      "SELECT $fieldSelect
        FROM template_fields
        WHERE id=? AND template_id=? AND can_child_edit=1
        LIMIT 1"
@@ -817,12 +840,20 @@ try {
 
     $type = (string)$frow['field_type'];
     $meta = meta_read($frow['meta_json'] ?? null);
+    foreach ([
+      'group_label' => 'group',
+      'group_label_en' => 'group_title_en',
+      'subgroup_label' => 'subgroup',
+      'subgroup_label_en' => 'subgroup_title_en',
+    ] as $column => $metaKey) {
+      $v = trim((string)($frow[$column] ?? ''));
+      if ($v !== '' && trim((string)($meta[$metaKey] ?? '')) === '') $meta[$metaKey] = $v;
+    }
     $maxLen = pdf_max_len_from_meta($meta);
     $valueText = isset($data['value_text']) ? (string)$data['value_text'] : null;
 
     if ($groupUnlocks['active']) {
-      $gKey = group_key_from_meta($meta);
-      if (empty($groupUnlocks['map'][$gKey])) {
+      if (!group_key_unlocked($groupUnlocks['map'], group_key_aliases_from_meta($meta))) {
         throw new RuntimeException('Kategorie noch nicht freigegeben.');
       }
     }

--- a/student/index.php
+++ b/student/index.php
@@ -190,6 +190,7 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
       white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
       max-width: 190px;
     }
+    .nav a.item.section-step .lbl{ font-weight:750; }
 
     .save-status{
       margin-top:4px;
@@ -247,6 +248,15 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     }
     .section-h .t{ font-weight:850; }
     .section-h .s{ color: var(--muted); font-size:12px; }
+    .subsection-h{
+      margin: 0 0 12px;
+      padding: 11px 13px;
+      border-radius: 14px;
+      border: 1px solid rgba(11,87,208,0.18);
+      background: rgba(11,87,208,0.06);
+    }
+    .subsection-h .t{ font-weight:900; }
+    .subsection-h .s{ color: var(--muted); font-size:12px; margin-top:2px; }
 
     .group-intro{
       border: 1px solid var(--border);
@@ -758,7 +768,8 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
         return String(elBody.innerText || '').trim();
       }
       if (cur && cur.kind === 'group_intro') {
-        const groupLabel = cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt');
+        const subgroupTitle = String(cur.subgroupTitle || '').trim();
+        const groupLabel = (cur.introLevel === 'subgroup' && subgroupTitle) ? sectionTitle(cur.groupTitle || cur.group, { title: subgroupTitle }) : (cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt'));
         const intro = t('student.js.group_intro_tts', 'Weiter geht es mit dem Thema');
         return `${intro} ${groupLabel}.`.trim();
       }
@@ -766,7 +777,7 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
         const idx = buildFieldNameIndex();
         const fieldLabel = resolveTextTemplate(String(cur.field?.label || cur.field?.name || tfmt('student.js.question_label', 'Frage {index}', { index: 1 })), idx);
         if (includeGroup) {
-          const groupLabel = cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt');
+          const groupLabel = cur.subgroupTitle ? sectionTitle(cur.groupTitle || cur.group, { title: cur.subgroupTitle }) : (cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt'));
           return `${groupLabel}. ${fieldLabel}`.trim();
         }
         return String(fieldLabel || '').trim();
@@ -1270,6 +1281,67 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     return (Array.isArray(state.steps) ? state.steps : []).filter(s => s && !s.is_intro);
   }
 
+  function subgroupLabelForField(f){
+    const key = String(f?.subgroup || '').trim();
+    if (!key) return '';
+    if (currentLang === 'en') {
+      const titleEn = String(f?.subgroup_title_en || '').trim();
+      if (titleEn) return titleEn;
+    }
+    return key;
+  }
+
+  function sectionTitle(groupTitle, section){
+    const group = String(groupTitle || t('student.js.section', 'Abschnitt'));
+    const sub = String(section?.title || '').trim();
+    return sub ? `${group} – ${sub}` : group;
+  }
+
+  function stableSectionHash(value){
+    let h = 2166136261;
+    const raw = String(value || '');
+    for (let i = 0; i < raw.length; i += 1) {
+      h ^= raw.charCodeAt(i);
+      h = Math.imul(h, 16777619);
+    }
+    return (h >>> 0).toString(36);
+  }
+
+  function groupIntroKey(groupKey){
+    return 'gi:group:' + stableSectionHash(groupKey);
+  }
+
+  function sectionIntroKey(sectionKey){
+    return 'gi:section:' + String(sectionKey || '');
+  }
+
+  function groupSections(g){
+    const gKey = String(g?.key || g?.title || t('student.js.section', 'Abschnitt'));
+    const fields = Array.isArray(g?.fields) ? g.fields : [];
+    const sections = [];
+    const bySubgroup = new Map();
+    for (const f of fields) {
+      const rawSubgroup = String(f?.subgroup || '').trim();
+      const mapKey = rawSubgroup === '' ? '__none__' : rawSubgroup;
+      if (!bySubgroup.has(mapKey)) {
+        const title = rawSubgroup === '' ? '' : subgroupLabelForField(f);
+        const sectionKey = 'sec:' + stableSectionHash(`${gKey}\u001f${rawSubgroup}`) + ':' + sections.length;
+        const section = {
+          key: sectionKey,
+          groupKey: gKey,
+          subgroupKey: rawSubgroup,
+          title,
+          fields: []
+        };
+        bySubgroup.set(mapKey, section);
+        sections.push(section);
+      }
+      bySubgroup.get(mapKey).fields.push(f);
+    }
+    return sections.filter(section => Array.isArray(section.fields) && section.fields.length > 0);
+  }
+
+
   function buildFlatSteps(){
     const steps = Array.isArray(state.steps) ? state.steps : [];
     const intro = steps.find(s => s && s.is_intro);
@@ -1287,66 +1359,65 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
       out.push({ kind:'intro', key:'intro', title:'Start', intro_html:'' });
     }
 
-    if (displayMode === 'groups') {
-      for (const g of groups) {
-        out.push({
-          kind:'group',
-          key: String(g.key || g.title || 'Abschnitt'),
-          title: String(g.title || g.key || 'Abschnitt'),
-          group: String(g.key || g.title || 'Abschnitt'),
-          fields: Array.isArray(g.fields) ? g.fields : []
-        });
-      }
-    } else if (displayMode === 'items') {
-      for (const g of groups) {
-        const gKey = String(g.key || g.title || 'Abschnitt');
-        const gTitle = String(g.title || g.key || 'Abschnitt');
-        const fields = Array.isArray(g.fields) ? g.fields : [];
+    for (const g of groups) {
+      const gKey = String(g.key || g.title || 'Abschnitt');
+      const gTitle = String(g.title || g.key || 'Abschnitt');
+      const sections = groupSections(g);
+      if (!sections.length) continue;
+      const allFields = sections.flatMap(section => section.fields);
 
-        out.push({
-          kind: 'group_intro',
-          key: 'gi:' + gKey,
-          title: gTitle,
-          group: gKey,
-          groupTitle: gTitle,
-          fields: fields
-        });
+      out.push({
+        kind: 'group_intro',
+        introLevel: 'group',
+        key: groupIntroKey(gKey),
+        title: gTitle,
+        group: gKey,
+        groupTitle: gTitle,
+        subgroup: '',
+        subgroupTitle: '',
+        fields: allFields
+      });
 
-        for (const f of fields) {
+      for (const section of sections) {
+        const title = sectionTitle(gTitle, section);
+        if (section.title) {
           out.push({
-            kind:'field',
-            key: gKey + ':' + String(f.id),
-            title: gTitle,
+            kind: 'group_intro',
+            introLevel: 'subgroup',
+            key: sectionIntroKey(section.key),
+            title,
             group: gKey,
             groupTitle: gTitle,
-            field: f
+            subgroup: section.subgroupKey,
+            subgroupTitle: section.title,
+            fields: section.fields
           });
         }
-      }
-    } else {
-      for (const g of groups) {
-        const gKey = String(g.key || g.title || 'Abschnitt');
-        const gTitle = String(g.title || g.key || 'Abschnitt');
-        const fields = Array.isArray(g.fields) ? g.fields : [];
 
-        out.push({
-          kind: 'group_intro',
-          key: 'gi:' + gKey,
-          title: gTitle,
-          group: gKey,
-          groupTitle: gTitle,
-          fields: fields
-        });
-
-        for (const f of fields) {
+        if (displayMode === 'groups') {
           out.push({
-            kind:'field',
-            key: gKey + ':' + String(f.id),
-            title: gTitle,
+            kind:'group',
+            key: section.key,
+            title,
             group: gKey,
             groupTitle: gTitle,
-            field: f
+            subgroup: section.subgroupKey,
+            subgroupTitle: section.title,
+            fields: section.fields
           });
+        } else {
+          for (const f of section.fields) {
+            out.push({
+              kind:'field',
+              key: section.key + ':' + String(f.id),
+              title,
+              group: gKey,
+              groupTitle: gTitle,
+              subgroup: section.subgroupKey,
+              subgroupTitle: section.title,
+              field: f
+            });
+          }
         }
       }
     }
@@ -1395,11 +1466,19 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
       </div>
     </div>`);
 
-    function stepIndexForGroupKey(gKey){
-      if (displayMode === 'groups') {
-        return flatSteps.findIndex(s => s.kind==='group' && String(s.group)===String(gKey));
+    function stepIndexForGroup(gKey){
+      return flatSteps.findIndex(s => s.kind === 'group_intro' && s.introLevel === 'group' && String(s.group) === String(gKey));
+    }
+
+    function stepIndexForSection(section){
+      if (section && section.title) {
+        return flatSteps.findIndex(s => s.kind === 'group_intro' && s.introLevel === 'subgroup' && String(s.key) === String(sectionIntroKey(section.key)));
       }
-      return flatSteps.findIndex(s => s.kind==='group_intro' && String(s.group)===String(gKey));
+      if (displayMode === 'groups') {
+        return flatSteps.findIndex(s => s.kind === 'group' && String(s.key) === String(section?.key || ''));
+      }
+      const firstField = Array.isArray(section?.fields) ? section.fields[0] : null;
+      return firstField ? flatSteps.findIndex(s => s.kind === 'field' && String(s.key) === String(section.key + ':' + String(firstField.id))) : -1;
     }
 
     for (const g of groups) {
@@ -1409,11 +1488,13 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
       const st = groupStats(fields);
       const badgeCls = (st.missing === 0) ? 'ok' : 'miss';
       const badgeTxt = (st.missing === 0) ? '✓' : String(st.missing);
+      const sections = groupSections(g);
+      if (!sections.length) continue;
+      const groupIdx = stepIndexForGroup(gKey);
 
       if (displayMode === 'groups') {
-        const idx = stepIndexForGroupKey(gKey);
-        html.push(`<div class="group" data-group="${esc(gKey)}">
-          <div class="group-h" data-jump="${idx}">
+        html.push(`<div class="group" data-group="${esc(gKey)}" data-kind="category">
+          <div class="group-h" data-jump="${groupIdx}">
             <div class="left">
               <div class="title">${esc(gTitle)}</div>
               <div class="sub">${st.done}/${st.total}</div>
@@ -1421,11 +1502,26 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
             <span class="badge-mini ${badgeCls}">${esc(badgeTxt)}</span>
           </div>
         </div>`);
-      } else {
-        const idx = stepIndexForGroupKey(gKey);
 
+        sections.forEach(section => {
+          const idx = stepIndexForSection(section);
+          const sectionStats = groupStats(section.fields);
+          const sectionBadgeCls = (sectionStats.missing === 0) ? 'ok' : 'miss';
+          const sectionBadgeTxt = (sectionStats.missing === 0) ? '✓' : String(sectionStats.missing);
+          const title = section.title || gTitle;
+          html.push(`<div class="group" data-group="${esc(gKey)}" data-section="${esc(section.key)}">
+            <div class="group-h" data-jump="${idx}">
+              <div class="left">
+                <div class="title">${esc(title)}</div>
+                <div class="sub">${sectionStats.done}/${sectionStats.total}</div>
+              </div>
+              <span class="badge-mini ${sectionBadgeCls}">${esc(sectionBadgeTxt)}</span>
+            </div>
+          </div>`);
+        });
+      } else {
         html.push(`<div class="group" data-group="${esc(gKey)}">
-          <div class="group-h" data-toggle="${esc(gKey)}" data-jump="${idx}">
+          <div class="group-h" data-toggle="${esc(gKey)}" data-jump="${groupIdx}">
             <div class="left">
               <div class="title">${esc(gTitle)}</div>
               <div class="sub">${st.done}/${st.total}</div>
@@ -1433,18 +1529,34 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
             <span class="badge-mini ${badgeCls}">${esc(badgeTxt)}</span>
           </div>
           <div class="items">` +
-            fields.map((f, i) => {
-              const missing = fieldIsMissing(f);
-              const stepIdx = flatSteps.findIndex(s => s.kind==='field' && String(s.group)===String(gKey) && String(s.field?.id)===String(f.id));
-              const active = stepIdx === activeStep;
-              const fullLbl = String(f.label || f.name || tfmt('student.js.question_label', 'Frage {index}', { index: i + 1 }));
-              return `<a class="item ${missing?'missing':'ok'} ${active?'active':''}" data-jump="${stepIdx}" title="${esc(fullLbl)}">
+            sections.map(section => {
+              const sectionIdx = stepIndexForSection(section);
+              const sectionStats = groupStats(section.fields);
+              const sectionMissing = sectionStats.missing > 0;
+              const sectionActive = sectionIdx === activeStep;
+              const sectionLabel = sectionTitle(gTitle, section);
+              const showSectionIntro = Boolean(section.title);
+              const sectionIntro = showSectionIntro ? `<a class="item section-step ${sectionMissing?'missing':'ok'} ${sectionActive?'active':''}" data-jump="${sectionIdx}" title="${esc(sectionLabel)}">
                 <div class="txt">
                   <span class="dot" aria-hidden="true"></span>
-                  <span class="lbl">${esc(tfmt('student.js.question_label', 'Frage {index}', { index: i + 1 }))}</span>
+                  <span class="lbl">${esc(section.title)}</span>
                 </div>
-                <span class="badge-mini ${missing?'miss':'ok'}">${missing?'!':'✓'}</span>
-              </a>`;
+                <span class="badge-mini ${sectionMissing?'miss':'ok'}">${sectionMissing ? String(sectionStats.missing) : '✓'}</span>
+              </a>` : '';
+              const fieldItems = section.fields.map((f, i) => {
+                const missing = fieldIsMissing(f);
+                const stepIdx = flatSteps.findIndex(s => s.kind === 'field' && String(s.key) === String(section.key + ':' + String(f.id)));
+                const active = stepIdx === activeStep;
+                const fullLbl = String(f.label || f.name || tfmt('student.js.question_label', 'Frage {index}', { index: i + 1 }));
+                return `<a class="item ${missing?'missing':'ok'} ${active?'active':''}" data-jump="${stepIdx}" title="${esc(fullLbl)}">
+                  <div class="txt">
+                    <span class="dot" aria-hidden="true"></span>
+                    <span class="lbl">${esc(tfmt('student.js.question_label', 'Frage {index}', { index: i + 1 }))}</span>
+                  </div>
+                  <span class="badge-mini ${missing?'miss':'ok'}">${missing?'!':'✓'}</span>
+                </a>`;
+              }).join('');
+              return sectionIntro + fieldItems;
             }).join('') +
           `</div>
         </div>`);
@@ -1820,12 +1932,14 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     return null;
   }
 
-  function firstFieldIndexForGroup(groupKey){
-    if (!Array.isArray(flatSteps)) return null;
+  function firstFieldIndexForSectionStep(matchStep){
+    if (!Array.isArray(flatSteps) || !matchStep) return null;
     for (let i = 0; i < flatSteps.length; i += 1) {
       const step = flatSteps[i];
       if (!step || step.kind !== 'field') continue;
-      if (String(step.group) === String(groupKey)) return i;
+      if (String(step.group) !== String(matchStep.group)) continue;
+      if (String(step.subgroup || '') !== String(matchStep.subgroup || '')) continue;
+      return i;
     }
     return null;
   }
@@ -1840,9 +1954,9 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     if (typeof missingIdx !== 'number') return 0;
     const step = flatSteps[missingIdx];
     if (step && step.kind === 'field' && displayMode !== 'groups') {
-      const firstIdx = firstFieldIndexForGroup(step.group);
+      const firstIdx = firstFieldIndexForSectionStep(step);
       if (firstIdx === missingIdx) {
-        const giIdx = flatSteps.findIndex(s => s.kind === 'group_intro' && String(s.group) === String(step.group));
+        const giIdx = flatSteps.findIndex(s => s.kind === 'group_intro' && String(s.group) === String(step.group) && String(s.subgroup || '') === String(step.subgroup || ''));
         if (giIdx >= 0) return giIdx;
       }
     }
@@ -2023,9 +2137,13 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
     }
 
     else if (cur.kind === 'group') {
-      elTitle.textContent = cur.title;
-      elSub.textContent = isBeginnerMode ? '' : t('student.js.group_sub', 'Du kannst weiterklicken und später zurückspringen, wenn etwas fehlt.');
-      elBody.innerHTML = ((cur.fields || []).map(f => renderFieldBlock(f)).join('') || `<p class="muted">${esc(t('student.js.no_fields', 'Keine Felder.'))}</p>`);
+      const subgroupTitle = String(cur.subgroupTitle || '').trim();
+      elTitle.textContent = cur.groupTitle || cur.title;
+      elSub.textContent = isBeginnerMode ? '' : (subgroupTitle || t('student.js.group_sub', 'Du kannst weiterklicken und später zurückspringen, wenn etwas fehlt.'));
+      const headerHtml = subgroupTitle
+        ? `<div class="subsection-h"><div class="t">${esc(subgroupTitle)}</div><div class="s">${esc(cur.groupTitle || cur.group || '')}</div></div>`
+        : '';
+      elBody.innerHTML = headerHtml + (((cur.fields || []).map(f => renderFieldBlock(f)).join('')) || `<p class="muted">${esc(t('student.js.no_fields', 'Keine Felder.'))}</p>`);
       attachFieldHandlers(elBody);
       btnNext.textContent = t('student.js.cta_next', t('student.buttons.next', 'Weiter'));
       btnNext.disabled = false;
@@ -2034,23 +2152,29 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
 
     else if (cur.kind === 'group_intro') {
       const fields = Array.isArray(cur.fields) ? cur.fields : [];
-      const groupLabel = cur.groupTitle || cur.title || t('student.js.section', 'Abschnitt');
-      elTitle.textContent = isBeginnerMode ? groupLabel : groupLabel;
-      elSub.textContent = isBeginnerMode ? '' : t('student.js.group_intro_sub', 'Bevor es losgeht: kurze Übersicht.');
+      const subgroupTitle = String(cur.subgroupTitle || '').trim();
+      const isSubgroupIntro = cur.introLevel === 'subgroup' && subgroupTitle !== '';
+      const heading = isSubgroupIntro ? subgroupTitle : (cur.groupTitle || cur.title || t('student.js.section', 'Abschnitt'));
+      const context = isSubgroupIntro ? (cur.groupTitle || cur.group || '') : '';
+      elTitle.textContent = heading;
+      elSub.textContent = isBeginnerMode ? context : (context || t('student.js.group_intro_sub', 'Bevor es losgeht: kurze Übersicht.'));
+      const contextHtml = context ? `<div class="muted" style="margin-bottom:8px;">${esc(context)}</div>` : '';
       elBody.innerHTML = isBeginnerMode
         ? `<div class="group-intro">
-            <h2 style="margin:0; font-weight:900; font-size:28px;">${esc(groupLabel)}</h2>
+            ${contextHtml}
+            <h2 style="margin:0; font-weight:900; font-size:28px;">${esc(heading)}</h2>
           </div>`
         : `<div class="group-intro">
             <p class="kicker">${esc(t('student.js.group_intro_kicker', 'Neuer Abschnitt'))}</p>
-            <h3>${esc(groupLabel)}</h3>
+            ${contextHtml}
+            <h3>${esc(heading)}</h3>
             <div class="muted">${esc(tfmt('student.js.group_intro_hint', 'Hier kommen {count} Fragen. Du kannst jederzeit im Menü springen.', { count: fields.length }))}</div>
             <div style="margin-top:12px;"><button class="btn" type="button" id="btnStartGroup">${esc(t('student.js.cta_begin_group', 'Starten'))}</button></div>
           </div>`;
       const b = document.getElementById('btnStartGroup');
       if (b) {
         b.addEventListener('click', () => {
-          const idx = flatSteps.findIndex(s => s.kind === 'field' && String(s.group) === String(cur.group));
+          const idx = flatSteps.findIndex(s => s.kind === 'field' && String(s.group) === String(cur.group) && String(s.subgroup || '') === String(cur.subgroup || ''));
           if (idx >= 0) { activeStep = idx; render(); }
           else { activeStep = Math.min(activeStep + 1, flatSteps.length - 1); render(); }
         });
@@ -2067,9 +2191,10 @@ $ttsVoicePrefEn = trim((string)($studentCfg['tts_voice_en'] ?? ''));
       const f = cur.field;
       const idx = buildFieldNameIndex();
       const fieldLabel = resolveTextTemplate(String(f.label || f.name || tfmt('student.js.question_label', 'Frage {index}', { index: 1 })), idx);
-      elTitle.textContent = isBeginnerMode ? fieldLabel : cur.groupTitle;
+      const sectionLabel = cur.subgroupTitle ? sectionTitle(cur.groupTitle || cur.group, { title: cur.subgroupTitle }) : (cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt'));
+      elTitle.textContent = isBeginnerMode ? fieldLabel : sectionLabel;
       elSub.textContent = isBeginnerMode
-        ? (cur.groupTitle || cur.group || t('student.js.section', 'Abschnitt'))
+        ? sectionLabel
         : t('student.js.field_sub', 'Eine Frage nach der anderen. Du kannst jederzeit zurückspringen.');
       elBody.innerHTML = renderFieldBlock(f, { showLabel: !isBeginnerMode, showHelp: !isBeginnerMode });
       attachFieldHandlers(elBody);

--- a/teacher/ajax/entry_api.php
+++ b/teacher/ajax/entry_api.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require __DIR__ . '/../../bootstrap.php';
+require_once __DIR__ . '/../../shared/group_keys.php';
 require __DIR__ . '/../../shared/text_snippets.php';
 require __DIR__ . '/../../shared/value_history.php';
 require_teacher();
@@ -833,29 +834,27 @@ function resolve_label_placeholders(string $tpl, array $classValueByName): strin
 }
 
 function group_parts_from_meta(array $meta): array {
-  $raw = trim((string)($meta['group'] ?? ''));
-  if ($raw === '') return ['group' => 'Allgemein', 'subgroup' => ''];
-
-  $parts = array_values(array_filter(array_map('trim', explode('/', $raw)), fn($p) => $p !== ''));
-  if (!$parts) return ['group' => 'Allgemein', 'subgroup' => ''];
-
-  $group = $parts[0];
-  if ($group !== '' && strpos($group, '-') !== false) {
-    $group = explode('-', $group, 2)[0];
-    $group = trim($group);
-  }
-
-  $subgroup = '';
-  if (count($parts) > 1) {
-    $subgroup = implode(' / ', array_slice($parts, 1));
-  }
-
-  return ['group' => $group !== '' ? $group : 'Allgemein', 'subgroup' => $subgroup];
+  return app_group_parts_from_meta($meta);
 }
 
 function group_key_from_meta(array $meta): string {
-  $parts = group_parts_from_meta($meta);
-  return $parts['group'];
+  return app_group_key_from_meta($meta);
+}
+
+function group_key_aliases_from_meta(array $meta): array {
+  return app_group_key_aliases_from_meta($meta);
+}
+
+function group_key_aliases_from_key(string $groupKey): array {
+  return app_group_key_aliases_from_label($groupKey);
+}
+
+function delegation_from_map_for_aliases(array $delegations, array $aliases): ?array {
+  return app_group_entry_from_alias_map($delegations, $aliases);
+}
+
+function delegation_from_map_for_meta(array $delegations, array $meta): ?array {
+  return delegation_from_map_for_aliases($delegations, group_key_aliases_from_meta($meta));
 }
 
 function label_for_lang(?string $labelDe, ?string $labelEn, string $lang): string {
@@ -969,12 +968,14 @@ function upsert_class_group_delegation(PDO $pdo, int $classId, string $schoolYea
   $status = ($status === 'done') ? 'done' : 'open';
 
   if ($userId <= 0) {
-    // clear
+    // clear current full key plus legacy aliases so stale pre-hyphen rows do not keep applying
+    $aliases = group_key_aliases_from_key($groupKey);
+    $in = implode(',', array_fill(0, count($aliases), '?'));
     $pdo->prepare(
       "DELETE FROM class_group_delegations
-       WHERE class_id=? AND school_year=? AND period_label=? AND group_key=?"
-    )->execute([$classId, $schoolYear, $periodLabel, $groupKey]);
-    audit('class_group_delegation_clear', $actorUserId, ['class_id'=>$classId,'school_year'=>$schoolYear,'period_label'=>$periodLabel,'group_key'=>$groupKey]);
+       WHERE class_id=? AND school_year=? AND period_label=? AND group_key IN ($in)"
+    )->execute(array_merge([$classId, $schoolYear, $periodLabel], $aliases));
+    audit('class_group_delegation_clear', $actorUserId, ['class_id'=>$classId,'school_year'=>$schoolYear,'period_label'=>$periodLabel,'group_key'=>$groupKey,'aliases'=>$aliases]);
     return;
   }
   // NOTE: Do NOT auto-assign delegates as class teachers (separation requirement).
@@ -993,17 +994,19 @@ function upsert_class_group_delegation(PDO $pdo, int $classId, string $schoolYea
   audit('class_group_delegation_upsert', $actorUserId, ['class_id'=>$classId,'school_year'=>$schoolYear,'period_label'=>$periodLabel,'group_key'=>$groupKey,'user_id'=>$userId,'status'=>$status]);
 }
 
-function delegated_users_for_group(PDO $pdo, int $classId, string $schoolYear, string $periodLabel, string $groupKey): array {
-  $groupKey = trim($groupKey);
-  if ($groupKey === '') return [];
+function delegated_users_for_group(PDO $pdo, int $classId, string $schoolYear, string $periodLabel, $groupKey): array {
+  $aliases = is_array($groupKey) ? $groupKey : group_key_aliases_from_key((string)$groupKey);
+  $aliases = array_values(array_unique(array_filter(array_map(fn($k) => trim((string)$k), $aliases), fn($k) => $k !== '')));
+  if (!$aliases) return [];
   $periodLabel = normalize_period_label($periodLabel);
+  $in = implode(',', array_fill(0, count($aliases), '?'));
   $st = $pdo->prepare(
     "SELECT user_id
      FROM class_group_delegations
-     WHERE class_id=? AND school_year=? AND period_label=? AND group_key=?
+     WHERE class_id=? AND school_year=? AND period_label=? AND group_key IN ($in)
      ORDER BY user_id ASC"
   );
-  $st->execute([$classId, $schoolYear, $periodLabel, $groupKey]);
+  $st->execute(array_merge([$classId, $schoolYear, $periodLabel], $aliases));
   $out = [];
   foreach ($st->fetchAll(PDO::FETCH_ASSOC) as $r) {
     $uid = (int)($r['user_id'] ?? 0);
@@ -1033,8 +1036,7 @@ function can_user_edit_field(PDO $pdo, array $currentUser, int $classId, string 
   $uid = (int)($currentUser['id'] ?? 0);
   if ($uid <= 0) return false;
 
-  $groupKey = group_key_from_meta($meta);
-  $assigned = delegated_users_for_group($pdo, $classId, $schoolYear, $periodLabel, $groupKey);
+  $assigned = delegated_users_for_group($pdo, $classId, $schoolYear, $periodLabel, group_key_aliases_from_meta($meta));
   $isClassTeacher = user_is_class_teacher($pdo, $uid, $classId);
   if (!$assigned) return $isClassTeacher;
 
@@ -1062,8 +1064,7 @@ function can_user_edit_field_in_view(
   if (($currentUser['role'] ?? '') === 'admin') return true;
   $uid = (int)($currentUser['id'] ?? 0);
   if ($uid <= 0) return false;
-  $groupKey = group_key_from_meta($meta);
-  $assigned = delegated_users_for_group($pdo, $classId, $schoolYear, $periodLabel, $groupKey);
+  $assigned = delegated_users_for_group($pdo, $classId, $schoolYear, $periodLabel, group_key_aliases_from_meta($meta));
   return $assigned && in_array($uid, $assigned, true);
 }
 
@@ -1883,8 +1884,7 @@ function load_teacher_values_for_user(
     $fieldType = (string)($fieldMap[$fid]['field_type'] ?? '');
     $isMultiline = (int)($fieldMap[$fid]['is_multiline'] ?? 0);
 
-    $groupKey = group_key_from_meta($meta);
-    $del = $groupKey !== '' ? ($delegations[$groupKey] ?? null) : null;
+    $del = delegation_from_map_for_meta($delegations, $meta);
     $assignedUsers = $del && isset($del['user_ids']) && is_array($del['user_ids']) ? array_map('intval', $del['user_ids']) : [];
     $hasDelegates = !empty($assignedUsers);
 
@@ -2207,12 +2207,16 @@ try {
 
       $gParts = group_parts_from_meta($meta);
       $gKey = $gParts['group'];
+      $gAliases = group_key_aliases_from_meta($meta);
       if (!isset($groups[$gKey])) {
         $groups[$gKey] = [
           'key' => $gKey,
           'title' => group_title_from_meta($meta, $gKey, $lang),
+          'aliases' => $gAliases,
           'fields' => [],
         ];
+      } else {
+        $groups[$gKey]['aliases'] = array_values(array_unique(array_merge($groups[$gKey]['aliases'] ?? [], $gAliases)));
       }
 
       $optsTeacher = [];
@@ -2295,7 +2299,8 @@ try {
     $groupsList2 = [];
     foreach ($groupsList as $g0) {
       $gk = (string)($g0['key'] ?? '');
-      $del = $gk !== '' && isset($delegations[$gk]) ? $delegations[$gk] : null;
+      $aliases = is_array($g0['aliases'] ?? null) ? $g0['aliases'] : group_key_aliases_from_key($gk);
+      $del = $gk !== '' ? delegation_from_map_for_aliases($delegations, $aliases) : null;
       $anyEditable = false;
       if (isset($g0['fields']) && is_array($g0['fields'])) {
         foreach ($g0['fields'] as $f0) {
@@ -2625,12 +2630,12 @@ try {
     ): void {
       $meta = meta_read($f['meta_json'] ?? null);
       $isSystemBound = is_system_bound($meta);
-      $groupKey = group_key_from_meta($meta);
+      $groupAliases = group_key_aliases_from_meta($meta);
       if (
         $delegateOnly
         && !$delegateShowOtherFieldsReadonly
         && !$isSystemBound
-        && !in_array($groupKey, $delegateGroupKeys, true)
+        && !array_intersect($groupAliases, $delegateGroupKeys)
       ) {
         return;
       }
@@ -2765,8 +2770,7 @@ try {
         $type = (string)($studentFieldMap[$fieldId]['field_type'] ?? '');
         $isMultiline = (int)($studentFieldMap[$fieldId]['is_multiline'] ?? 0);
         if (!is_free_text_field($type, $isMultiline)) continue;
-        $gKey = group_key_from_meta($meta);
-        $delMeta = $gKey !== '' ? ($delegations[$gKey] ?? null) : null;
+        $delMeta = delegation_from_map_for_meta($delegations, $meta);
         $assignedUsers = $delMeta && isset($delMeta['user_ids']) && is_array($delMeta['user_ids'])
           ? array_map('intval', $delMeta['user_ids'])
           : [];
@@ -3381,7 +3385,7 @@ if ($action === 'delegations_save') {
 
     // current delegations
     $delegations = load_class_group_delegations($pdo, $classId, $schoolYear, $periodLabel);
-    $cur = $delegations[$groupKey] ?? null;
+    $cur = delegation_from_map_for_aliases($delegations, group_key_aliases_from_key($groupKey));
     $assignedUsers = $cur && isset($cur['user_ids']) && is_array($cur['user_ids'])
       ? array_map('intval', $cur['user_ids'])
       : [];

--- a/teacher/students.php
+++ b/teacher/students.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 require __DIR__ . '/../bootstrap.php';
 require __DIR__ . '/_layout.php';
+require_once __DIR__ . '/../shared/group_keys.php';
 require_teacher();
 
 $pdo = db();
@@ -27,29 +28,15 @@ function meta_read(?string $json): array {
 }
 
 function group_parts_from_meta(array $meta): array {
-  $raw = trim((string)($meta['group'] ?? ''));
-  if ($raw === '') return ['group' => 'Allgemein', 'subgroup' => ''];
-
-  $parts = array_values(array_filter(array_map('trim', explode('/', $raw)), fn($p) => $p !== ''));
-  if (!$parts) return ['group' => 'Allgemein', 'subgroup' => ''];
-
-  $group = $parts[0];
-  if ($group !== '' && strpos($group, '-') !== false) {
-    $group = explode('-', $group, 2)[0];
-    $group = trim($group);
-  }
-
-  $subgroup = '';
-  if (count($parts) > 1) {
-    $subgroup = implode(' / ', array_slice($parts, 1));
-  }
-
-  return ['group' => $group !== '' ? $group : 'Allgemein', 'subgroup' => $subgroup];
+  return app_group_parts_from_meta($meta);
 }
 
 function group_key_from_meta(array $meta): string {
-  $parts = group_parts_from_meta($meta);
-  return $parts['group'];
+  return app_group_key_from_meta($meta);
+}
+
+function group_key_aliases_from_meta(array $meta): array {
+  return app_group_key_aliases_from_meta($meta);
 }
 
 function group_title_override_lang(string $groupKey, string $lang): string {
@@ -73,8 +60,12 @@ function group_title_from_meta(array $meta, string $groupKey, string $lang): str
 
 function load_child_groups_for_template(PDO $pdo, int $templateId, string $lang): array {
   if ($templateId <= 0) return [];
+  $select = 'id, meta_json';
+  foreach (['group_label', 'group_label_en', 'subgroup_label', 'subgroup_label_en'] as $column) {
+    if (db_has_column($pdo, 'template_fields', $column)) $select .= ', ' . $column;
+  }
   $st = $pdo->prepare(
-    "SELECT id, meta_json
+    "SELECT $select
      FROM template_fields
      WHERE template_id=? AND can_child_edit=1
      ORDER BY sort_order ASC, id ASC"
@@ -85,12 +76,23 @@ function load_child_groups_for_template(PDO $pdo, int $templateId, string $lang)
     $fid = (int)($r['id'] ?? 0);
     if ($fid <= 0) continue;
     $meta = meta_read($r['meta_json'] ?? null);
+    foreach ([
+      'group_label' => 'group',
+      'group_label_en' => 'group_title_en',
+      'subgroup_label' => 'subgroup',
+      'subgroup_label_en' => 'subgroup_title_en',
+    ] as $column => $metaKey) {
+      $v = trim((string)($r[$column] ?? ''));
+      if ($v !== '' && trim((string)($meta[$metaKey] ?? '')) === '') $meta[$metaKey] = $v;
+    }
     $gKey = group_key_from_meta($meta);
     $gTitle = group_title_from_meta($meta, $gKey, $lang);
+    $gAliases = group_key_aliases_from_meta($meta);
     if (!isset($groups[$gKey])) {
-      $groups[$gKey] = ['key' => $gKey, 'title' => $gTitle, 'field_ids' => []];
+      $groups[$gKey] = ['key' => $gKey, 'title' => $gTitle, 'aliases' => $gAliases, 'field_ids' => []];
     } else {
       $groups[$gKey]['title'] = $gTitle;
+      $groups[$gKey]['aliases'] = array_values(array_unique(array_merge($groups[$gKey]['aliases'] ?? [], $gAliases)));
     }
     $groups[$gKey]['field_ids'][] = $fid;
   }
@@ -1655,8 +1657,9 @@ render_teacher_header(t('teacher.students.title', 'Schüler') . ' – ' . (strin
             <tbody>
               <?php foreach ($childGroups as $gKey => $gData): ?>
                 <?php
+                  $groupAliases = is_array($gData['aliases'] ?? null) ? $gData['aliases'] : [(string)$gKey];
                   $isUnlocked = $groupUnlockInfo['active']
-                    ? (bool)($groupUnlockInfo['map'][$gKey] ?? false)
+                    ? app_group_key_matches_map($groupUnlockInfo['map'], $groupAliases)
                     : true;
                   $prog = $groupProgress[$gKey] ?? ['students_done'=>0,'students_total'=>0,'fields_total'=>count($gData['field_ids'] ?? []),'students_percent'=>null];
                   $pct = $prog['students_percent'] !== null ? (string)$prog['students_percent'] : '–';


### PR DESCRIPTION
### Motivation

- Centralize group label/key parsing and backward-compatible aliases to avoid duplicated logic and to preserve legacy behavior for old DB rows.
- Allow templates to carry optional `group_label`/`subgroup_label` columns while keeping UI display and unlocking/delegation checks robust against legacy hyphen-truncated keys.
- Improve the student beginner UI by splitting groups into subsections (subgroups) and rendering subgroup intros and navigation.

### Description

- Introduce `shared/group_keys.php` with reusable functions such as `app_group_meta_first_string`, `app_group_parts_from_meta`, `app_group_key_from_meta`, `app_legacy_group_key_from_label`, `app_group_key_aliases_from_meta`, and alias/map lookup helpers. 
- Replace duplicated group-parsing logic in `student/ajax/wizard_api.php`, `teacher/ajax/entry_api.php`, `teacher/students.php`, and other places to use the new shared helpers, including adding alias-aware checks for child group unlocks and delegation lookups. 
- Make DB selects resilient to optional columns by conditionally including `group_label`, `group_label_en`, `subgroup_label`, and `subgroup_label_en` if the `template_fields` table has them, and copy those column values into field `meta` when present. 
- Update delegation and unlocking logic to consider both the current full group key and legacy hyphen-truncated aliases when clearing, querying, or applying delegations/unlocks (including deleting all aliases on clear). 
- Enhance the student frontend (`student/index.php`) to group fields into sections by `subgroup`, add stable section hashing, intro keys for group/subgroup, new rendering for subgroup headers/intros, and navigation items for subgroup steps, while preserving beginner-mode TTS behavior and field rendering. 

### Testing

- Ran PHP syntax checks (`php -l`) on the modified PHP files; no syntax errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da862ede0832e93aa7886a9b845c1)